### PR TITLE
Add Lifecyle page to design guidelines

### DIFF
--- a/content/foundations/component-lifecycle.mdx
+++ b/content/foundations/component-lifecycle.mdx
@@ -8,11 +8,13 @@ These milestones summarize the maturity lifecycle of UI components in Primer. Co
 
 Proof-of-concept built outside of Primer.
 
+- The component exists as a proof-of-concept built outside of Primer, often in a GitHub application such as GitHub.com.
+
 ## Alpha
 
 The component is ready for preliminary usage, with breaking changes expected.
 
-- <details><summary>The component does not have external dependencies that are not relevant to end-user experiences. </summary>This could be external libraries or dependencies on libraries in an application (like GitHub.com)</details>
+- <details><summary>The component does not have external dependencies. </summary>This could be external libraries or dependencies on libraries in an application (like GitHub.com)</details>
 - <details><summary>The component is compatible with color modes and can adapt to different themes. </summary>The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.</details>
 - Basic documentation exists that includes example usage of the component.
 - Primary use cases tested and reviewed.
@@ -22,17 +24,17 @@ The component is ready for preliminary usage, with breaking changes expected.
 
 The component meets most maturity criteria, and use is encouraged for most scenarios.
 
-- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Usage has been audited and reviewed.</details>
+- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Uses of the component have been reviewed for correctness.</details>
 - <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
 - <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s used in production.</details>
 - The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
-- <details><summary>The component does not introduce unnecessary performance regressions to the user experience or the Primer library.</summary>Where a component is handling loading states or progressive loading of UI, this may require designing for performance.</details>
+- <details><summary>The component does not introduce unnecessary performance regressions to the user experience or the Primer library.
 
 ## Stable
 
 The component is significantly mature and usage is strongly encouraged, with long-term support expected.
 
-- <details><summary>The API remains stable, with no breaking changes for at least one month.</summary>Feedback has been sought and stats on component usage and implementation use cases reviewed. Complex components may require more detailed research, such as setting up scenarios that let consumers test the usability of the API.</details>
+- <details><summary>The API remains stable, with no breaking changes for at least one month.</summary>Feedback on API usabliity has been sought from developers using the component and production use cases have been reviewed for correctness.</details>
 - <details><summary>Documentation exists for the remaining implementation, usage, and design guidelines.</summary>Primer React and/or Primer ViewComponents documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.</details>
 - Tooling (such as linters, codemods, etc.) exists to prevent further use of alternatives.
 
@@ -40,12 +42,12 @@ The component is significantly mature and usage is strongly encouraged, with lon
 
 The component will be removed in the future and should be avoided.
 
-- Documentation exists for the deprecation and alternative solutions.
-- Using the component emits a warning.
+- Documentation exists for the deprecation, including any alternative components to use instead.
+- When using the component, a warning is shown to the consumer.
 
 ## Removed
 
 The component no longer exists in Primer.
 
-- The removal date has been announced and is at least one month away from the release date of the package.
+- The removal date has been announced and is at least one month away from the release date of the package that removes the component..
 - Manual and automated migration paths are documented and have been available for at least one month.

--- a/content/foundations/lifecycle.mdx
+++ b/content/foundations/lifecycle.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lifecyle
+title: Component lifecycle
 ---
 
 These milestones summarize the maturity lifecycle of UI components in Primer. Components are required to meet all criteria _before_ being proceeding to a given milestone.
@@ -22,7 +22,7 @@ The component is ready for preliminary usage, with breaking changes expected.
 
 The component meets most maturity criteria, and use is encouraged for most scenarios.
 
-- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for PVC, at least one or more instances for PRC. Usage has been audited and reviewed.</details>
+- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Usage has been audited and reviewed.</details>
 - <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during Beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
 - <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s being used in production.</details>
 - The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
@@ -33,8 +33,8 @@ The component meets most maturity criteria, and use is encouraged for most scena
 The component is significantly mature and usage is strongly encouraged, with long-term support expected.
 
 - <details><summary>The API remains stable, with no breaking changes for at least one month.</summary>Feedback has been sought and stats on component usage and implementation use cases reviewed. Complex components may require more detailed research, such as setting up scenarios that let consumers test the usability of the API.</details>
-- <details><summary>Documentation exists for the remaining implementation, usage, and design guidelines.</summary>PRC and/or PVC documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.</details>
-- Tooling (such as linters, codemods, etc.) to prevent further use of alternatives.
+- <details><summary>Documentation exists for the remaining implementation, usage, and design guidelines.</summary>Primer React and/or Primer ViewComponents documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.</details>
+- Tooling (such as linters, codemods, etc.) exists to prevent further use of alternatives.
 
 ## Deprecated
 

