### PR TITLE
Create Blankslate Documentation

### DIFF
--- a/pages/design/ui-patterns/blankslate.mdx
+++ b/pages/design/ui-patterns/blankslate.mdx
@@ -1,0 +1,45 @@
+import {Flex, Box, Text, BorderBox} from '@primer/components'
+
+export const meta = {displayName: 'Blankslate'}
+
+# Blankslate
+Blankslates are a great way to create cohesive and effective empty states. These guidelines will suggest ways to use the blankslate component and best practices. If you're looking for guidelines on implementation, please refer to [Primer CSS](https://primer.style/css/components/blankslate) or [Primer Components](https://primer.style/components).
+
+## The Blankslate Component
+The blankslate is made up of several elements that work together to inform the user about a feature and how to proceed forward. Below are the pieces of the component and guidelines on modifying them.
+
+![anatomy](https://user-images.githubusercontent.com/6846673/62644438-f3066f80-b8fe-11e9-8e4b-e8af1cac0e58.png)
+
+### Graphic
+The graphic can bring delight, preview an interface element, or simply add color to balance the information of the component. There are a few variations to the graphic, which are outlined later on this page.
+
+### Primary Text
+This text will be the largest in the component and can make a user feel much more comfortable to engage. Primary text is meant to be welcoming and invitational. Text should sound human and convey the intention of the feature.
+
+### Secondary Text
+This optional text will be located below the primary text and should support informing the user about the feature. Secondary text should be brief and nonredundant if possible. Users should understand the general purpose of the feature and how it might help them accomplish a goal.
+
+### Primary Action
+Blankslates should contain at least one primary button. This button to lead to a feature or component creation flow. Button copy should be keep brief and descriptive. If a button requires further specification, consider adding an Octicon.
+
+### Secondary Action
+Secondary actions, if needed, should be located underneath the primary button in the form of a text link. These links typically lead to more information about the feature or component. This might look like "[Learn more about pull requests](https://help.github.com/en/articles/about-pull-requests)" or "[Check out the guide on deploy keys](https://developer.github.com/v3/guides/managing-deploy-keys/)".
+
+### Border
+The border is visible by default and helps define the structure of the blankslate component within the context of the page. It can be removed by adding `.border-o`.
+
+## Variations
+### Pictograms
+Blankslates should default to using pictogram for graphic elements. Pictograms present a great preview of what should be in place of the empty state.
+
+![pictogram blankslate](https://user-images.githubusercontent.com/6846673/62644441-f39f0600-b8fe-11e9-93da-30aeb0437606.png)
+
+### Illustrations
+Illustrations can be a great way to bring delight to an empty state. Illustrations should be used **sparingly** in empty states and only in cases where emotion is necessarily evoked from the user. For example, illustrations in a new user experience can help introduce octocats to the user and bring a more personalized experience.
+
+![illustration blankslate](https://user-images.githubusercontent.com/6846673/62645137-796f8100-b900-11e9-9309-39b1f323a5eb.png)
+
+## Content and Copy
+Voice and language are important to making sure users are not only engaged, but also informed about features. Empty states should explain features in addition to conveying intention. Below is a good example of conveying intention in the primary text and using the secondary text to inform.
+
+![code of conduct blankslate](https://user-images.githubusercontent.com/6846673/62644439-f39f0600-b8fe-11e9-9b38-6c75d8f95128.png)

--- a/pages/design/ui-patterns/blankslate.mdx
+++ b/pages/design/ui-patterns/blankslate.mdx
@@ -11,10 +11,10 @@ The blankslate is made up of several elements that work together to inform the u
 ![anatomy](https://user-images.githubusercontent.com/6846673/62644438-f3066f80-b8fe-11e9-8e4b-e8af1cac0e58.png)
 
 ### Graphic
-The graphic can bring delight, preview an interface element, or simply add color to balance the information of the component. There are a few variations to the graphic, which are outlined later on this page.
+The graphic can bring delight, preview an interface element, or represent the goal of the feature. Graphics should be placed intentionally and with thought about the intention of the content. Graphics also differ in meaning and appeal to the user, which is why the blank slate component has multiple variations. These variations are outlined later on this page.
 
 ### Primary Text
-This text will be the largest in the component and can make a user feel much more comfortable to engage. Primary text is meant to be welcoming and invitational. Text should sound human and convey the intention of the feature.
+Primary text is the first piece of information in the empty state presented to the user. It can make a user feel much more comfortable to engage with the content or begin a feature flow. Primary text should sound welcoming, human, and convey the intention of the feature.
 
 ### Secondary Text
 This optional text will be located below the primary text and should support informing the user about the feature. Secondary text should be brief and nonredundant if possible. Users should understand the general purpose of the feature and how it might help them accomplish a goal.


### PR DESCRIPTION
This PR adds documentation for the Primer Blankslate component. Initial ship contains new blankslate components for pictograms and illustrations as well as 2-3 line variations for each.

- [x] Open PR for documentation
- [x] Add components to the primer-blankslate Figma

These components look like:

#### Pictograms
![pictogram blankslate](https://user-images.githubusercontent.com/6846673/62644441-f39f0600-b8fe-11e9-93da-30aeb0437606.png)

#### Illustrations
![illustration blankslate](https://user-images.githubusercontent.com/6846673/62645137-796f8100-b900-11e9-9309-39b1f323a5eb.png)

The documentation also contains guidelines for copy for each aspect of the component. 

I'm open to feedback on content of the documentation and if there's anything else we need to include. Thanks for y'alls help 🤠 