### PR TITLE
Add "How to use Primer colors?" section

### DIFF
--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -66,13 +66,13 @@ Color roles are defined by the meaning they convey in the UI. Primer has 8 color
 
 Primer colors exist in different formats and are made available throughout the Primer libraries and tools. Not all colors exist everywhere and the naming depends on the Primer library. Below a list to help find the right Primer color documentation that is specific to that role and environment.
 
-| I am | I work | Color documentation | Example usage |
-| -------- | -------- | -------- | -------- |
-| A product **designer** | in **Figma** | [Primer Primitives](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | `bg/accent` |
-| An **engineer** | using **Primer ViewComponents** | [color system arguments](https://primer.style/view-components/system-arguments#color) | `bg: :accent` |
-| An **engineer** | using **Primer React** | [sx props](https://primer.style/react/overriding-styles) | `accent.sublte` |
-| An **engineer** | creating **custom UI** | [Primer CSS color utilities](https://primer.style/css/utilities/colors) | `color-bg-accent` |
-| A Primer **React maintainer** | creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `accent.sublte` |
-| A Primer **CSS maintainer** | creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `--color-accent-sublte` |
+| I am | Documentation | Example color usage |
+| -------- | -------- | -------- |
+| A product **designer** working in **Figma** | [Primer Primitives](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | `bg/accent` |
+| An **engineer** using **Primer ViewComponents** | [color system arguments](https://primer.style/view-components/system-arguments#color) | `bg: :accent` |
+| An **engineer** using **Primer React** | [sx props](https://primer.style/react/overriding-styles) | `accent.sublte` |
+| An **engineer** creating **custom UI** | [Primer CSS color utilities](https://primer.style/css/utilities/colors) | `color-bg-accent` |
+| A Primer **React maintainer** creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `accent.sublte` |
+| A Primer **CSS maintainer** creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `--color-accent-sublte` |
 
 Stuck choosing the right color? Feel free to reach out in the [#primer](https://github.slack.com/archives/CSGAVNZ19) Slack channel.

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -62,4 +62,17 @@ Color roles are defined by the meaning they convey in the UI. Primer has 8 color
 | `-muted` | Medium contrast alpha value, recommended for borders. |
 |`-subtle` | Low contrast solid color, recommended for backgrounds. |
 
- 
+## How to use Primer colors?
+
+Primer colors exist in different formats and are made available throughout the Primer libraries and tools. Not all colors exist everywhere and the naming depends on the Primer library. Below a list to help find the right Primer color documentation that is specific to that role and environment.
+
+| I am | I work | Color documentation | Example usage |
+| -------- | -------- | -------- | -------- |
+| A product **designer** | in **Figma** | [Primer Primitives](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | `bg/accent` |
+| An **engineer** | using **Primer ViewComponents** | [color system arguments](https://primer.style/view-components/system-arguments#color) | `bg: :accent` |
+| An **engineer** | using **Primer React** | [sx props](https://primer.style/react/overriding-styles) | `accent.sublte` |
+| An **engineer** | creating **custom UI** | [Primer CSS color utilities](https://primer.style/css/utilities/colors) | `color-bg-accent` |
+| A Primer **React maintainer** | creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `accent.sublte` |
+| A Primer **CSS maintainer** | creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `--color-accent-sublte` |
+
+Stuck choosing the right color? Feel free to reach out in the [#primer](https://github.slack.com/archives/CSGAVNZ19) Slack channel.


### PR DESCRIPTION
This came up in [Slack](https://github.slack.com/archives/GACAW0NPM/p1638936063390800?thread_ts=1638871330.290100&cid=GACAW0NPM) and adds a "How to use Primer colors?" section at the end of the [Color](https://primer.style/design/foundations/color) docs.

![image](https://user-images.githubusercontent.com/378023/145167524-fa6a0140-0dce-451b-a668-450b0b14aa11.png)

👀  [Live preview](https://design-git-primer-color-usage-primer.vercel.app/design/foundations/color#how-to-use-primer-colors)
