### PR TITLE
Add Figma documentation

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -86,5 +86,3 @@ References
 * https://material.io/design/
 * https://designsystem.gov.au/components/core/
 * https://www.microsoft.com/design/fluent/
-
-

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -36,7 +36,7 @@ GitHub has a Figma team that contains all of our design assets. In Figma, [style
 </Text>
 
 ## <a name="Styles"></a>Styles
-Primer uses [Figma styles](https://help.figma.com/category/221-styles) to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography.
+Primer uses [Figma styles](https://help.figma.com/category/221-styles) to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography. Styles within Figma also map to our styles in [Primer CSS](https://primer.style/css), so we can make sure that our designs are consistent with that we code. 
 
 
 <Text textAlign="center">

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -36,7 +36,7 @@ GitHub has a Figma team that contains all of our design assets. In Figma, [style
 </Text>
 
 ## <a name="Styles"></a>Styles
-Primer uses Figma styles to maintain a consistent look and feel across all of GitHub's UI. We have provided styles for color variables as well as our typography.
+Primer uses Figma styles to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography.
 
 Color styles are used to keep colors consistent across different products. Different type styles are used based on the importance and actionability of the text.
 

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -1,6 +1,45 @@
+import {Flex, Box, Text, BorderBox} from '@primer/components'
+
 # Figma
+Welcome to the Figma page of the Primer design system! Figma is used at GitHub as a single source of design, collaboration, and exploration. This page can help you learn how to use visual styles, library components, prototyping tools, and multiplayer collaboration.
+
+<Text textAlign="center">
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+    <Box width={12/12}>
+      <BorderBox height="250px" overflow='hidden'>
+       <img src="https://user-images.githubusercontent.com/6846673/61730055-6ddf6000-ad2d-11e9-92ce-cd14fccc6851.png"/>
+      </BorderBox>
+    </Box>
+   </Flex>
+</Text>
+
+## Styles
+GitHub’s Figma styles help give our products the same great feel across multiple products, sites, and places.
+
+Color styles are used to keep colors consistent across different products. Different type styles are used based on the importance and actionability of the text.
+
+<Text textAlign="center">
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+    <Box width={6/12} mr='4'>
+      <BorderBox height="250px" overflow='hidden'>
+       <img src="https://user-images.githubusercontent.com/6846673/61730793-ff9b9d00-ad2e-11e9-8f1b-dc52afce9bba.gif"/>
+      </BorderBox>
+      <Text textAlign='center' color='gray.6'>Each color has 10 variations, creating a spectrum of light and dark shades.</Text>
+    </Box>
+    <Box width={6/12} mr='4'>
+      <BorderBox height="250px" overflow='hidden'>
+       <img src="https://user-images.githubusercontent.com/6846673/61730796-01fdf700-ad2f-11e9-9208-065eabc8e806.gif"/>
+      </BorderBox>
+      <Text textAlign='center' color='gray.6'>The type system includes bold, uppercase, and small variations for body and header text.</Text>
+    </Box>
+   </Flex>
+</Text>
+
+Check out our [color guidelines](https://primer.style/design/foundation/color) and [typography guidelines](https://primer.style/design/foundation/typography) for more details.
 
 ## Components
+Components are elements that have a common visual style and purpose across GitHub products. While they may share the same basic design, some have hidden layers or groups for different states or colors. In Figma, you can access these components from the “Assets” tab at the top of the lefthand sidebar. Here's a list of our current components (and their Figma files):
+
 - [Alerts](https://www.figma.com/file/GTgkWXgIN2DzTY9nVLKkpzxe/primer-alerts)
 - [Avatars](https://www.figma.com/file/NRdQUqZUgJJ4grrIe0vfktEB/primer-avatars)
 - [Blankslate](https://www.figma.com/file/XscebjmfHCvUkUc3J9G4yEo5/primer-blankslate)
@@ -24,12 +63,42 @@
 - [Tooltips](https://www.figma.com/file/EmivQqEsAexN5eEclS78JTVH/primer-tooltips)
 
 
-## Utilities
-- [Colors](https://www.figma.com/file/IbJhpJJZRwGg4KlBE6TxhaQn/primer-colors)
-- [Cursors](https://www.figma.com/file/MbUdjMu8XZWBepwihiDFaFtT/Cursors)
-- [GitHub Templates](https://www.figma.com/file/VCkfDFhhJQz32TQSxGyLntrt/primer-buttons)
-- [Typography](https://www.figma.com/file/gHUvCi7ypiw9d2VzgqfhchNH/primer-typography)
+## Prototyping and Wireframing
+We’ve developed a set of page templates to help you get started with exploration and prototyping in Figma. These pages are “medium” fidelity and have flexible elements that can be hidden or shown to work in different complexities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play button in the top right.
 
+<Text textAlign="center" fontStyle='italic'>
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+    <Box width={12/12}>
+      <BorderBox overflow='hidden'>
+       <img src="https://user-images.githubusercontent.com/6846673/61732575-bfd6b480-ad32-11e9-8e77-5a8c28b9bd88.png"/>
+      </BorderBox>
+    </Box>
+   </Flex>
+</Text>
 
+Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/prototyping-pages?node-id=0%3A1) to your own project to use these templates for prototyping or exploration.
+
+## Collaboration
+Because of GitHub’s remote culture and workforce, we work asynchronously from around the world. We use [issues](https://help.github.com/en/articles/about-issues) to keep track of progress and get feedback outside of meetings. Using issues and GitHub.com to keep track of progress and iteration allows designers to better understand our users. Furthermore, we design on a process of incremental correctness – meaning designs should be shared early and shared often with continuous iteration in small steps. GitHub’s collaboration workflow is integral to design, development, and building a great culture for our company.
+
+## Team Library
+In Figma, styles and components can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
+
+<Text textAlign="center" fontStyle='italic'>
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+    <Box width={12/12}>
+      <BorderBox overflow='hidden'>
+       <img width="100%" src="https://user-images.githubusercontent.com/6846673/61732332-3f17b880-ad32-11e9-8e18-bfbfc0267d81.gif"/>
+      </BorderBox>
+      <Text textAlign='center' color='gray.6'>Enable and disable libraries of components from across your team.</Text>
+    </Box>
+   </Flex>
+</Text>
+
+## Resources
+Check out these places to learn more about Figma and GitHub:
+- [Figma Design Documentation](https://help.figma.com/)
+- [GitHub takes its collaborative culture to a new level](https://www.figma.com/blog/github-case-study/)
+- [GitHub Primer Design](https://primer.style/design)
 
 export const meta = {displayName: 'Figma', nav: 'side'}

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -80,7 +80,7 @@ Primer uses components for all of our common UI patterns. For components that ha
 
 
 ## <a name="Prototyping"></a>Prototyping and Wireframing
-We’ve developed a prototyping toolkit that includes a set of page templates and components to help you get started with exploration and prototyping in Figma. These pages are “medium” fidelity and have flexible elements that can be hidden or shown to work in different complexities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play (▶️) button in the top right.
+We’ve developed a prototyping toolkit that includes a set of page templates and components to help you get started with exploration and prototyping in Figma. These pages have flexible elements that can be hidden or shown to work for different fidelities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play (▶️) button in the top right.
 
 
 <Text textAlign="center" fontStyle='italic'>

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -96,7 +96,7 @@ We’ve developed a prototyping toolkit that includes a set of page templates an
 Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/prototyping-pages?node-id=0%3A1) to your own project to use these templates for prototyping or exploration.
 
 ## <a name="Collaboration"></a>Collaboration
-All Hubbers have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback within Figma and check [issues](https://help.github.com/en/articles/about-issues) to track decisions and progress. The design team works with incremental correctness, so share early and share often!
+All Hubbers have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback and use [issues](https://help.github.com/en/articles/about-issues) to document design exploration, track decisions and progress. The design team values [incremental correctness](https://github.com/github/product-design/blob/master/principles-and-practices.md#incremental-correctness), so share early and share often.
 
 ## <a name="Resources"></a>Resources
 List of current Primer Components:

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -1,7 +1,7 @@
 import {Flex, Box, Text, BorderBox} from '@primer/components'
 
 # Figma
-Welcome to the Figma page of the Primer design system! Figma is used at GitHub as a single source of design, collaboration, and exploration. This page can help you learn how to use visual styles, library components, prototyping tools, and multiplayer collaboration.
+Welcome to the Figma page of the Primer design system! Figma is used at GitHub as a single source of design, collaboration, and exploration.
 
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
@@ -13,7 +13,14 @@ Welcome to the Figma page of the Primer design system! Figma is used at GitHub a
    </Flex>
 </Text>
 
-## Team Library
+This page can help you learn how to use:
+* [Team Library](#Library)
+* [Styles](#Styles)
+* [Components](#Components)
+* [Prototyping and Wireframing](#Prototyping)
+* [Collaboration](#Collaboration)
+
+## <a name="Library"></a>Team Library
 GitHub has a Figma team that contains all of GitHub's design assets. In Figma, [styles](#Styles) and [components](#Components) can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
 
 <Text textAlign="center" fontStyle='italic'>
@@ -51,10 +58,8 @@ Color styles are used to keep colors consistent across different products. Diffe
 
 Check out our [color guidelines](https://primer.style/design/foundation/color) and [typography guidelines](https://primer.style/design/foundation/typography) for more details.
 
-## Components
-Primer uses components for all of our common UI patterns. For components that have several different states, we use layers or groups within each component to quickly switch between states.
-
-In Figma, you can access these components from the “Assets” tab at the top of the lefthand sidebar. Here's a list of our current components (and their Figma files):
+## <a name="Components"></a>Components
+Primer uses components for all of our common UI patterns. For components that have several different states, we use layers or groups within each component to quickly switch between states. For a full list of Primer Components, please see the [resources](#Resources) below.
 
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
@@ -74,7 +79,7 @@ In Figma, you can access these components from the “Assets” tab at the top o
 </Text>
 
 
-## Prototyping and Wireframing
+## <a name="Prototyping"></a>Prototyping and Wireframing
 We’ve developed a set of page templates to help you get started with exploration and prototyping in Figma. These pages are “medium” fidelity and have flexible elements that can be hidden or shown to work in different complexities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play button in the top right.
 
 <Text textAlign="center" fontStyle='italic'>
@@ -89,10 +94,10 @@ We’ve developed a set of page templates to help you get started with explorati
 
 Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/prototyping-pages?node-id=0%3A1) to your own project to use these templates for prototyping or exploration.
 
-## Collaboration
-Because of GitHub’s remote culture and workforce, we work asynchronously from around the world. We use [issues](https://help.github.com/en/articles/about-issues) to keep track of progress and get feedback outside of meetings. Using issues and GitHub.com to keep track of progress and iteration allows designers to better understand our users. Furthermore, we design on a process of incremental correctness – meaning designs should be shared early and shared often with continuous iteration in small steps. GitHub’s collaboration workflow is integral to design, development, and building a great culture for our company.
+## <a name="Collaboration"></a>Collaboration
+All Hubbers have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback within Figma and check [issues](https://help.github.com/en/articles/about-issues) to track decisions and progress. The design team works with incremental correctness, so share early and share often!
 
-## Resources
+## <a name="Resources"></a>Resources
 Check out these places to learn more about Figma and GitHub:
 - [Figma Design Documentation](https://help.figma.com/)
 - [GitHub takes its collaborative culture to a new level](https://www.figma.com/blog/github-case-study/)

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -22,7 +22,7 @@ This page can help you become more familiar with::
 * [Resources](#Resources)
 
 ## <a name="Library"></a>Team Library
-GitHub has a Figma team that contains all of GitHub's design assets. In Figma, [styles](#Styles) and [components](#Components) can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
+GitHub has a Figma team that contains all of our design assets. In Figma, [styles](#Styles) and [components](#Components) can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
 
 <Text textAlign="center" fontStyle='italic'>
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -13,7 +13,21 @@ Welcome to the Figma page of the Primer design system! Figma is used at GitHub a
    </Flex>
 </Text>
 
-## Styles
+## Team Library
+GitHub has a Figma team that contains all of GitHub's design assets. In Figma, [styles](#Styles) and [components](#Components) can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
+
+<Text textAlign="center" fontStyle='italic'>
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+    <Box width={12/12}>
+      <BorderBox overflow='hidden'>
+       <img width="100%" src="https://user-images.githubusercontent.com/6846673/61732332-3f17b880-ad32-11e9-8e18-bfbfc0267d81.gif"/>
+      </BorderBox>
+      <Text textAlign='center' color='gray.6'>Enable and disable libraries of components from across your team.</Text>
+    </Box>
+   </Flex>
+</Text>
+
+## <a name="Styles"></a>Styles
 GitHub’s Figma styles help give our products the same great feel across multiple products, sites, and places.
 
 Color styles are used to keep colors consistent across different products. Different type styles are used based on the importance and actionability of the text.
@@ -22,7 +36,7 @@ Color styles are used to keep colors consistent across different products. Diffe
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
     <Box width={6/12} mr='4'>
       <BorderBox height="250px" overflow='hidden'>
-       <img src="https://user-images.githubusercontent.com/6846673/61730793-ff9b9d00-ad2e-11e9-8f1b-dc52afce9bba.gif"/>
+       <img src="https://user-images.githubusercontent.com/6846673/61830580-5af98800-ae20-11e9-8a25-c68d566de2f0.gif"/>
       </BorderBox>
       <Text textAlign='center' color='gray.6'>Each color has 10 variations, creating a spectrum of light and dark shades.</Text>
     </Box>
@@ -37,9 +51,51 @@ Color styles are used to keep colors consistent across different products. Diffe
 
 Check out our [color guidelines](https://primer.style/design/foundation/color) and [typography guidelines](https://primer.style/design/foundation/typography) for more details.
 
-## Components
-Components are elements that have a common visual style and purpose across GitHub products. While they may share the same basic design, some have hidden layers or groups for different states or colors. In Figma, you can access these components from the “Assets” tab at the top of the lefthand sidebar. Here's a list of our current components (and their Figma files):
+## <a name="Components"></a>Components
 
+<Text textAlign="center">
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+   <Box width={6/12} mr='4'>
+     <BorderBox height="250px" overflow='hidden'>
+      <img src="https://user-images.githubusercontent.com/6846673/61830583-5af98800-ae20-11e9-8aa9-459fc2d51133.gif"/>
+     </BorderBox>
+     <Text textAlign='center' color='gray.6'>Search for components in the assets menu and drag them onto the canvas.</Text>
+   </Box>
+    <Box width={6/12} mr='4'>
+      <BorderBox height="250px" overflow='hidden'>
+       <img src="https://user-images.githubusercontent.com/6846673/61830581-5af98800-ae20-11e9-93ab-9c33ff0dd2be.gif"/>
+      </BorderBox>
+      <Text textAlign='center' color='gray.6'>Some components have multiple states, which you can toggle in the layer list.</Text>
+    </Box>
+   </Flex>
+</Text>
+
+
+## Prototyping and Wireframing
+We’ve developed a set of page templates to help you get started with exploration and prototyping in Figma. These pages are “medium” fidelity and have flexible elements that can be hidden or shown to work in different complexities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play button in the top right.
+
+<Text textAlign="center" fontStyle='italic'>
+   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
+    <Box width={12/12}>
+      <BorderBox overflow='hidden'>
+       <img src="https://user-images.githubusercontent.com/6846673/61732575-bfd6b480-ad32-11e9-8e77-5a8c28b9bd88.png"/>
+      </BorderBox>
+    </Box>
+   </Flex>
+</Text>
+
+Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/prototyping-pages?node-id=0%3A1) to your own project to use these templates for prototyping or exploration.
+
+## Collaboration
+Because of GitHub’s remote culture and workforce, we work asynchronously from around the world. We use [issues](https://help.github.com/en/articles/about-issues) to keep track of progress and get feedback outside of meetings. Using issues and GitHub.com to keep track of progress and iteration allows designers to better understand our users. Furthermore, we design on a process of incremental correctness – meaning designs should be shared early and shared often with continuous iteration in small steps. GitHub’s collaboration workflow is integral to design, development, and building a great culture for our company.
+
+## Resources
+Check out these places to learn more about Figma and GitHub:
+- [Figma Design Documentation](https://help.figma.com/)
+- [GitHub takes its collaborative culture to a new level](https://www.figma.com/blog/github-case-study/)
+- [GitHub Primer Design](https://primer.style/design)
+
+List of current Primer Components:
 - [Alerts](https://www.figma.com/file/GTgkWXgIN2DzTY9nVLKkpzxe/primer-alerts)
 - [Avatars](https://www.figma.com/file/NRdQUqZUgJJ4grrIe0vfktEB/primer-avatars)
 - [Blankslate](https://www.figma.com/file/XscebjmfHCvUkUc3J9G4yEo5/primer-blankslate)
@@ -61,44 +117,5 @@ Components are elements that have a common visual style and purpose across GitHu
 - [Select Menu](https://www.figma.com/file/XNlerVQDAKoG5QyYFXHLCvXg/primer-select-menu)
 - [Subhead](https://www.figma.com/file/0qti8UWx1SR9M7dyXlYzHm6Z/primer-subhead)
 - [Tooltips](https://www.figma.com/file/EmivQqEsAexN5eEclS78JTVH/primer-tooltips)
-
-
-## Prototyping and Wireframing
-We’ve developed a set of page templates to help you get started with exploration and prototyping in Figma. These pages are “medium” fidelity and have flexible elements that can be hidden or shown to work in different complexities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play button in the top right.
-
-<Text textAlign="center" fontStyle='italic'>
-   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
-    <Box width={12/12}>
-      <BorderBox overflow='hidden'>
-       <img src="https://user-images.githubusercontent.com/6846673/61732575-bfd6b480-ad32-11e9-8e77-5a8c28b9bd88.png"/>
-      </BorderBox>
-    </Box>
-   </Flex>
-</Text>
-
-Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/prototyping-pages?node-id=0%3A1) to your own project to use these templates for prototyping or exploration.
-
-## Collaboration
-Because of GitHub’s remote culture and workforce, we work asynchronously from around the world. We use [issues](https://help.github.com/en/articles/about-issues) to keep track of progress and get feedback outside of meetings. Using issues and GitHub.com to keep track of progress and iteration allows designers to better understand our users. Furthermore, we design on a process of incremental correctness – meaning designs should be shared early and shared often with continuous iteration in small steps. GitHub’s collaboration workflow is integral to design, development, and building a great culture for our company.
-
-## Team Library
-In Figma, styles and components can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
-
-<Text textAlign="center" fontStyle='italic'>
-   <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
-    <Box width={12/12}>
-      <BorderBox overflow='hidden'>
-       <img width="100%" src="https://user-images.githubusercontent.com/6846673/61732332-3f17b880-ad32-11e9-8e18-bfbfc0267d81.gif"/>
-      </BorderBox>
-      <Text textAlign='center' color='gray.6'>Enable and disable libraries of components from across your team.</Text>
-    </Box>
-   </Flex>
-</Text>
-
-## Resources
-Check out these places to learn more about Figma and GitHub:
-- [Figma Design Documentation](https://help.figma.com/)
-- [GitHub takes its collaborative culture to a new level](https://www.figma.com/blog/github-case-study/)
-- [GitHub Primer Design](https://primer.style/design)
 
 export const meta = {displayName: 'Figma', nav: 'side'}

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -13,7 +13,7 @@ Welcome to the Figma page of the Primer design system! Figma is used at GitHub a
    </Flex>
 </Text>
 
-This page can help you become more familiar with::
+This page can help you become more familiar with:
 * [Team Library](#Library)
 * [Styles](#Styles)
 * [Components](#Components)
@@ -36,7 +36,7 @@ GitHub has a Figma team that contains all of our design assets. In Figma, [style
 </Text>
 
 ## <a name="Styles"></a>Styles
-Primer uses [Figma styles](https://help.figma.com/category/221-styles) to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography. Styles within Figma also map to our styles in [Primer CSS](https://primer.style/css), so we can make sure that our designs are consistent with that we code. 
+Primer uses [Figma styles](https://help.figma.com/category/221-styles) to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography. Styles within Figma also map to our styles in [Primer CSS](https://primer.style/css), so we can make sure that our designs are consistent with that we code.
 
 
 <Text textAlign="center">
@@ -59,7 +59,7 @@ Primer uses [Figma styles](https://help.figma.com/category/221-styles) to mainta
 Check out our [color guidelines](https://primer.style/design/foundation/color) and [typography guidelines](https://primer.style/design/foundation/typography) for more details.
 
 ## <a name="Components"></a>Components
-Primer uses components for all of our common UI patterns. For components that have several different states, we use layers or groups within each component to quickly switch between states. For a full list of Primer Components, please see the [resources](#Resources) below.
+Primer uses components for all of our common UI patterns. For components with different states, we use layers or groups within each component to quickly switch between states. For a full list of Primer Components, please see the [resources](#Resources) below.
 
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -36,7 +36,7 @@ GitHub has a Figma team that contains all of our design assets. In Figma, [style
 </Text>
 
 ## <a name="Styles"></a>Styles
-Primer uses Figma styles to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography.
+Primer uses [Figma styles](https://help.figma.com/category/221-styles) to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography.
 
 
 <Text textAlign="center">

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -6,7 +6,7 @@ Welcome to the Figma page of the Primer design system! Figma is used at GitHub a
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
     <Box width={12/12}>
-      <BorderBox height="250px" overflow='hidden'>
+      <BorderBox overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61899371-26dda000-aed0-11e9-9f97-c1e2f2e8ebbf.png"/>
       </BorderBox>
     </Box>
@@ -24,7 +24,7 @@ This page can help you become more familiar with::
 ## <a name="Library"></a>Team Library
 GitHub has a Figma team that contains all of our design assets. In Figma, [styles](#Styles) and [components](#Components) can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
 
-<Text textAlign="center" fontStyle='italic'>
+<Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
     <Box width={12/12}>
       <BorderBox overflow='hidden'>
@@ -42,13 +42,13 @@ Primer uses [Figma styles](https://help.figma.com/category/221-styles) to mainta
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
     <Box width={6/12} mr='4'>
-      <BorderBox height="250px" overflow='hidden'>
+      <BorderBox overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61830580-5af98800-ae20-11e9-8a25-c68d566de2f0.gif"/>
       </BorderBox>
       <Text textAlign='center' fontSize='1' color='gray.6'>Each color has 10 variations, creating a spectrum of light and dark shades.</Text>
     </Box>
     <Box width={6/12} mr='4'>
-      <BorderBox height="250px" overflow='hidden'>
+      <BorderBox overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61730796-01fdf700-ad2f-11e9-9208-065eabc8e806.gif"/>
       </BorderBox>
       <Text textAlign='center' fontSize='1' color='gray.6'>The type system includes bold, uppercase, and small variations for body and header text.</Text>
@@ -64,13 +64,13 @@ Primer uses components for all of our common UI patterns. For components that ha
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
    <Box width={6/12} mr='4'>
-     <BorderBox height="250px" overflow='hidden'>
+     <BorderBox overflow='hidden'>
       <img src="https://user-images.githubusercontent.com/6846673/61830583-5af98800-ae20-11e9-8aa9-459fc2d51133.gif"/>
      </BorderBox>
      <Text textAlign='center' fontSize='1' color='gray.6'>Search for components in the assets menu and drag them onto the canvas.</Text>
    </Box>
     <Box width={6/12} mr='4'>
-      <BorderBox height="250px" overflow='hidden'>
+      <BorderBox overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61830581-5af98800-ae20-11e9-93ab-9c33ff0dd2be.gif"/>
       </BorderBox>
       <Text textAlign='center' fontSize='1' color='gray.6'>Some components have multiple states, which you can toggle in the layer list.</Text>
@@ -83,7 +83,7 @@ Primer uses components for all of our common UI patterns. For components that ha
 We’ve developed a prototyping toolkit that includes a set of page templates and components to help you get started with exploration and prototyping in Figma. These pages have flexible elements that can be hidden or shown to work for different fidelities. While Figma contains lots of [prototyping features](https://help.figma.com/category/87-prototyping), most designers at GitHub use code to prototype in higher fidelities.
 
 
-<Text textAlign="center" fontStyle='italic'>
+<Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
     <Box width={12/12}>
       <BorderBox overflow='hidden'>

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -7,18 +7,19 @@ Welcome to the Figma page of the Primer design system! Figma is used at GitHub a
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>
     <Box width={12/12}>
       <BorderBox height="250px" overflow='hidden'>
-       <img src="https://user-images.githubusercontent.com/6846673/61730055-6ddf6000-ad2d-11e9-92ce-cd14fccc6851.png"/>
+       <img src="https://user-images.githubusercontent.com/6846673/61899371-26dda000-aed0-11e9-9f97-c1e2f2e8ebbf.png"/>
       </BorderBox>
     </Box>
    </Flex>
 </Text>
 
-This page can help you learn how to use:
+This page can help you become more familiar with::
 * [Team Library](#Library)
 * [Styles](#Styles)
 * [Components](#Components)
 * [Prototyping and Wireframing](#Prototyping)
 * [Collaboration](#Collaboration)
+* [Resources](#Resources)
 
 ## <a name="Library"></a>Team Library
 GitHub has a Figma team that contains all of GitHub's design assets. In Figma, [styles](#Styles) and [components](#Components) can be reused across multiple files and projects with the [team library](https://help.figma.com/article/29-team-library) feature. With team libraries, you can enable and disable components styles within certain files. This makes it easy for designers to easily access Primer components from anywhere.
@@ -29,7 +30,7 @@ GitHub has a Figma team that contains all of GitHub's design assets. In Figma, [
       <BorderBox overflow='hidden'>
        <img width="100%" src="https://user-images.githubusercontent.com/6846673/61732332-3f17b880-ad32-11e9-8e18-bfbfc0267d81.gif"/>
       </BorderBox>
-      <Text textAlign='center' color='gray.6'>Enable and disable libraries of components from across your team.</Text>
+      <Text textAlign='center' fontSize='1' color='gray.6'>Enable and disable libraries of components from across your team.</Text>
     </Box>
    </Flex>
 </Text>
@@ -45,13 +46,13 @@ Color styles are used to keep colors consistent across different products. Diffe
       <BorderBox height="250px" overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61830580-5af98800-ae20-11e9-8a25-c68d566de2f0.gif"/>
       </BorderBox>
-      <Text textAlign='center' color='gray.6'>Each color has 10 variations, creating a spectrum of light and dark shades.</Text>
+      <Text textAlign='center' fontSize='1' color='gray.6'>Each color has 10 variations, creating a spectrum of light and dark shades.</Text>
     </Box>
     <Box width={6/12} mr='4'>
       <BorderBox height="250px" overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61730796-01fdf700-ad2f-11e9-9208-065eabc8e806.gif"/>
       </BorderBox>
-      <Text textAlign='center' color='gray.6'>The type system includes bold, uppercase, and small variations for body and header text.</Text>
+      <Text textAlign='center' fontSize='1' color='gray.6'>The type system includes bold, uppercase, and small variations for body and header text.</Text>
     </Box>
    </Flex>
 </Text>
@@ -67,13 +68,13 @@ Primer uses components for all of our common UI patterns. For components that ha
      <BorderBox height="250px" overflow='hidden'>
       <img src="https://user-images.githubusercontent.com/6846673/61830583-5af98800-ae20-11e9-8aa9-459fc2d51133.gif"/>
      </BorderBox>
-     <Text textAlign='center' color='gray.6'>Search for components in the assets menu and drag them onto the canvas.</Text>
+     <Text textAlign='center' fontSize='1' color='gray.6'>Search for components in the assets menu and drag them onto the canvas.</Text>
    </Box>
     <Box width={6/12} mr='4'>
       <BorderBox height="250px" overflow='hidden'>
        <img src="https://user-images.githubusercontent.com/6846673/61830581-5af98800-ae20-11e9-93ab-9c33ff0dd2be.gif"/>
       </BorderBox>
-      <Text textAlign='center' color='gray.6'>Some components have multiple states, which you can toggle in the layer list.</Text>
+      <Text textAlign='center' fontSize='1' color='gray.6'>Some components have multiple states, which you can toggle in the layer list.</Text>
     </Box>
    </Flex>
 </Text>
@@ -99,11 +100,6 @@ Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/
 All Hubbers have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback within Figma and check [issues](https://help.github.com/en/articles/about-issues) to track decisions and progress. The design team works with incremental correctness, so share early and share often!
 
 ## <a name="Resources"></a>Resources
-Check out these places to learn more about Figma and GitHub:
-- [Figma Design Documentation](https://help.figma.com/)
-- [GitHub takes its collaborative culture to a new level](https://www.figma.com/blog/github-case-study/)
-- [GitHub Primer Design](https://primer.style/design)
-
 List of current Primer Components:
 - [Alerts](https://www.figma.com/file/GTgkWXgIN2DzTY9nVLKkpzxe/primer-alerts)
 - [Avatars](https://www.figma.com/file/NRdQUqZUgJJ4grrIe0vfktEB/primer-avatars)
@@ -126,5 +122,10 @@ List of current Primer Components:
 - [Select Menu](https://www.figma.com/file/XNlerVQDAKoG5QyYFXHLCvXg/primer-select-menu)
 - [Subhead](https://www.figma.com/file/0qti8UWx1SR9M7dyXlYzHm6Z/primer-subhead)
 - [Tooltips](https://www.figma.com/file/EmivQqEsAexN5eEclS78JTVH/primer-tooltips)
+
+Check out these places to learn more about Figma and GitHub:
+- [Figma Design Documentation](https://help.figma.com/)
+- [GitHub takes its collaborative culture to a new level](https://www.figma.com/blog/github-case-study/)
+- [GitHub Primer Design](https://primer.style/design)
 
 export const meta = {displayName: 'Figma', nav: 'side'}

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -80,7 +80,7 @@ Primer uses components for all of our common UI patterns. For components that ha
 
 
 ## <a name="Prototyping"></a>Prototyping and Wireframing
-We’ve developed a prototyping toolkit that includes a set of page templates and components to help you get started with exploration and prototyping in Figma. These pages have flexible elements that can be hidden or shown to work for different fidelities. You can use the “Prototype” tab in the righthand sidebar to get started with interactive prototype projects. When you’re ready to present, simply hit the play (▶️) button in the top right.
+We’ve developed a prototyping toolkit that includes a set of page templates and components to help you get started with exploration and prototyping in Figma. These pages have flexible elements that can be hidden or shown to work for different fidelities. While Figma contains lots of [prototyping features](https://help.figma.com/category/87-prototyping), most designers at GitHub use code to prototype in higher fidelities.
 
 
 <Text textAlign="center" fontStyle='italic'>

--- a/pages/design/tools/figma.mdx
+++ b/pages/design/tools/figma.mdx
@@ -38,7 +38,6 @@ GitHub has a Figma team that contains all of our design assets. In Figma, [style
 ## <a name="Styles"></a>Styles
 Primer uses Figma styles to maintain a consistent look and feel across all of our UI. We have provided styles for color variables as well as our typography.
 
-Color styles are used to keep colors consistent across different products. Different type styles are used based on the importance and actionability of the text.
 
 <Text textAlign="center">
    <Flex alignItems='center' flexDirection='row' mt='4' mb='4'>


### PR DESCRIPTION
This pull request adds documentation and content for the Figma design tools page. A few notes I wrote down about creating GIFs and images for the docsites:

### GIF and Image Guidelines
- Should not be longer than 10 seconds
- 50% width should be 800 x 500 px (or proportional up to 100% width)
    - Crop and convert from mov to gif using [EZGif](https://ezgif.com)
- 100% width should be 932 x 383 px (or proportional up to 100% width)
    - Crop using [EZGif](https://ezgif.com)
    - Convert to gif using [Zamzar](https://www.zamzar.com/convert/mov-to-gif/)

### Figma Live Embed Guidelines
- Should only be used when one page is necessary to understand the document
- Dimensions should be 1600 x 1000 px (or proportional up to 100% width)

I'm looking for feedback on copy and content. If anyone has suggestions, I greatly appreciate it!