### PR TITLE
Update Compact Blankslate guideline examples

### DIFF
--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -40,7 +40,7 @@ Empty states have multiple variations that can be used in different contexts.
 ### Illustrations
 Illustrations can be used to give more personality to a Blankslate and prioritize it as a feature worth learning.
 
-![illustration Blankslate](https://user-images.githubusercontent.com/6846673/62806617-394b0280-baa8-11e9-9abc-ccbb76a9f63f.png)
+![illustration Blankslate](https://user-images.githubusercontent.com/6846673/63133678-20948e00-bf7b-11e9-8774-9474d961c4b9.png)
 
 ### Compact
 Compact states are a great way to engage and educate a user in places where there are more UI elements and the area is much more condensed. Generally, this would be in places where the content or feature would be left-aligned. While the border is optional for all empty states, we suggest adding the border on the Compact variation to better support page structure.

--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -48,10 +48,10 @@ Compact states are a great way to engage and educate a user in places where ther
 <Text textAlign="center">
   <Flex alignItems="center" flexDirection="row" mt="4" mb="4">
     <Box width={6 / 12} mr="4">
-      <img alt="compact Blankslate with border" src="https://user-images.githubusercontent.com/6846673/63041086-dbd5fd80-be7b-11e9-8929-3a9c72f53edc.png" />
+      <img alt="compact Blankslate with border" src="https://user-images.githubusercontent.com/6846673/63132959-e1b10900-bf77-11e9-9ddc-2060cf70dd73.png" />
     </Box>
     <Box width={6 / 12} mr="4">
-      <img alt="compact Blankslate without border" src="https://user-images.githubusercontent.com/6846673/63123918-f46b1400-bf5e-11e9-9f03-6105a5728b56.png" />
+      <img alt="compact Blankslate without border" src="https://user-images.githubusercontent.com/6846673/63132935-c0e8b380-bf77-11e9-8cbc-410e574c7a08.png" />
     </Box>
   </Flex>
 </Text>


### PR DESCRIPTION
Fixed them to include inline secondary actions:

#### Before:
<img width="903" alt="Screen Shot 2019-08-15 at 4 19 09 PM" src="https://user-images.githubusercontent.com/6846673/63133110-80d60080-bf78-11e9-839e-5ed9fea0b427.png">

#### After:
<img width="899" alt="Screen Shot 2019-08-15 at 4 20 01 PM" src="https://user-images.githubusercontent.com/6846673/63133130-9ba87500-bf78-11e9-9c94-ea4231bb1bb9.png">
