### PR TITLE
Update links for typography related components

### DIFF
--- a/content/foundations/typography.mdx
+++ b/content/foundations/typography.mdx
@@ -105,10 +105,10 @@ When certain typographic patterns in your design emerge, or you believe a certai
 
 Primer includes many typographic solutions. Please utilize them when possible before creating a custom component. Some include:
 
-- [Alerts](https://styleguide.github.com/primer/components/alerts/)
-- [Labels](https://styleguide.github.com/primer/components/labels/)
-- [Subheads](https://styleguide.github.com/primer/components/subhead/)
-- [Navigation](https://styleguide.github.com/primer/components/navigation/)
+- [Alerts](https://primer.style/css/components/alerts)
+- [Labels](https://primer.style/css/components/labels)
+- [Subheads](https://primer.style/css/components/subhead)
+- [Navigation](https://primer.style/css/components/navigation)
 
 ### Further reading and resources
 

--- a/content/ui-patterns/button-usage.mdx
+++ b/content/ui-patterns/button-usage.mdx
@@ -4,7 +4,7 @@ title: Button usage
 
 import {Box, Flex, BorderBox, Text} from '@primer/components'
 
-These guidelines summarize how GitHub implements buttons across our products. We have standardized buttons documented on [Primer CSS](https://styleguide.github.com/primer/) and [Primer Components](https://primer.style/components), and these docs which serve as the source of truth for development implementation. This article serves to supplement our technical docs with proper guidance on design implementation.
+These guidelines summarize how GitHub implements buttons across our products. We have standardized buttons documented on [Primer CSS](https://primer.style/css/) and [Primer Components](https://primer.style/components), and these docs which serve as the source of truth for development implementation. This article serves to supplement our technical docs with proper guidance on design implementation.
 
 ## Button types
 


### PR DESCRIPTION
The links now go to the primer.style website rather than the old styleguide.github.com