### PR TITLE
Fix Contributors Data

### DIFF
--- a/src/Contributors.js
+++ b/src/Contributors.js
@@ -53,9 +53,10 @@ const Contributors = ({filePath, repoPath, contributors}) => {
       const url = `https://api.github.com/repos/${repoPath}/commits?path=${filePath}`
       fetch(url)
         .then(response => response.json())
-        .then(commits => {
+        .then(data => {
           const commitData = []
           const ids = []
+          const commits = data.filter(commit => commit.author)
           for (const commit of commits) {
             if (!ids.includes(commit.author.id)) {
               commitData.push({

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,5 @@ export const extraContributors = {
   '/design/global/accessibility.mdx': [{login: 'muan'}, {login: 'eanakashima'}],
   '/design/ui-patterns/button-usage.mdx': [{login: 'jhuashao'}],
   '/design/foundation/typography.mdx': [{login: 'jhuashao'}],
-  '/design/ui-patterns/progressive-disclosure.mdx': [{login: 'jhuashao'}],
-
+  '/design/ui-patterns/progressive-disclosure.mdx': [{login: 'jhuashao'}]
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,5 +2,9 @@ export const SITE_TITLE = 'Primer Design'
 export const ROOT_URL = '/design'
 
 export const extraContributors = {
-  '/design/global/accessibility.mdx': [{login: 'muan'}, {login: 'eanakashima'}]
+  '/design/global/accessibility.mdx': [{login: 'muan'}, {login: 'eanakashima'}],
+  '/design/ui-patterns/button-usage.mdx': [{login: 'jhuashao'}],
+  '/design/foundation/typography.mdx': [{login: 'jhuashao'}],
+  '/design/ui-patterns/progressive-disclosure.mdx': [{login: 'jhuashao'}],
+
 }


### PR DESCRIPTION
This PR fixes a bug in which our commit data wasn't handling cases where there is no author data on a commit. This can happen when someone commits via the cli but isn't logged in. There's no github username to display or associated data that we're pulling from the `author` property. For now we're just omitting these commits and manually adding the contributor through the escape hatch