### PR TITLE
Update old button screenshots in "Button types" table

### DIFF
--- a/content/ui-patterns/button-usage.mdx
+++ b/content/ui-patterns/button-usage.mdx
@@ -10,10 +10,10 @@ At GitHub, buttons are a fundamental building block of our products. Most of the
 
 | Type      | Visual                                                                                                                 | Usage                                                                                   |
 | --------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Default   | ![btn](https://user-images.githubusercontent.com/24916540/52498774-86e4c200-2b8e-11e9-953b-e0e7a70493ea.png)           | The go-to style to render a button                                                      |
-| Outline   | ![btn-outline](https://user-images.githubusercontent.com/24916540/52498769-864c2b80-2b8e-11e9-984a-d5b88c846b74.png)   | To downplay a button, for navigation buttons, or for filter buttons                     |
+| Default   | ![btn](https://user-images.githubusercontent.com/2313998/130091137-4f65a6cd-a890-434d-8ec7-292417f149af.png)           | The go-to style to render a button                                                      |
+| Outline   | ![btn-outline](https://user-images.githubusercontent.com/2313998/130091138-3e548b4a-0f31-45fb-beed-70aaf7c6b4f2.png)   | To downplay a button, for navigation buttons, or for filter buttons                     |
 | Primary   | ![btn-primary](https://user-images.githubusercontent.com/2313998/129806123-d7001d50-2900-435e-bb6b-f8289de1a415.png)   | To emphasize the highest priority action on a view                                      |
-| Danger    | ![btn-danger](https://user-images.githubusercontent.com/24916540/52498772-864c2b80-2b8e-11e9-8eeb-bef8729c1fd1.png)    | To warn that an action is potentially dangerous or destructive                          |
+| Danger    | ![btn-danger](https://user-images.githubusercontent.com/2313998/130091133-a48deda5-089a-4e1d-ac6b-a058a5c2497f.png)    | To warn that an action is potentially dangerous or destructive                          |
 | Invisible | ![btn-invisible](https://user-images.githubusercontent.com/2313998/129628226-bbb0aae4-8cba-4175-aa0f-33a6213f4f67.png) | A subtle style used for actions that are of lower priority in a view's button hierarchy |
 
 ## Text


### PR DESCRIPTION
I missed a few outdated button screenshots with my last PR

## Before
<img width="975" alt="Screen Shot 2021-08-19 at 10 57 22 AM" src="https://user-images.githubusercontent.com/2313998/130091994-2ee1b6ba-0559-434c-b1f9-8a1fe5164729.png">

## After
<img width="975" alt="Screen Shot 2021-08-19 at 10 57 59 AM" src="https://user-images.githubusercontent.com/2313998/130092009-6918ec34-c3fc-4618-bf26-4ff05bba763f.png">
