### PR TITLE
Spelling correction

### DIFF
--- a/content/ui-patterns/progressive-disclosure.mdx
+++ b/content/ui-patterns/progressive-disclosure.mdx
@@ -32,9 +32,9 @@ The following table outlines common progressive disclosure solutions in use at G
 
 | Component                       | Icon                                                                                                              | Usage                                                          | Notes                                                                                                                             |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [Chevron icon](#chevron-icon)   | ![chevron](https://user-images.githubusercontent.com/24916540/52089727-1ae9d480-2564-11e9-8291-1ee9d3225427.png)  | When elements of content are collapsed and can be toggled open | Do not use this icon to trigger a dropdown menus or navigation; the caret icon is the more suitable for this.                     |
+| [Chevron icon](#chevron-icon)   | ![chevron](https://user-images.githubusercontent.com/24916540/52089727-1ae9d480-2564-11e9-8291-1ee9d3225427.png)  | When elements of content are collapsed and can be toggled open | Do not use this icon to trigger dropdown menus or navigation; the caret icon is the more suitable for this.                     |
 | [Fold/Unfold icon](#foldunfold) | ![expand](https://user-images.githubusercontent.com/24916540/52089724-1a513e00-2564-11e9-84f8-eba077f6abfc.png)   | Signify that there is content (typically text) to be revealed  | Should generally stand alone, rather than being paired with text                                                                  |
-| [Ellipsis icon](#ellipsis-icon) | ![ellipsis](https://user-images.githubusercontent.com/24916540/52089725-1ae9d480-2564-11e9-8d29-1dc28740924a.png) | For toggling truncated inline text content                     | Do not use this icon to trigger a dropdown menus or navigation; the Kebab icon is the more suitable for this.                     |
+| [Ellipsis icon](#ellipsis-icon) | ![ellipsis](https://user-images.githubusercontent.com/24916540/52089725-1ae9d480-2564-11e9-8d29-1dc28740924a.png) | For toggling truncated inline text content                     | Do not use this icon to trigger dropdown menus or navigation; the Kebab icon is the more suitable for this.                     |
 | Text-only toggles               |                                                                                                                   |                                                                | Usage of this solution is discouraged, as generally icons or icon+text pairings provide better accessibility and more information |
 | Kebab                           | ![kebab](https://user-images.githubusercontent.com/24916540/52089726-1ae9d480-2564-11e9-984b-2d304cc0d46e.png)    | N/A                                                            | For toggling inline dropdowns and menus                                                                                           |
 | Caret                           | ![caret](https://user-images.githubusercontent.com/24916540/52089723-1a513e00-2564-11e9-8179-420bba7922e7.png)    | N/A                                                            | Refrain from using this icon as a progressive disclosure solution                                                                 |
@@ -63,7 +63,7 @@ The chevron icon is used when elements of content are collapsed and can be toggl
 
 **Caution:**
 
-- The chevron should not be used as a call-to-action for drop down menus
+- The chevron should not be used as a call-to-action for dropdown menus
 - It should not be used for pagination, or indicate directional actions
 
 ### Fold/Unfold


### PR DESCRIPTION
a dropdown munus -> dropdown menus
drop down -> dropdown (it should either be dropdown or drop-down)