### PR TITLE
Redirect /design/foundation -> /design/foundations

### DIFF
--- a/now.json
+++ b/now.json
@@ -10,8 +10,16 @@
     }
   ],
   "routes": [
-    {"src": "/design/foundation/?", "dest": "/design/foundations"},
-    {"src": "/design/foundation/typography/?", "dest": "/design/foundations/typography"},
+    {
+      "src": "/design/foundation/?",
+      "status": 301,
+      "headers": {"Location": "/design/foundations"}
+    },
+    {
+      "src": "/design/foundation/typography/?",
+      "status": 301,
+      "headers": {"Location": "/design/foundations/typography"}
+    },
     {"src": "/design(/.*)?", "dest": "$1"},
     {
       "src": "/",

--- a/now.json
+++ b/now.json
@@ -10,11 +10,12 @@
     }
   ],
   "routes": [
-    { "src": "/design(/.*)?", "dest": "$1" },
+    {"src": "/design/foundation(/typography)?/?$", "dest": "/design/foundations/$1"},
+    {"src": "/design(/.*)?", "dest": "$1"},
     {
       "src": "/",
       "status": 301,
-      "headers": { "Location": "/design" }
+      "headers": {"Location": "/design"}
     }
   ]
 }

--- a/now.json
+++ b/now.json
@@ -10,7 +10,8 @@
     }
   ],
   "routes": [
-    {"src": "/design/foundation(/typography)?/?$", "dest": "/design/foundations/$1"},
+    {"src": "/design/foundation/?", "dest": "/design/foundations"},
+    {"src": "/design/foundation/typography/?", "dest": "/design/foundations/typography"},
     {"src": "/design(/.*)?", "dest": "$1"},
     {
       "src": "/",


### PR DESCRIPTION
Just in case anyone's linked to the `/design/foundation` or `/design/foundation/typography` URLs invalidated by #83! URLs to test in deployment:

* [/design/foundation](https://design-git-foundation-redirect.primer.now.sh/design/foundation)
* [/design/foundation/](https://design-git-foundation-redirect.primer.now.sh/design/foundation/)
* [/design/foundation/typography](https://design-git-foundation-redirect.primer.now.sh/design/foundation/typography)
* [/design/foundation/typography/](https://design-git-foundation-redirect.primer.now.sh/design/foundation/typography/)