### PR TITLE
don't discourage the use of kebabs generally

### DIFF
--- a/pages/design/ui-patterns/progressive-disclosure.mdx
+++ b/pages/design/ui-patterns/progressive-disclosure.mdx
@@ -14,7 +14,7 @@ The following table outlines common progressive disclosure solutions in use at G
 Expand/ Collapse Icon | ![expand](https://user-images.githubusercontent.com/24916540/52089724-1a513e00-2564-11e9-84f8-eba077f6abfc.png) | Signify that there is content (typically text) to be revealed | Should generally stand alone, rather than being paired with text | 
 Ellipses Icon | ![ellipses](https://user-images.githubusercontent.com/24916540/52089725-1ae9d480-2564-11e9-8d29-1dc28740924a.png) | For toggling truncated inline text content | Do not use this icon to trigger a dropdown menus or navigation; the Kebab icon is the more suitable for this. | 
 Text-only Toggles | | | Usage of this solution is discouraged, as generally icons or icon+text pairings provide better accessibility and more information |
-Kebab | ![kebab](https://user-images.githubusercontent.com/24916540/52089726-1ae9d480-2564-11e9-984b-2d304cc0d46e.png) | N/A | Refrain from using this icon as a progressive disclosure solution |
+Kebab | ![kebab](https://user-images.githubusercontent.com/24916540/52089726-1ae9d480-2564-11e9-984b-2d304cc0d46e.png) | N/A | For toggling inline dropdowns and menus |
 Caret | ![caret](https://user-images.githubusercontent.com/24916540/52089723-1a513e00-2564-11e9-8179-420bba7922e7.png) | N/A | Refrain from using this icon as a progressive disclosure solution |
 
 


### PR DESCRIPTION
Our kebab usage guidelines send mixed messages. In the table at the top of our [progressive disclosure guide](https://primer.style/design/ui-patterns/progressive-disclosure), we say:

> Refrain from using this icon as a progressive disclosure solution

But in the "Ellipses [sic] Icon" section, the first bullet under "Caution" reads (emphasis mine):

> While visually similar, the ellipses icon is different from **the kebab icon, which is used for dropdown menus or general call-to-actions**. Be careful not to confuse them for one another.

This PR simply updates the first part in the table to read:

> For toggling inline dropdowns and menus

Which I think resolves the inconsistency, but I think we could do better by having a separate section about kebabs and dropdown/menus with do and don't screenshots.
