### PR TITLE
Auto-bump: @primer/gatsby-theme-doctocat@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@loadable/component": "^5.10.2",
-    "@primer/gatsby-theme-doctocat": "^0.25.2",
+    "@primer/gatsby-theme-doctocat": "^1.0.0",
     "@primer/octicons-react": "^11.0.0",
     "eslint": "5.8.0",
     "eslint-plugin-github": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,16 +1273,17 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@^0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.25.2.tgz#f0d871ac204902b153e2c9a1926390e54aa2419b"
-  integrity sha512-Hihiz2yTT4tEOUurLBRr8SlHNP9jPupBoMXbc/IC7HoxwyNONKpl8wOojgJvswAiHx1Gd4knTEzD6ZbC3KGtyw==
+"@primer/gatsby-theme-doctocat@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-1.0.0.tgz#e2412b1ce25bcb49d291b512491295ad24000a65"
+  integrity sha512-ZrZpdgs7Xpio1ZR6fihe9ISTWFXUXTR2WJKtHQJnp0k1WFI9CmqGXTnpJC9dlY/62wLp5rLCGlWr3dRM6KTE4A==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
     "@mdx-js/mdx" "^1.0.21"
     "@mdx-js/react" "^1.0.21"
     "@primer/components" "^20.0.0"
+    "@primer/octicons-react" "^11.0.0"
     "@styled-system/theme-get" "^5.0.12"
     "@testing-library/jest-dom" "^4.1.0"
     "@testing-library/react" "^9.1.3"


### PR DESCRIPTION
Auto-upgrade of `@primer/gatsby-theme-doctocat` to `1.0.0` via multibump.