### PR TITLE
Fix for stretched image in Safari

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -49,6 +49,7 @@ import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link
 <ImageContainer>
   <img
     width="868"
+    height="608px"
     src="https://user-images.githubusercontent.com/293280/125994797-430b8376-30f8-4971-b476-c5186f9ef6ca.png"
     alt="Action list examples"
     style="background: none"


### PR DESCRIPTION
No bueno:

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/589285/139926677-5ebfa821-a60f-4e80-8d9c-13e5725cfc9e.png">

It needs the `height` attribute to get avoid stretching