### PR TITLE
Remove disabled text from Foundations

### DIFF
--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -25,8 +25,8 @@ Foundation variables are the building blocks of all interfaces. Use them to crea
 | `border-muted`     | Secondary border to emphasize separation between elements.     |
 | `border-subtle`    | Low opacity border designed to blend with backgrounds like images on avatars or primary buttons.     |
 | `fg-default`    | Provides high readability. Default text and icons, and most foregrounds.      |
-| `fg-muted`    | Provides medium readability. Used to create hierarchy in combination with `fg-default`. Do not use for placeholder or disabled states.      |
-| `fg-subtle`    | Provides low contrast. Used for disabled states — in these cases, it's acceptable that it does not pass general text contrast requirements.      |
+| `fg-muted`    | Provides medium readability. Used to create hierarchy in combination with `fg-default`.      |
+| `fg-subtle`    | Provides low contrast. Used for placeholder text.      |
 | `fg-on-emphasis`    | Used for text and icons on color backgrounds.     |
 
 ## Color roles 


### PR DESCRIPTION
This is in response to https://github.com/github/primer/issues/292.

In https://github.com/primer/primitives/pull/252 a new `primer.fg.disabled` was added. Which makes disabled text somewhat private. This PR reflects that in the color guidelines.