### PR TITLE
Adding NUX blankslate documentation

### DIFF
--- a/pages/design/ui-patterns/empty-states.mdx
+++ b/pages/design/ui-patterns/empty-states.mdx
@@ -47,6 +47,6 @@ Voice and tone are important to making sure users are not only engaged, but also
 ![code of conduct illustration blankslate](https://user-images.githubusercontent.com/6846673/62806616-394b0280-baa8-11e9-8a5e-45f0c51aaa22.png)
 
 ## New User Experiences
-For new users, use illustration blankslates to introduce the user to the octocat as a symbol of GitHub. Primary text should convey GitHub's mission while secondary text should seek to educate the user.
+For new user experiences, use illustration blankslates to playfully engage the user and introduce the Octocats as symbols of GitHub. Primary text should similarly convey how the feature connects to GitHub's mission. Secondary text should seek to educate the user, but at a simpler, less-technical level.
 
 ![new user blankslate](https://user-images.githubusercontent.com/6846673/62813307-efb9e200-babe-11e9-93e7-a6fd45d7f942.png)

--- a/pages/design/ui-patterns/empty-states.mdx
+++ b/pages/design/ui-patterns/empty-states.mdx
@@ -47,6 +47,6 @@ Voice and tone are important to making sure users are not only engaged, but also
 ![code of conduct illustration blankslate](https://user-images.githubusercontent.com/6846673/62806616-394b0280-baa8-11e9-8a5e-45f0c51aaa22.png)
 
 ## New User Experiences
-For new user experiences, use illustration blankslates to playfully engage the user and introduce the Octocats as symbols of GitHub. Primary text should similarly convey how the feature connects to GitHub's mission. Secondary text should seek to educate the user, but at a simpler, less-technical level.
+For new user experiences, use illustration blankslates to playfully engage the user and introduce the Octocat as a symbol of GitHub. Primary text should similarly convey how the feature connects to GitHub's mission. Secondary text should seek to educate the user, but at a simpler, less-technical level.
 
 ![new user blankslate](https://user-images.githubusercontent.com/6846673/62813307-efb9e200-babe-11e9-93e7-a6fd45d7f942.png)

--- a/pages/design/ui-patterns/empty-states.mdx
+++ b/pages/design/ui-patterns/empty-states.mdx
@@ -45,3 +45,8 @@ Illustrations should be used **sparingly** in blankslates - only in cases where 
 Voice and tone are important to making sure users are not only engaged, but also informed about features. Empty states should explain features _in addition_ to conveying intention. Below is a good example of conveying intention in the primary text and using the secondary text to inform.
 
 ![code of conduct illustration blankslate](https://user-images.githubusercontent.com/6846673/62806616-394b0280-baa8-11e9-8a5e-45f0c51aaa22.png)
+
+## New User Experiences
+For new users, use illustration blankslates to introduce the user to the octocat as a symbol of GitHub. Primary text should convey GitHub's mission while secondary text should seek to educate the user.
+
+![new user blankslate](https://user-images.githubusercontent.com/6846673/62813307-efb9e200-babe-11e9-93e7-a6fd45d7f942.png)

--- a/pages/design/ui-patterns/empty-states.mdx
+++ b/pages/design/ui-patterns/empty-states.mdx
@@ -47,6 +47,6 @@ Voice and tone are important to making sure users are not only engaged, but also
 ![code of conduct illustration blankslate](https://user-images.githubusercontent.com/6846673/62806616-394b0280-baa8-11e9-8a5e-45f0c51aaa22.png)
 
 ## New User Experiences
-For new user experiences, use illustration blankslates to playfully engage the user and introduce the Octocat as a symbol of GitHub. Primary text should similarly convey how the feature connects to GitHub's mission. Secondary text should seek to educate the user, but at a simpler, less-technical level.
+For new user experiences, use illustration blankslates to playfully engage the user and introduce the Octocat as a symbol of GitHub. Primary text should welcome the user to the platform and feature. Secondary text should seek to educate the user, but at a simpler, less-technical level.
 
 ![new user blankslate](https://user-images.githubusercontent.com/6846673/62813307-efb9e200-babe-11e9-93e7-a6fd45d7f942.png)


### PR DESCRIPTION
This PR adds a section to the Empty States guidelines about using illustration blankslate components for new user experiences.