### PR TITLE
Site follow-up items

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -16,6 +16,54 @@ Please follow these conventions when naming new pages:
 1. Use all lower-case letters: `about.md`, not `About.md`
 1. Separate words with hyphens, not underscores: `color-system.md` rather than `color_system` or `colorsystem`
 
+## Navigation
+The top and side navigation is generated automatically from the `pages` directory structure and a [tree model](https://www.npmjs.com/package/tree-model) that can be programmatically walked and searched. To get a sense of what that structure looks like, run the `tree` command in `pages/design`:
+
+
+```
+~/primer/design/pages/design% tree
+.
+├── communication
+├── foundation
+│   ├── color.mdx
+│   └── index.mdx
+├── global
+│   ├── accessibility.mdx
+│   └── index.mdx
+├── index.mdx
+└── tools
+    ├── figma.mdx
+    ├── index.mdx
+    └── sketch.mdx
+
+4 directories, 8 files
+```
+
+### Top navigation
+The top nav is made from the list of pages that export `meta.nav.top === true`. Pages written in [MDX] or JS can be included in this list with:
+
+```js
+export const meta = {nav: {top: true}, /* etc. */ }
+```
+
+### Side navigation
+The side navigation is built by looking for the closest "ancestor" of the current page that exports `meta.nav.side === true`:
+
+```js
+export const meta = {nav: {side: true}, /* etc. */ }
+```
+
+You can set both `top` and `side` nav keys; in fact, we do this in `pages/design/tools/index.mdx` so that it's listed in the top nav _and_ so that its children are listed whenever you're in that section. (We exclude pages with `meta.nav.top === true` from being side nav listings.)
+
+### Link text
+The link text will always be either the page's `meta.displayName` export or the filename. So if you see a nav link with a filename as its text (e.g. `design/tools/sketch.mdx`), be sure to add a `meta` export by adding this line to the bottom of your [MDX] or JS file:
+
+```js
+export const meta = {displayName: 'Link text'}
+```
+
+For consistency and skimmability, lists of links in the top and side navigation areas are sorted alphabetically.
+
 ## Content types
 You can write pages in any of the following formats:
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -56,7 +56,7 @@ export const meta = {nav: {side: true}, /* etc. */ }
 You can set both `top` and `side` nav keys; in fact, we do this in `pages/design/tools/index.mdx` so that it's listed in the top nav _and_ so that its children are listed whenever you're in that section. (We exclude pages with `meta.nav.top === true` from being side nav listings.)
 
 ### Link text
-The link text will always be either the page's `meta.displayName` export or the filename. So if you see a nav link with a filename as its text (e.g. `design/tools/sketch.mdx`), be sure to add a `meta` export by adding this line to the bottom of your [MDX] or JS file:
+The link text will be the page's `meta.displayName` export. If you see a nav link with a filename as its text (e.g. `design/tools/sketch.mdx`), it's probably missing the `meta` export, which you can add to the bottom of your [MDX] or JS file:
 
 ```js
 export const meta = {displayName: 'Link text'}

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -17,27 +17,7 @@ Please follow these conventions when naming new pages:
 1. Separate words with hyphens, not underscores: `color-system.md` rather than `color_system` or `colorsystem`
 
 ## Navigation
-The top and side navigation is generated automatically from the `pages` directory structure and a [tree model](https://www.npmjs.com/package/tree-model) that can be programmatically walked and searched. To get a sense of what that structure looks like, run the `tree` command in `pages/design`:
-
-
-```
-~/primer/design/pages/design% tree
-.
-├── communication
-├── foundation
-│   ├── color.mdx
-│   └── index.mdx
-├── global
-│   ├── accessibility.mdx
-│   └── index.mdx
-├── index.mdx
-└── tools
-    ├── figma.mdx
-    ├── index.mdx
-    └── sketch.mdx
-
-4 directories, 8 files
-```
+The top and side navigation are generated automatically from the `pages` directory structure and a [tree model](https://www.npmjs.com/package/tree-model) that can be programmatically walked and searched.
 
 ### Top navigation
 The top nav is made from the list of pages that export `meta.nav.top === true`. Pages written in [MDX] or JS can be included in this list with:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation for UI patterns and interaction guidelines.
 
 ## Deployment
 
-Each pull request (actually, each push!) is linted, tested, then deployed to a unique [Now] URL. Code merged to the `master` branch will be automatically deployed to [primer-design.now.sh](https://primer-design.now.sh).
+Each pull request (actually, each push!) is linted, tested, then deployed to a unique [Now] URL. Code merged to the `master` branch will be automatically deployed to [primer-design-master.now.sh](https://primer-design-master.now.sh).
 
 ### Branch previews
 

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,8 @@ const getPageMap = require('next-page-map')
 const withPlugins = require('next-compose-plugins')
 const mdx = require('@zeit/next-mdx')
 
-const assetPrefix = process.env.NOW_URL
+const {NOW_URL, GITHUB_REF} = process.env
+const assetPrefix = NOW_URL
 const pageExtensions = ['js', 'jsx', 'md', 'mdx']
 
 module.exports = withPlugins([
@@ -13,6 +14,7 @@ module.exports = withPlugins([
 
   publicRuntimeConfig: {
     assetPrefix,
+    branch: (GITHUB_REF || 'master').split('/').pop(),
     pageMap: getPageMap({pageExtensions}),
     pageTree: getPageMap({pageExtensions, nested: true})
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -962,9 +962,9 @@
       }
     },
     "@primer/components": {
-      "version": "5.0.0-beta",
-      "resolved": "https://registry.npmjs.org/@primer/components/-/components-5.0.0-beta.tgz",
-      "integrity": "sha512-XIuKT8cRZNr77ibPS5uLiRNJmYS1GPCQQ4lTn0y6Cprb0TvFyywWUcxU8KS+u4w4SDMS2v3DbAOKoqb6QNTuRQ==",
+      "version": "6.0.1-beta",
+      "resolved": "https://registry.npmjs.org/@primer/components/-/components-6.0.1-beta.tgz",
+      "integrity": "sha512-lkEhQx1UgAVpaKyzRGAIuBBWxeTxfqJAcLd4oBrOI8pyRFaenDQvqkGnKfFNrT099SzjYNemhgqRSQc4uivBxA==",
       "requires": {
         "@githubprimer/octicons-react": "8.0.0",
         "babel-plugin-macros": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@mdx-js/tag": "0.15.0",
-    "@primer/components": "5.0.0-beta",
+    "@primer/components": "6.0.1-beta",
     "@svgr/webpack": "3.1.0",
     "@zeit/next-mdx": "1.2.0",
     "emotion-server": "9.2.12",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,11 @@
 import React from 'react'
+import Head from 'next/head'
 import App, {Container} from 'next/app'
 import {MDXProvider} from '@mdx-js/tag'
 import Octicon, {Pencil} from '@githubprimer/octicons-react'
 import {repository} from '../package.json'
 import * as primer from '@primer/components'
-import {SideNav, Header, IndexHero} from '../src'
+import {SideNav, Header, IndexHero, SITE_TITLE} from '../src'
 import root, {populateTree} from '../src/nav'
 
 const {BaseStyles, BorderBox, Box, Flex, Link, Text} = primer
@@ -33,11 +34,14 @@ export default class MyApp extends App {
     const {pathname} = this.props.router
     const {Component, page} = this.props
     // look up the meta key in the nav tree
-    const node = root.first(node => node.path === pathname)
-    const meta = (node ? node.meta : null) || {}
+    const node = root.first(node => node.path === pathname) || {meta: {}, model: {}}
+    const {meta, model} = node
 
     return (
       <BaseStyles>
+        <Head>
+          <title>{SITE_TITLE}{meta.displayName ? ` / ${meta.displayName}` : null}</title>
+        </Head>
         <Container>
           <Header />
           <Flex display={['block', 'block', 'flex', 'flex']} flexDirection="row-reverse">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,10 +6,11 @@ import Octicon, {Pencil} from '@githubprimer/octicons-react'
 import {repository} from '../package.json'
 import * as primer from '@primer/components'
 import {SideNav, Header, IndexHero, SITE_TITLE} from '../src'
+import {config} from '../src/utils'
 import root, {populateTree} from '../src/nav'
 
 const {BaseStyles, BorderBox, Box, Flex, Link, Text} = primer
-const editLinkBase = `https://github.com/${repository}/edit/master/pages`
+const editLinkBase = `https://github.com/${repository}/edit/${config.branch}/pages`
 
 const components = {
   ...primer,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,7 +9,6 @@ import {SideNav, Header, IndexHero, SITE_TITLE} from '../src'
 import root, {populateTree} from '../src/nav'
 
 const {BaseStyles, BorderBox, Box, Flex, Link, Text} = primer
-const DocLink = props => <Link nounderline {...props} />
 const editLinkBase = `https://github.com/${repository}/edit/master/pages`
 
 const components = {
@@ -57,9 +56,9 @@ export default class MyApp extends App {
                       <Text mr={2}>
                         <Octicon icon={Pencil} />
                       </Text>
-                      <DocLink muted href={`${editLinkBase}${node.model.file}`}>
+                      <Link color="inherit" href={`${editLinkBase}${node.model.file}`}>
                         Edit this page
-                      </DocLink>{' '}
+                      </Link>{' '}
                       on GitHub
                     </Text>
                   </BorderBox>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -39,7 +39,10 @@ export default class MyApp extends App {
     return (
       <BaseStyles>
         <Head>
-          <title>{SITE_TITLE}{meta.displayName ? ` / ${meta.displayName}` : null}</title>
+          <title>
+            {SITE_TITLE}
+            {meta.displayName ? ` / ${meta.displayName}` : null}
+          </title>
         </Head>
         <Container>
           <Header />
@@ -50,13 +53,13 @@ export default class MyApp extends App {
                 <MDXProvider components={components}>
                   <Component {...page} />
                 </MDXProvider>
-                {node.model.file && (
+                {model.file && (
                   <BorderBox color="gray.5" border={0} borderTop={1} my={6} pt={1}>
                     <Text fontSize={1}>
                       <Text mr={2}>
                         <Octicon icon={Pencil} />
                       </Text>
-                      <Link color="inherit" href={`${editLinkBase}${node.model.file}`}>
+                      <Link color="inherit" href={`${editLinkBase}${model.file}`}>
                         Edit this page
                       </Link>{' '}
                       on GitHub

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,10 +1,9 @@
 import React from 'react'
-import Document, {Head, Main, NextScript} from 'next/document'
+import Document, {Main, NextScript} from 'next/document'
 import {ServerStyleSheet} from 'styled-components'
 import {extractCritical} from 'emotion-server'
-import {getAssetPath, SITE_TITLE} from '../src'
-
 import {markdown} from '@primer/components/css'
+import {getAssetPath, SITE_TITLE} from '../src'
 
 export default class MyDocument extends Document {
   static getInitialProps({renderPage}) {
@@ -27,7 +26,7 @@ export default class MyDocument extends Document {
 
     return (
       <html lang="en">
-        <Head>
+        <head>
           <title>{SITE_TITLE}</title>
           <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126681523-1" />
           <script async href={getAssetPath('analytics.js')} />
@@ -43,7 +42,7 @@ export default class MyDocument extends Document {
             content="https://user-images.githubusercontent.com/586552/46702062-ca82eb80-cbef-11e8-8c0b-4a9252dc04c6.png"
           />
           {styles}
-        </Head>
+        </head>
         <body>
           <Main />
           <NextScript />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -28,9 +28,9 @@ export default class MyDocument extends Document {
     return (
       <html lang="en">
         <Head>
+          <title>{SITE_TITLE}</title>
           <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126681523-1" />
           <script async href={getAssetPath('analytics.js')} />
-          <title>{SITE_TITLE}</title>
           <meta charSet="utf8" />
           <link rel="icon" href={getAssetPath('favicon.png')} />
           <link rel="apple-touch-icon" href={getAssetPath('apple-touch-icon.png')} />

--- a/pages/design/foundation/index.mdx
+++ b/pages/design/foundation/index.mdx
@@ -1,3 +1,3 @@
 # Foundation
 
-export const meta = {displayName: 'Foundation', nav: 'side'}
+export const meta = {displayName: 'Foundation'}

--- a/pages/design/global/index.mdx
+++ b/pages/design/global/index.mdx
@@ -1,3 +1,3 @@
 # Global
 
-export const meta = {displayName: 'Global', nav: 'side'}
+export const meta = {displayName: 'Global'}

--- a/pages/design/index.mdx
+++ b/pages/design/index.mdx
@@ -1,3 +1,3 @@
 # Guidelines
 
-export const meta = {displayName: 'Guidelines', nav: 'top', hero: true}
+export const meta = {displayName: 'Guidelines', hero: true, nav: {top: true, side: true}}

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -2,4 +2,4 @@
 
 Figma rocks!
 
-export const meta = {displayName: 'Figma', nav: 'side'}
+export const meta = {displayName: 'Figma'}

--- a/pages/design/tools/index.mdx
+++ b/pages/design/tools/index.mdx
@@ -1,3 +1,3 @@
 # Design tools
 
-export const meta = {displayName: 'Design tools', nav: 'top'}
+export const meta = {displayName: 'Design tools', nav: {top: true, side: true}}

--- a/pages/design/tools/sketch.mdx
+++ b/pages/design/tools/sketch.mdx
@@ -2,4 +2,4 @@
 
 Sketch is deprecated?
 
-export const meta = {displayName: 'Sketch', nav: 'side'}
+export const meta = {displayName: 'Sketch'}

--- a/src/Header.js
+++ b/src/Header.js
@@ -5,12 +5,12 @@ import Octicon, {MarkGithub} from '@githubprimer/octicons-react'
 import {Text, Flex, Link, Sticky, BorderBox, Box} from '@primer/components'
 import BoxShadow from './BoxShadow'
 import {ROOT_URL, SITE_TITLE} from './constants'
-import root from './nav'
+import root, {isNav} from './nav'
 
 export default withRouter(({router, ...rest}) => {
   // XXX this has to run inside the component because the tree
   // won't have been "initialized"
-  const links = root.all(node => node.meta.nav === 'top')
+  const links = root.all(node => isNav(node, 'top'))
   // get all (both) links with a path matching the beginning of the current page,
   // then sort them by length *descending* to get the most specific one. we
   // have to do this because if "/design" and "/design/tools" are the paths,

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -20,15 +20,13 @@ export default withRouter(({router, ...rest}) => {
         borderColor="gray.2"
         borderRadius={0}
       >
-        {sections && sections.map(node => (
-          <Section key={node.path} node={node} />
-        ))}
+        {sections && sections.map(node => <Section key={node.path} node={node} />)}
       </BorderBox>
     </Relative>
   )
 })
 
-function getSectionsForPath(path, check) {
+function getSectionsForPath(path) {
   const node = root.first(node => node.path === path)
   // search from bottom to top
   const ancestors = node.getPath().reverse()

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -48,7 +48,7 @@ function Section({node, ...rest}) {
     </PageLink>
   ))
   return (
-    <BorderBox px={5} py={3} border={0} borderBottom={1} borderColor="gray.2" borderRadius={0} bg={null} {...rest}>
+    <BorderBox p={5} pb={2} border={0} borderBottom={1} borderColor="gray.2" borderRadius={0} bg={null} {...rest}>
       <Flex flexDirection="column" alignItems="start">
         <SectionLink href={path}>{name}</SectionLink>
         {links}
@@ -58,7 +58,7 @@ function Section({node, ...rest}) {
 }
 
 const SectionLink = withRouter(({href, router, ...rest}) => (
-  <Box my={3}>
+  <Box mb={4} {...rest}>
     <NextLink href={href}>
       <Link href={href} color="gray.9" fontWeight={router.pathname.startsWith(href) ? 'bold' : null} {...rest} />
     </NextLink>
@@ -66,7 +66,7 @@ const SectionLink = withRouter(({href, router, ...rest}) => (
 ))
 
 const PageLink = withRouter(({href, router, ...rest}) => (
-  <Box mb={3}>
+  <Box mb={4} mt={-2}>
     <NextLink href={href}>
       <Link href={href} color={router.pathname === href ? 'gray.9' : 'blue.5'} fontSize={1} {...rest} />
     </NextLink>

--- a/src/nav.js
+++ b/src/nav.js
@@ -28,3 +28,7 @@ export function populateTree(context) {
 
   return root
 }
+
+export function isNav(node, type) {
+  return node.meta.nav && (type ? node.meta.nav[type] === true : true)
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,10 +5,7 @@ export const config = getConfig().publicRuntimeConfig || {}
 
 export const assetPrefix = config.assetPrefix || ''
 export const assetPath = `${assetPrefix}/static/assets/`
-
-export function getAssetPath(path) {
-  return `${assetPath}${path}`
-}
+export const getAssetPath = path => `${assetPath}${path}`
 
 /**
  * Export this as your default from a page, and it'll redirect both server-


### PR DESCRIPTION
### [:eyes: Preview](https://primer-design-site-updates.now.sh/)

- [x] Fix deployment URL in the README
- [x] Upgrade to `@primer/components@6.0.1-beta`
- [x] Fix warnings about using Next's `<Head>` in `_document.js`

Address @broccolini's [design feedback](https://github.com/primer/design/pull/8#pullrequestreview-170428722):
- [x] The padding between nav items in the header and the right padding between the nav and the edge of the page does not match primer/components
- [x] The vertical padding in the left nav doesn't match primer/components

Closes #2 