--- a/content/foundations/lifecycle.mdx
+++ b/content/foundations/lifecycle.mdx
@@ -2,7 +2,7 @@
 title: Component lifecycle
 ---
 
-These milestones summarize the maturity lifecycle of UI components in Primer. Components are required to meet all criteria _before_ being proceeding to a given milestone.
+These milestones summarize the maturity lifecycle of UI components in Primer. Components must meet all criteria _before_ proceeding to a given milestone.
 
 ## Experimental
 

--- a/content/foundations/lifecycle.mdx
+++ b/content/foundations/lifecycle.mdx
@@ -1,0 +1,51 @@
+---
+title: Lifecyle
+---
+
+These milestones summarize the maturity lifecycle of UI components in Primer. Components are required to meet all criteria _before_ being proceeding to a given milestone.
+
+## Experimental
+
+Proof-of-concept built outside of Primer.
+
+## Alpha
+
+The component is ready for preliminary usage, with breaking changes expected.
+
+- <details><summary>The component does not have external dependencies that are not relevant to end-user experiences. </summary>This could be external libraries or dependencies on libraries in an application (like GitHub.com)</details>
+- <details><summary>The component is compatible with color modes and can adapt to different themes. </summary>The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.</details>
+- Basic documentation exists that includes example usage of the component.
+- Primary use cases tested and reviewed.
+- The component has 100% test coverage.
+
+## Beta
+
+The component meets most maturity criteria, and use is encouraged for most scenarios.
+
+- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for PVC, at least one or more instances for PRC. Usage has been audited and reviewed.</details>
+- <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during Beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
+- <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s being used in production.</details>
+- The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
+- <details><summary>The component does not introduce unnecessary performance regressions to the user experience or the Primer library.</summary>Where a component is handling loading states or progressive loading of UI, this may require designing for performance.</details>
+
+## Stable
+
+The component is significantly mature and usage is strongly encouraged, with long-term support expected.
+
+- <details><summary>The API remains stable, with no breaking changes for at least one month.</summary>Feedback has been sought and stats on component usage and implementation use cases reviewed. Complex components may require more detailed research, such as setting up scenarios that let consumers test the usability of the API.</details>
+- <details><summary>Documentation exists for the remaining implementation, usage, and design guidelines.</summary>PRC and/or PVC documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.</details>
+- Tooling (such as linters, codemods, etc.) to prevent further use of alternatives.
+
+## Deprecated
+
+The component will be removed in the future and should be avoided.
+
+- Documentation exists for the deprecation and alternative solutions.
+- Using the component emits a warning.
+
+## Removed
+
+The component no longer exists in Primer.
+
+- The removal date has been announced and is at least one month away from the release date of the package.
+- Manual and automated migration paths are documented and have been available for at least one month.

--- a/content/foundations/lifecycle.mdx
+++ b/content/foundations/lifecycle.mdx
@@ -23,8 +23,8 @@ The component is ready for preliminary usage, with breaking changes expected.
 The component meets most maturity criteria, and use is encouraged for most scenarios.
 
 - <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Usage has been audited and reviewed.</details>
-- <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during Beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
-- <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s being used in production.</details>
+- <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
+- <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s used in production.</details>
 - The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
 - <details><summary>The component does not introduce unnecessary performance regressions to the user experience or the Primer library.</summary>Where a component is handling loading states or progressive loading of UI, this may require designing for performance.</details>
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -7,8 +7,8 @@
       url: /foundations/typography
     - title: Content
       url: /foundations/content
-    - title: Lifecyle
-      url: /foundations/lifecycle
+    - title: Component lifecyle
+      url: /foundations/component-lifecycle
 - title: Accessibility
   url: /accessibility/accessibility-at-github
   children:
@@ -30,7 +30,7 @@
     - title: Messaging
       url: /ui-patterns/messaging
     - title: Progressive disclosure
-      url: /ui-patterns/progressive-disclosure    
+      url: /ui-patterns/progressive-disclosure
 - title: Components
   url: /components
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -7,6 +7,8 @@
       url: /foundations/typography
     - title: Content
       url: /foundations/content
+    - title: Lifecyle
+      url: /foundations/lifecycle
 - title: Accessibility
   url: /accessibility/accessibility-at-github
   children:


### PR DESCRIPTION
This PR introduces a `Lifecycle` page to the design guidelines on `primer.style`.

## Context

As part of our goals we're working on increasing the maturity of Primer, to make it more robust and consistent, and to create clarity for people working with the system. Our component libraries have diverged as we experimented and developed different parts of Primer, and we don't have all the pattern coverage we think consumers need across the system. These criteria are meant to establish baseline expectations for components in Primer as they mature over time.

## Notes

We had originally titled these levels `maturity statuses` but I feel that the term `Lifecycle` better captures the intention for this to be a process that we move components through.  I also used the term `milestone` in place of `status` for similar reasons.

