### PR TITLE
Update Figma docs

### DIFF
--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -105,13 +105,13 @@ We’ve developed a prototyping toolkit that includes a set of page templates an
   </Flex>
 </Text>
 
-Duplicate this [Figma file](https://www.figma.com/file/ex9hnSDJTr8fG24cTMyRJzHD/prototyping-pages?node-id=0%3A1) to your own project to use these templates for prototyping or exploration.
-
 ## Collaboration
 
-All Hubbers have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback and use [issues](https://help.github.com/en/articles/about-issues) to document design exploration, track decisions and progress. The design team values [incremental correctness](https://github.com/github/product-design/blob/master/principles-and-practices.md#incremental-correctness), so share early and share often.
+All GitHub members have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback and use [issues](https://help.github.com/en/articles/about-issues) to document design exploration, track decisions and progress. The design team values [incremental correctness](https://github.com/github/product-design/blob/master/principles-and-practices.md#incremental-correctness), so share early and share often.
 
 ## Resources
+
+We currently *only* provide access to our Figma components to members of our GitHub team. Public access to the component libraries is currently in progress and will be available via our [Figma Community page](https://www.figma.com/@primer).
 
 List of current Primer Components:
 


### PR DESCRIPTION
This PR addresses the broken links for public access explaining that they are currently for internal GitHub use only. A link to the Primer community page in Figma has been added for public use.﻿
