### PR TITLE
Add content to index pages

### DIFF
--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -1,3 +1,36 @@
 ---
 title: Foundations
 ---
+
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+
+
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+    <div>
+        <Link href="/design/foundations/color">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/design/foundations/color" fontWeight="bold">Color</Link>
+        <Box as="p">How to work with color modes and themes, and how to apply color to GitHub interfaces.</Box>
+    </div>
+  <div>
+        <Link href="/design/foundations/typography">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/design/foundations/typography" fontWeight="bold">Typography</Link>
+        <Box as="p">How to use and apply typography to GitHub interfaces.</Box>
+    </div>
+  <div>
+        <Link href="/design/foundations/content">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/design/foundations/content" fontWeight="bold">Content</Link>
+        <Box as="p">How to create interfaces that follow GitHub's content guidelines.</Box>
+    </div>
+  </Grid>

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -8,7 +8,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
     <div>
         <Link href="/design/foundations/color">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
         </Link>
     </div>
     <div>
@@ -17,7 +17,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
   <div>
         <Link href="/design/foundations/typography">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
         </Link>
     </div>
     <div>
@@ -26,7 +26,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
   <div>
         <Link href="/design/foundations/content">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
         </Link>
     </div>
     <div>

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -5,8 +5,6 @@ title: Interface guidelines
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
 export default HeroLayout
 
-# Introduction
-
 Primer's interface guidelines are a collection of principles, standards, and usage guidelines for designing GitHub interfaces.
 
 ## [Foundations](https://primer.style/design/foundations)

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -8,3 +8,29 @@ export default HeroLayout
 # Introduction
 
 Primer's interface guidelines are a collection of principles, standards, and usage guidelines for designing GitHub interfaces.
+
+## [Foundations](https://primer.style/design/foundations)
+
+The fundamental parts of the design system, such as color and typography, that underpin all GitHub interfaces.
+
+## [Accessibility](https://primer.style/design/accessibility/accessibility-at-github)
+
+Standards, guidelines, and tools to design accessible GitHub interfaces.
+
+## [UI patterns](https://primer.style/design/ui-patterns)
+
+Design guidelines covering common user workflows. 
+
+## [Components](https://primer.style/design/components)
+
+Design and usage guidelines for individual Primer components.
+
+## [Using Figma](https://primer.style/design/tools/figma)
+
+A guide on how to get started using Figma to design interfaces at GitHub.
+
+## Need help?
+
+If you found a bug on this website, please [open a new issue](https://github.com/primer/design/issues/new) with as much detail as possible, including steps to replicate the bug, screenshots, links, and expected results. 
+
+If you need help using and designing with Primer, and you are GitHub staff, please visit the #primer Slack channel.

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -7,7 +7,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
     <div>
         <Link href="/design/tools/figma">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
         </Link>
     </div>
     <div>

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -1,3 +1,17 @@
 ---
 title: Design tools
 ---
+
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+    <div>
+        <Link href="/design/tools/figma">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/design/tools/figma" fontWeight="bold">Figma</Link>
+        <Box as="p">A guide on how to get started using Figma to design interfaces at GitHub.</Box>
+    </div>
+  </Grid>

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -2,24 +2,52 @@
 title: UI patterns
 ---
 
-import {Grid, Flex, Box, Link, Text} from '@primer/components'
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 
-#### [Button usage](/ui-patterns/button-usage)
-
-Buttons are a fundamental building block of the GitHub UI. These guidelines summarize how to use buttons across the product.
-
-#### [Empty states](/ui-patterns/empty-states)
-
-Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the blankslate component and designing empty states.
-
-#### [Feature onboarding](/ui-patterns/feature-onboarding)
-
-Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
-
-#### [Messaging](/ui-patterns/messaging)
-
-Messaging components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more. Primer includes three different messaging components: toasts, flash alerts, popovers.
-
-#### [Progressive disclosure](/ui-patterns/progressive-disclosure)
-
-These guidelines summarize how to use progressive disclosure, as well as guiding principles, best practices, and implementation support.
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+    <div>
+        <Link href="/ui-patterns/button-usage">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/ui-patterns/button-usage" fontWeight="bold">Button usage</Link>
+        <Box as="p">Buttons are a fundamental building block of the GitHub UI. These guidelines summarize how to use buttons across the product.</Box>
+    </div>
+    <div>
+        <Link href="/ui-patterns/empty-states">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/ui-patterns/empty-states" fontWeight="bold">Empty states</Link>
+        <Box as="p">Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the blankslate component and designing empty states.</Box>
+    </div>
+    <div>
+        <Link href="/ui-patterns/feature-onboarding">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/ui-patterns/feature-onboarding" fontWeight="bold">Feature onboarding</Link>
+        <Box as="p">Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.</Box>
+    </div>
+    <div>
+        <Link href="/ui-patterns/messaging">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/ui-patterns/messaging" fontWeight="bold">Messaging</Link>
+        <Box as="p">Messaging components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more. Primer includes three different messaging components: toasts, flash alerts, popovers.</Box>
+    </div>
+    <div>
+        <Link href="/ui-patterns/progressive-disclosure">
+            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />-->
+        </Link>
+    </div>
+    <div>
+        <Link href="/ui-patterns/progressive-disclosure" fontWeight="bold">Progressive disclosure</Link>
+        <Box as="p">These guidelines summarize how to use progressive disclosure, as well as guiding principles, best practices, and implementation support.</Box>
+    </div>
+</Grid>

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -7,7 +7,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
     <div>
         <Link href="/ui-patterns/button-usage">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
         </Link>
     </div>
     <div>
@@ -16,7 +16,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/ui-patterns/empty-states">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png" /> */}
         </Link>
     </div>
     <div>
@@ -25,7 +25,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/ui-patterns/feature-onboarding">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" /> */}
         </Link>
     </div>
     <div>
@@ -34,7 +34,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/ui-patterns/messaging">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" /> */}
         </Link>
     </div>
     <div>
@@ -43,7 +43,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/ui-patterns/progressive-disclosure">
-            <!--<img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />-->
+            {/* <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" /> */}
         </Link>
     </div>
     <div>


### PR DESCRIPTION
- added more text to primer.style/design homepage
- edit layout of **UI patterns** to use same grid as **Components** - images missing but not urgent
- edit layout of **Design tools** to use same grid as **Components** - images missing but not urgent
- add content to **Foundations** index

Note: The content I added is very basic, but the goal right now is just to not have dead end, empty pages. 