### PR TITLE
Chore: fix variant suffix and grammar error at `/design/foundations/color`

### DIFF
--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -70,9 +70,9 @@ Primer colors exist in different formats and are made available throughout the P
 | -------- | -------- | -------- |
 | A product **designer** working in **Figma** | [Primer Primitives](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | `bg/accent` |
 | An **engineer** using **Primer ViewComponents** | [color system arguments](https://primer.style/view-components/system-arguments#color) | `bg: :accent` |
-| An **engineer** using **Primer React** | [sx props](https://primer.style/react/overriding-styles) | `accent.sublte` |
+| An **engineer** using **Primer React** | [sx props](https://primer.style/react/overriding-styles) | `accent.subtle` |
 | An **engineer** creating **custom UI** | [Primer CSS color utilities](https://primer.style/css/utilities/colors) | `color-bg-accent` |
-| A Primer **React maintainer** creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `accent.sublte` |
-| A Primer **CSS maintainer** creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `--color-accent-sublte` |
+| A Primer **React maintainer** creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `accent.subtle` |
+| A Primer **CSS maintainer** creating a **component** | [Primer Primitives variables](https://primer.style/primitives/colors) | `--color-accent-subtle` |
 
 Stuck choosing the right color? Feel free to reach out in the [#primer](https://github.slack.com/archives/CSGAVNZ19) Slack channel.

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -64,7 +64,7 @@ Color roles are defined by the meaning they convey in the UI. Primer has 8 color
 
 ## How to use Primer colors?
 
-Primer colors exist in different formats and are made available throughout the Primer libraries and tools. Not all colors exist everywhere and the naming depends on the Primer library. Below a list to help find the right Primer color documentation that is specific to that role and environment.
+Primer colors exist in different formats and are made available throughout the Primer libraries and tools. Not all colors exist everywhere and the naming depends on the Primer library. Use the list below to help find the right Primer color documentation that is specific to that role and environment.
 
 | I am | Documentation | Example color usage |
 | -------- | -------- | -------- |


### PR DESCRIPTION
Hello! 👋 

Big fan of Primer here. 

This PR makes two vanishingly small but important changes at [How to use Primer colors?](https://primer.style/design/foundations/color). 

• The variant suffix for `subtle` was misspelled as "sublte" in every row of the table. This fixes that.

• The directive above the table ('Below a list to help find') was missing its verb. This fix proposes a change that improves readability and clarity by using an imperative, so it reads 'Use the table below to help find'.

Not exactly what you'd call a set of breaking changes and I'm sure people could connect the dots, but hey, you never know. Feel free to just close this and fix without going through the rigamarole of merging a PR. :) And thanks for making Primer! It is great.