### PR TITLE
[WIP] Document guidelines for saving or submitting data

### DIFF
--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -47,7 +47,7 @@ TODO: find an example of this, mock one up (if that's allowed), or exclude this 
 
 Do not disable or hide a form's save button if the form is invalid or has not been changed. The only time the save button should be disabled is in cases where you need to prevent the user from taking further action while the request completes (such as updating notification preferences). In these cases, disable the save button and the form inputs. While the form is disabled, update the save button's label with the present continuous form of the action's verb (for example, "Save" becomes "Saving...", "Follow" becomes "Following...") to indicate that they shouldn't navigate away from the current page which may cause the request to fail silently in the event of an error. In most cases, these actions should take minimal time, but in cases where it takes longer than normal, this clear indication is invaluable.
 
-![Screenshot of a CTA label that changes from "Update" to "Updating..."](https://user-images.githubusercontent.com/2313998/150868916-ea209d7c-136e-4f6a-a1b0-51d1e54faf46.png)
+![Button that changes from "Update" to "Updating..." when selected](https://user-images.githubusercontent.com/2313998/150868916-ea209d7c-136e-4f6a-a1b0-51d1e54faf46.png)
 
 ## Explicit saving
 An explicit save does not apply changes until the user explicitly takes an action to submit the changes.

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -1,12 +1,16 @@
 ---
-title: Save
+title: Saving
 ---
 
-Save patterns help users to store and update their content and configuration throughout GitHub. These changes should be represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
+import {Box} from '@primer/components'
+
+<Box sx={{fontSize: 3}} class="lead" as="p">
+    Save patterns help users to store and update their content and configuration throughout GitHub. These changes should be represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
+</Box>
 
 ## Calls to action
 
-### Label copy
+### Label
 
 All configuration flows should have calls to action that include an obvious active verb such as "Create", "Save", "Delete", or "Update" (for example, "Create" a new repository, "Add" an SSH key to your profile, "Save" security preferences, "Update" a repository's description, "Delete" an old email address).
 
@@ -14,47 +18,82 @@ When defining these calls to actions, make sure to:
 1. Keep the text as succinct and clear as possible
 2. Add the item’s name to the button text in cases where it may be unclear to the user what is being changed
 
+### Appearance
+
+If the save button is used to save every input on the page, use the _primary_ button appearance.
+
+If the save button has a corresponding cancel button, use the _primary_ button appearance for the save button, and _secondary_ for the cancel button.
+
+If the save button only refers to a segment of inputs on the page, use the _secondary_ button appearance.
+
+For more guidance on button usage, see the [button interface guidelines](/ui-patterns/button-usage).
+
 ### Placement
 
 Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidlines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
 
 It's strongly recommended to have only one save button on a page. Allow only one edit mode activated at a time if you're designing a page with content that can be edited separately (such as an Issue title). Pages that contain multiple save buttons can cause confusion about which save button saves which group. Multiple save buttons with the same label can cause confusion for people who use assistive technologies like screen readers and voice recognition software.
 
-{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+<img width="960" src="https://user-images.githubusercontent.com/2313998/151448415-24fc9f15-627f-47b7-abab-2020d285b770.png" />
 
-{/*TODO: reference the case where there's a declaratively saved form on a page with inherently saved inputs (such as user Profile settings)*/}
+#### Bottom-left
 
-#### Common places for a submit button
+If there is a button to submit and a button to cancel, the cancel button should go to the right of the submit button.
 
-Default to placing the submit button at the bottom left of the form. Field labels and inputs are left-aligned and run from top-to-bottom, so users would naturally move their eyes down and to the left.
+<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
+    <img
+        width="456"
+        alt="A form with the inputs and save button left aligned"
+        src="https://user-images.githubusercontent.com/2313998/151623721-2cbe406b-ee3d-4bef-85f2-7f671771308a.png"
+    />
+    <Box as="p" mt="0">Default to placing the submit button at the bottom left of the form. Field labels and inputs are left-aligned and run from top-to-bottom, so users would naturally move their eyes down and to the left.</Box>
+</Box>
 
-{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+#### Bottom-right
 
-If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog buttons feel familiar because it's a very common pattern. For example: Windows, macOS, and Android.
+If there is a button to submit and a button to cancel, the button to cancel should go to the left of the submit button.
 
-{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
+    <img
+        width="456"
+        alt="A small form in a dialog that has 'Cancel' and 'Save' buttons at the bottom right"
+        src="https://user-images.githubusercontent.com/2313998/151623724-d59d5967-5484-4e81-a4c2-1109409956ee.png"
+    />
+    <Box as="p" mt="0">If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog buttons feel familiar because it's a very common pattern. For example: Windows, macOS, and Android.</Box>
+</Box>
 
-If the save button in the dialog has a label that makes the button almost as wide as the dialog, you may opt to make the dialog action buttons full-width. If there is a secondary action button, it must also be full-width.
+<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
+    <img
+        width="456"
+        alt="A multi-line text input with 'Close with Comment' and 'Comment' buttons right-aligned below the input"
+        src="https://user-images.githubusercontent.com/2313998/151623722-96b6f25d-d8b7-4de7-affe-cd202d6282f1.png"
+    />
+    <Box as="p" mt="0">If the button is used to send a message such as a comment on an issue, right-align the button below the text area. This is where GitHub has traditionally placed the "submit" button for issues and pull requests, and it's common to place a "send" button to the right. For example: iMessage, Facebook (mobile web), Twitter, Reddit.</Box>
+</Box>
 
-{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
 
-If the button is used to send a message such as a comment on an issue, right-align the button below the text area. This is where GitHub has traditionally placed the "Submit" button for issues and pull requests, and it's common to place a "send" button to the right. For example: iMessage, Facebook (mobile web), Twitter, Reddit.
-
-{/*TODO: Make sure right-aligned send buttons are ok for right-to-left languages*/}
-{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
-
-{/*
+<!--
 TODO:
 1. Be more specific about when a button should be placed somewhere besides the bottom-right. Define alternative patterns and when to use them.
 
 2. Consider how we might define more patterns to keep the "Save" button easily accessible on long forms:
 - add save and cancel buttons on top AND bottom?
 - use a sticky header with save and cancel buttons?
-*/}
+-->
 
-To minimize UI, some content may be edited inline without taking the user to a separate flow. An input used for inline editing should have a save button placed very close to visually group the input with the button.
+#### Adjacent to inline editing input
 
-![Save button is placed to the right of the input used to edit the PR title](https://user-images.githubusercontent.com/2313998/150868914-6af36067-39a6-4fec-adb9-518c5abd595d.gif)
+To minimize UI, some content may be edited inline without taking the user to a separate flow.
+
+An input used for inline editing should have a save button placed very close to visually group the input with the button.
+
+<img
+    width="960"
+    alt="Two images of a pull request header. The first image shows the title as read-only text. The second image shows a text input to edit the pull request title with 'Cancel' and 'Save' buttons below the input."
+    src="https://user-images.githubusercontent.com/2313998/151623718-9f3f7fe5-ad35-4e4a-b236-da594388203b.png"
+/>
+
+#### Other
 
 If you encounter a case where your submit button would not be intuitive or easily accessible using any of the placement options described above, then consider alternatives and optinally propose a new Primer pattern.
 
@@ -62,31 +101,56 @@ If you encounter a case where your submit button would not be intuitive or easil
 
 Do not disable or hide a form's save button even if the form is invalid or has not been changed. Disabled buttons cannot be focused using the Tab key, and disabled button styles are typically low-contrast and difficult to read.
 
+<DoDontContainer>
+  <Do>
+    <img src="https://user-images.githubusercontent.com/2313998/151623709-2a4257d6-e8d0-4156-b928-c7097981791c.png" />
+    <Caption>Always keep the save button enabled</Caption>
+  </Do>
+  <Dont>
+    <img src="https://user-images.githubusercontent.com/2313998/151623715-3b298004-b624-43dc-875c-2590c08070e7.png" />
+    <Caption>Disable the save button if the form is invalid or unchanged</Caption>
+  </Dont>
+</DoDontContainer>
+
 ## Explicit saving
-An explicit save does not apply changes until the user explicitly takes an action to submit the changes.
+An explicit save does not apply changes until the user explicitly takes an action to submit the changes. If you're designing a form, start with an explicit saving pattern.
 
 Explicitly saved forms can be saved by clicking a submit button or by pressing the "Enter" key while focused on an input.
 
-If you're designing a form, start with an explicit saving pattern. Avoid mixing explicit and automatic save patterns on a single page with multiple forms, and never mix save patterns in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
-
 If there was an error saving the data, the user's data should be preserved in the form and they should be given [feedback](#feedback) about the failure.
+
+Avoid mixing explicit and automatic save patterns on a single page with multiple forms, and never mix save patterns in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
+
+<DoDontContainer>
+  <Do>
+    <img src="https://user-images.githubusercontent.com/2313998/151623711-ad294946-fd67-428d-96b2-e4f534857c8a.png" />
+    <Caption>Separate auto-saving controls from an explicitly saved form</Caption>
+  </Do>
+  <Dont>
+    <img src="https://user-images.githubusercontent.com/2313998/151623713-12028e6d-86ba-4ae6-b46b-d3c88c0fa2c0.png" />
+    <Caption>Mix auto-saving controls with explictly saved controls in the same form</Caption>
+  </Dont>
+</DoDontContainer>
+
+### Unsaved changes
+
+With the addition of the command palette there are additional opportunities to accidentally navigate away from a page with unpublished edits.
 
 If a user tries to navigate away from a page with a form that has unsaved changes, you can optionally warn them that their changes will be lost using the [beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event). Modern browsers prevent developers from customizing the alrt message, so we're limited to a generic message like "Do you want to leave this site? Changes you made may not be saved."
 
-### Declarative inputs
+### Declarative controls
 
-When designing a form that is saved explicitly, use the following inputs:
 - Text inputs
 - Checkbox groups
 - Radio button groups
 - Browser-native `<select>` dropdown menus
-- Custom dropdown menus that allow multiple selections
+- Multi-select dropdown menus
 
 To maintain consistent interaction patterns across your app, do not use toggle switches or segmented controls in an explicitly saved form. They should only be used when they automatically change based on user input.
 
 To build an accessible and consistent app, do not automatically save declarative inputs.
 
-### Problems with autosaving:
+#### Problems with autosaving declarative inputs:
 **Text inputs**
 - Users are expecting to set a value and then submit
 - Sensitive information could be unintentionally submitted. For example: a change password input
@@ -96,10 +160,21 @@ To build an accessible and consistent app, do not automatically save declarative
 - Users may accidentally submit a selection that they clicked by accident
 
 **Radio button groups**
-Screenreader users can't read the options without selecting them. This could accidentally apply a selection the user didn't want.
+- Screenreader users can't read the options without selecting them. This could accidentally apply a selection the user didn't want.
 
 **Browser-native `<select>` dropdowns**
-A select dropdown has a similar problem as a radio button group. Options are selected when a user focuses the select and uses their arrow keys to read through each option
+- A select dropdown has a similar problem as a radio button group. Options are selected when a user focuses the select and uses their arrow keys to read through each option
+
+<DoDontContainer>
+  <Do>
+    <img src="https://user-images.githubusercontent.com/2313998/151623712-d9148e5e-3682-4a92-a7a0-69aa3dad44ac.png" />
+    <Caption>Use save and cancel buttons in dropdowns that take multiple selections</Caption>
+  </Do>
+  <Dont>
+    <img src="https://user-images.githubusercontent.com/2313998/151623716-a3ced0bd-d27f-4c45-922d-c4af80cea18c.png" />
+    <Caption>Automatically save selections when the dropdown is closed</Caption>
+  </Dont>
+</DoDontContainer>
 
 ## Automatic saving
 
@@ -107,12 +182,19 @@ Automatic saving applies changes as they are made.
 
 Automatic saving should be used when the user expects instant feedback from the change they made. Changes should only be saved automatically using [imperitive inputs](#imperitive-inputs) and for individual settings that are not changed via separate flows.
 
-If a field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for a field that has been "saved" or has an error "error" could be mistaken as a validation status.
+<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
+    <img
+        width="456"
+        alt="Two toggle switches"
+        src="https://user-images.githubusercontent.com/2313998/151448402-69b15752-65d2-4d93-8b5c-e2456e1fb802.png"
+    />
+    <div>
+        <Box as="p" mt="0">If a field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for a field that has been "saved" or has an error "error" could be mistaken as a validation status.</Box>
+    </div>
+</Box>
 
-![Screen recording of a user changing their theme in the 'Appearance' settings tab](https://user-images.githubusercontent.com/2313998/150868921-afc2b8b8-e39f-478f-b17d-398b790bda89.gif)
 
-
-### Imperitive inputs
+### Imperitive controls
 
 When user input is automatically saved, use the following inputs:
 - Toggle switches
@@ -121,45 +203,30 @@ When user input is automatically saved, use the following inputs:
 
 These inputs are designed to reduce UI by giving instant feedback. The toggle switch behaves like a light switch: the light just switches on and off without you having to confirm each time you flip the switch. Segmented controls and single-select dropdowns behave like a soda machine: the soda comes out as soon as you press the buttons without you confirming which soda you wanted.
 
+<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
+    <img
+        width="456"
+        alt="A switching being turned off, reverting back to on due to an error, then being turned off again"
+        src="https://user-images.githubusercontent.com/2313998/151624246-76c19631-9a63-4feb-85ec-1d1abdb8e519.gif"
+    />
+    <Box as="p" mt="0">If an imperitive input did not automatically save, show the original value and an error message.</Box>
+</Box>
+
 ## Feedback
 
 If the change may not be obvious in the UI within the user's viewport, provide feedback to let the user know that the change occurred successfully. If the change occured without a redirect or page refresh, you could use a toast message. If the change occured and the page refreshes or redirects, you could use a flash banner message.
 
 **A note on toasts:** If your design is being implemented in github.com, avoid using a toast for now. They have accessibility issues that need to be fixed.
 
-<img width="1787" alt="Flash banner on activity feed page confirming a successful repository deletion" src="https://user-images.githubusercontent.com/2313998/150868934-b96e6d9d-d022-433f-87ab-189baf1776fa.png">
-
-
-If an imperitive input did not automatically save, show an error message that explains why the change wasn't saved.
-
-{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
-
 ## Error forgiveness
 
-For risky changes, provide an option to "undo" after saving.
-
-![Mouse cursor hovering over the 'Revert' button after merging a PR](https://user-images.githubusercontent.com/2313998/150870681-349185eb-342a-49f2-a7d3-6e58132e86a0.png)
-
+For risky changes, provide a way to undo those changes after saving.
 
 Before submitting a form with very dangerous consequences (for example, delete a repository), ask the to user confirm they want to submit the form.
-
-![User flow of a user confirming that they want to delete a repository](https://user-images.githubusercontent.com/2313998/150868926-f99d23f6-6e31-4333-9545-2625451dae99.gif)
-
-{/*TODO: come up with some helpful guidance on tabbed forms, or just exclude these guidelines until an issue comes up*/
-
-## Saving multi-page forms
-
-### Sequential pages
-If a form is broken up into steps using sequential pages, wait until the last step has been completed to submit the form. However, a user should be able to go back to any step's page without losing data.
-
-### Non-sequential pages
-If a form is broken up into non-sequential pages (for example, form tabs), ???
-*/}
-
 
 ## Redirecting
 When creating new content like issues, discussions, or even larger entities such as repositories or organizations, you may redirect the user to the entity they just created at the end of the flow.
 
 In some cases, such as forking or using a template, you may need to hold the user at a waiting page while the entity is generated. In these cases, make the user feel confident that something is happening and that their configuration details will not be lost. 
 
-![Screen recording of a user forking a repository](https://user-images.githubusercontent.com/2313998/150868932-6c7ba5a0-3eac-4fcb-826f-08459c6efa30.gif)
+![Screen recording of a user forking a repository](https://user-images.githubusercontent.com/2313998/151446009-58bfb92f-00e1-4a15-a2a3-f1afb6fb4031.gif)

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -20,8 +20,30 @@ When defining these calls to actions, make sure to:
 
 Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidlines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
 
-Default to placing the submit button at the bottom right of the form. In cases where this is an unintuitive placement, explore other positions to place the button.
-<img width="1790" alt="Save changes button aligned to the lower right corner of the Edit repository details form dialog" src="https://user-images.githubusercontent.com/2313998/150868909-71f72f1a-eafc-4777-a639-96d81b33eebb.png">
+It's strongly recommended to have only one save button on a page. Allow only one edit mode activated at a time if you're designing a page with content that can be edited separately (such as an Issue title). Pages that contain multiple save buttons can cause confusion about which save button saves which group. Multiple save buttons with the same label can cause confusion for people who use assistive technologies like screen readers and voice recognition software.
+
+{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+
+{/*TODO: reference the case where there's a declaratively saved form on a page with inherently saved inputs (such as user Profile settings)*/}
+
+#### Common places for a submit button
+
+Default to placing the submit button at the bottom left of the form. Field labels and inputs are left-aligned and run from top-to-bottom, so users would naturally move their eyes down and to the left.
+
+{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+
+If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog buttons feel familiar because it's a very common pattern. For example: Windows, macOS, and Android.
+
+{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+
+If the save button in the dialog has a label that makes the button almost as wide as the dialog, you may opt to make the dialog action buttons full-width. If there is a secondary action button, it must also be full-width.
+
+{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
+
+If the button is used to send a message such as a comment on an issue, right-align the button below the text area. This is where GitHub has traditionally placed the "Submit" button for issues and pull requests, and it's common to place a "send" button to the right. For example: iMessage, Facebook (mobile web), Twitter, Reddit.
+
+{/*TODO: Make sure right-aligned send buttons are ok for right-to-left languages*/}
+{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
 
 {/*
 TODO:
@@ -34,18 +56,9 @@ TODO:
 
 To minimize UI, some content may be edited inline without taking the user to a separate flow. An input used for inline editing should have a save button placed very close to visually group the input with the button.
 
-If a save button is used to save an inline edit to the input or inputs where the change was made.
 ![Save button is placed to the right of the input used to edit the PR title](https://user-images.githubusercontent.com/2313998/150868914-6af36067-39a6-4fec-adb9-518c5abd595d.gif)
 
-It's strongly recommended to have only one save button on a page. Allow only one edit mode activated at a time if you're designing a page with content that can be edited separately (such as an Issue title). Pages that contain multiple save buttons can cause confusion about which save button saves which group. Multiple save buttons with the same label can cause confusion for people who use assistive technologies like screen readers and voice recognition software.
-
-{/* 
-TODO: Mock up one or more examples of this
-
-![🖼 Include a DO example with image to reinforce message]()
-*/}
-
-{/* TODO: reference the case where there's a declaratively saved form on a page with inherently saved inputs (such as user Profile settings) */}
+If you encounter a case where your submit button would not be intuitive or easily accessible using any of the placement options described above, then consider alternatives and optinally propose a new Primer pattern.
 
 ### State
 
@@ -93,7 +106,7 @@ A select dropdown has a similar problem as a radio button group. Options are sel
 
 Automatic saving applies changes as they are made.
 
-Automatic saving should be used when the user expects instant feedback from the change they made. Changes should only be saved automatically using[imperitive inputs](#imperitive-inputs) and for individual settings that are not changed via separate flows.
+Automatic saving should be used when the user expects instant feedback from the change they made. Changes should only be saved automatically using [imperitive inputs](#imperitive-inputs) and for individual settings that are not changed via separate flows.
 
 If a field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for a field that has been "saved" or has an error "error" could be mistaken as a validation status.
 
@@ -120,11 +133,7 @@ If the change may not be obvious in the UI within the user's viewport, provide f
 
 If an imperitive input did not automatically save, show an error message that explains why the change wasn't saved.
 
-{/*
-TODO: Mock up one or more examples of this
-
-![🖼 Include a DO example with image to reinforce message]()
-*/}
+{/*TODO: ![🖼 Include a DO example with image to reinforce message]()*/}
 
 ## Error forgiveness
 
@@ -137,8 +146,7 @@ Before submitting a form with very dangerous consequences (for example, delete a
 
 ![User flow of a user confirming that they want to delete a repository](https://user-images.githubusercontent.com/2313998/150868926-f99d23f6-6e31-4333-9545-2625451dae99.gif)
 
-{/*
-TODO: come up with some helpful guidance on tabbed forms, or just exclude these guidelines until an issue comes up
+{/*TODO: come up with some helpful guidance on tabbed forms, or just exclude these guidelines until an issue comes up*/
 
 ## Saving multi-page forms
 

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -21,7 +21,7 @@ When defining these calls to actions, make sure to:
 Save buttons should be placed somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved.
 
 Default to placing the submit button at the bottom right of the form. In cases where this is an unintuitive placement, explore other positions to place the button.
-<img width="1790" alt="Screenshot of the 'Edit repository details' form" src="https://user-images.githubusercontent.com/2313998/150868909-71f72f1a-eafc-4777-a639-96d81b33eebb.png">
+<img width="1790" alt="Save changes button aligned to the lower right corner of the Edit repository details form dialog" src="https://user-images.githubusercontent.com/2313998/150868909-71f72f1a-eafc-4777-a639-96d81b33eebb.png">
 
 {/*
 TODO:

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -129,7 +129,7 @@ TODO: find an example of this, mock one up (if that's allowed), or exclude this 
 
 For risky changes, provide an option to "undo" after saving.
 
-![Screenshot of a user hovering the 'Revert' button after merging a PR](https://user-images.githubusercontent.com/2313998/150870681-349185eb-342a-49f2-a7d3-6e58132e86a0.png)
+![Mouse cursor hovering over the 'Revert' button after merging a PR](https://user-images.githubusercontent.com/2313998/150870681-349185eb-342a-49f2-a7d3-6e58132e86a0.png)
 
 
 Before submitting a form with very dangerous consequences (for example, delete a repository), ask the to user confirm they want to submit the form.

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -25,7 +25,9 @@ Default to placing the submit button at the bottom right of the form. In cases w
 
 {/*
 TODO:
-Consider how we might define more patterns to keep the "Save" button easily accessible on long forms:
+1. Be more specific about when a button should be placed somewhere besides the bottom-right. Define alternative patterns and when to use them.
+
+2. Consider how we might define more patterns to keep the "Save" button easily accessible on long forms:
 - add save and cancel buttons on top AND bottom?
 - use a sticky header with save and cancel buttons?
 */}
@@ -111,13 +113,15 @@ These inputs are designed to reduce UI by giving instant feedback. The toggle sw
 
 If the change may not be obvious in the UI within the user's viewport, provide feedback to let the user know that the change occurred successfully. If the change occured without a redirect or page refresh, you could use a toast message. If the change occured and the page refreshes or redirects, you could use a flash banner message.
 
+**A note on toasts:** If your design is being implemented in github.com, avoid using a toast for now. They have accessibility issues that need to be fixed.
+
 <img width="1787" alt="Flash banner on activity feed page confirming a successful repository deletion" src="https://user-images.githubusercontent.com/2313998/150868934-b96e6d9d-d022-433f-87ab-189baf1776fa.png">
 
 
 If an imperitive input did not automatically save, show an error message that explains why the change wasn't saved.
 
 {/*
-TODO: find an example of this, mock one up (if that's allowed), or exclude this visual example
+TODO: Mock up one or more examples of this
 
 ![🖼 Include a DO example with image to reinforce message]()
 */}

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -18,7 +18,7 @@ When defining these calls to actions, make sure to:
 
 ### Placement
 
-Save buttons should be placed somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved.
+Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidlines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
 
 Default to placing the submit button at the bottom right of the form. In cases where this is an unintuitive placement, explore other positions to place the button.
 <img width="1790" alt="Save changes button aligned to the lower right corner of the Edit repository details form dialog" src="https://user-images.githubusercontent.com/2313998/150868909-71f72f1a-eafc-4777-a639-96d81b33eebb.png">
@@ -30,13 +30,15 @@ Consider how we might define more patterns to keep the "Save" button easily acce
 - use a sticky header with save and cancel buttons?
 */}
 
-If a save button is used to save an inline edit to the input or inputs where the change was made.
-![Screen recording of a user editing a PR's title](https://user-images.githubusercontent.com/2313998/150868914-6af36067-39a6-4fec-adb9-518c5abd595d.gif)
+To minimize UI, some content may be edited inline without taking the user to a separate flow. An input used for inline editing should have a save button placed very close to visually group the input with the button.
 
-It's strongly recommended to have a single save button for all of the inputs on the page. If you're designing a page with pieces of content that can be separately toggled into an edit mode (such as editing an issue title), only allow one edit mode toggled on at a time so that only one save button is visible. When there is on save button per section of a page or form, users may be confused about whether the save button will save all of the inputs or just the subset of the inputs. This confusion is even more likely for visually impaired users because they can't see if each save button is visually grouped with a set of inputs.
+If a save button is used to save an inline edit to the input or inputs where the change was made.
+![Save button is placed to the right of the input used to edit the PR title](https://user-images.githubusercontent.com/2313998/150868914-6af36067-39a6-4fec-adb9-518c5abd595d.gif)
+
+It's strongly recommended to have only one save button on a page. Allow only one edit mode activated at a time if you're designing a page with content that can be edited separately (such as an Issue title). Pages that contain multiple save buttons can cause confusion about which save button saves which group. Multiple save buttons with the same label can cause confusion for people who use assistive technologies like screen readers and voice recognition software.
 
 {/* 
-TODO: find an example of this, mock one up (if that's allowed), or exclude this visual example
+TODO: Mock up one or more examples of this
 
 ![🖼 Include a DO example with image to reinforce message]()
 */}
@@ -45,22 +47,18 @@ TODO: find an example of this, mock one up (if that's allowed), or exclude this 
 
 ### State
 
-Do not disable or hide a form's save button if the form is invalid or has not been changed. The only time the save button should be disabled is in cases where you need to prevent the user from taking further action while the request completes (such as updating notification preferences). In these cases, disable the save button and the form inputs. While the form is disabled, update the save button's label with the present continuous form of the action's verb (for example, "Save" becomes "Saving...", "Follow" becomes "Following...") to indicate that they shouldn't navigate away from the current page which may cause the request to fail silently in the event of an error. In most cases, these actions should take minimal time, but in cases where it takes longer than normal, this clear indication is invaluable.
-
-![Button that changes from "Update" to "Updating..." when selected](https://user-images.githubusercontent.com/2313998/150868916-ea209d7c-136e-4f6a-a1b0-51d1e54faf46.png)
+Do not disable or hide a form's save button even if the form is invalid or has not been changed.
 
 ## Explicit saving
 An explicit save does not apply changes until the user explicitly takes an action to submit the changes.
 
-If you're designing a form, start with an explicit saving pattern. Avoid mixing paradigms on a single page with multiple forms, and never mix paradigms in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
+Explicitly saved forms can be saved by clicking a submit button or by pressing the "Enter" key while focused on an input.
+
+If you're designing a form, start with an explicit saving pattern. Avoid mixing explicit and automatic save patterns on a single page with multiple forms, and never mix save patterns in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
 
 If there was an error saving the data, the user's data should be preserved in the form and they should be given [feedback](#feedback) about the failure.
 
-{/*
-TODO: determine if we should include the following guidance:
-
-If a user tries to navigate away from a page with an unsaved form, we should warn them that their changes will be lost.
-*/}
+If a user tries to navigate away from a page with a form that has unsaved changes, you can optionally warn them that their changes will be lost using the [beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event). Modern browsers prevent developers from customizing the alrt message, so we're limited to a generic message like "Do you want to leave this site? Changes you made may not be saved."
 
 ### Declarative inputs
 
@@ -71,6 +69,23 @@ When designing a form that is saved explicitly, use the following inputs:
 - Dropdown menus
 
 To maintain consistent interaction patterns across your app, do not use toggle switches or segmented controls in an explicitly saved form. They should only be used when they automatically change based on user input.
+
+To build an accessible and consistent app, do not automatically save declarative inputs.
+
+### Problems with autosaving:
+**Text inputs**
+- Users are expecting to set a value and then submit
+- Sensitive information could be unintentionally submitted. For example: a change password input
+
+**Checkbox groups**
+- It could be unclear whether or not their selections have been saved
+- Users may accidentally submit a selection that they clicked by accident
+
+**Radio button groups**
+Screenreader users can't read the options without selecting them. This could accidentally apply a selection the user didn't want.
+
+**Browser-native `<select>` dropdowns**
+A select dropdown has a similar problem as a radio button group. Options are selected when a user focuses the select and uses their arrow keys to read through each option
 
 ## Automatic saving
 
@@ -88,27 +103,9 @@ If a field is saved automatically, it should be obvious whether or not it saved 
 When user input is automatically saved, use the following inputs:
 - Toggle switches
 - Segmented controls
-- Single-select dropdowns
+- Single-select dropdowns that are not native `<select>` dropdowns or part of an explicitly saved form
 
 These inputs are designed to reduce UI by giving instant feedback. The toggle switch behaves like a light switch: the light just switches on and off without you having to confirm each time you flip the switch. Segmented controls and single-select dropdowns behave like a soda machine: the soda comes out as soon as you press the buttons without you confirming which soda you wanted.
-
-To build an accessible and consistent app, do not automatically save declarative inputs.
-
-### Inputs that are problematic for autosaving:
-**Text inputs**
-- Users are expecting to set a value and then submit
-- Sensitive information could be unintentionally submitted. For example: a change password input
-
-**Checkbox groups**
-- It could be unclear whether or not their selections have been saved
-- Users may accidentally submit a selection that they clicked by accident
-
-**Radio button groups**
-Screenreader users can't read the options without selecting them. This could accidentally apply a selection the user didn't want.
-
-**Browser-native `<select>` dropdowns**
-On Windows, a select dropdown has a similar problem as a radio button group. 
-Options are selected when a user focuses the select and uses their arrow keys to read through each option
 
 ## Feedback
 
@@ -145,7 +142,7 @@ TODO: come up with some helpful guidance on tabbed forms, or just exclude these 
 If a form is broken up into steps using sequential pages, wait until the last step has been completed to submit the form. However, a user should be able to go back to any step's page without losing data.
 
 ### Non-sequential pages
-If a form is broken up into non-sequential pages (for example, form tabs),
+If a form is broken up into non-sequential pages (for example, form tabs), ???
 */}
 
 

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -134,7 +134,7 @@ For risky changes, provide an option to "undo" after saving.
 
 Before submitting a form with very dangerous consequences (for example, delete a repository), ask the to user confirm they want to submit the form.
 
-![Screen recording of a user confirming that they want to delete a repository](https://user-images.githubusercontent.com/2313998/150868926-f99d23f6-6e31-4333-9545-2625451dae99.gif)
+![User flow of a user confirming that they want to delete a repository](https://user-images.githubusercontent.com/2313998/150868926-f99d23f6-6e31-4333-9545-2625451dae99.gif)
 
 {/*
 TODO: come up with some helpful guidance on tabbed forms, or just exclude these guidelines until an issue comes up

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -124,11 +124,11 @@ If there is an error saving the data, the user's data should be preserved in the
 
 <DoDontContainer>
   <Do>
-    <img src="https://user-images.githubusercontent.com/2313998/151623711-ad294946-fd67-428d-96b2-e4f534857c8a.png" />
+    <img src="https://user-images.githubusercontent.com/2313998/151623712-d9148e5e-3682-4a92-a7a0-69aa3dad44ac.png" />
     <Caption>Separate auto-saving controls from an explicitly saved form</Caption>
   </Do>
   <Dont>
-    <img src="https://user-images.githubusercontent.com/2313998/151623713-12028e6d-86ba-4ae6-b46b-d3c88c0fa2c0.png" />
+    <img src="https://user-images.githubusercontent.com/2313998/151623716-a3ced0bd-d27f-4c45-922d-c4af80cea18c.png" />
     <Caption>Mix auto-saving controls with explictly saved controls in the same form</Caption>
   </Dont>
 </DoDontContainer>
@@ -168,11 +168,11 @@ To ensure your forms are accessible, do not automatically save declarative input
 
 <DoDontContainer>
   <Do>
-    <img src="https://user-images.githubusercontent.com/2313998/151623712-d9148e5e-3682-4a92-a7a0-69aa3dad44ac.png" />
+    <img src="https://user-images.githubusercontent.com/2313998/151623711-ad294946-fd67-428d-96b2-e4f534857c8a.png" />
     <Caption>Use save and cancel buttons in dropdowns that take multiple selections</Caption>
   </Do>
   <Dont>
-    <img src="https://user-images.githubusercontent.com/2313998/151623716-a3ced0bd-d27f-4c45-922d-c4af80cea18c.png" />
+    <img src="https://user-images.githubusercontent.com/2313998/151623713-12028e6d-86ba-4ae6-b46b-d3c88c0fa2c0.png" />
     <Caption>Automatically save selections when the dropdown is closed</Caption>
   </Dont>
 </DoDontContainer>

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -1,0 +1,163 @@
+---
+title: Save
+---
+
+Save patterns help users to store and update their content and configuration throughout GitHub. These changes should be represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
+
+## Calls to action
+
+### Label copy
+
+All configuration flows should have calls to action that include an obvious active verb such as "Create", "Save", "Delete", or "Update" (for example, "Create" a new repository, "Add" an SSH key to your profile, "Save" security preferences, "Update" a repository's description, "Delete" an old email address).
+
+When defining these calls to actions, make sure to:
+1. Keep the text as succinct and clear as possible
+2. Add the item’s name to the button text in cases where it may be unclear to the user what is being changed
+
+![Screenshot of the 'Create a new repository' form](https://user-images.githubusercontent.com/2313998/150868902-a8514e84-5cd4-4081-b13d-46f00f404625.png)
+
+### Placement
+
+Save buttons should be placed somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved.
+
+Default to placing the submit button at the bottom right of the form. In cases where this is an unintuitive placement, explore other positions to place the button.
+<img width="1790" alt="Screenshot of the 'Edit repository details' form" src="https://user-images.githubusercontent.com/2313998/150868909-71f72f1a-eafc-4777-a639-96d81b33eebb.png">
+
+{/*
+TODO:
+Consider how we might define more patterns to keep the "Save" button easily accessible on long forms:
+- add save and cancel buttons on top AND bottom?
+- use a sticky header with save and cancel buttons?
+*/}
+
+If a save button is used to save an inline edit to the input or inputs where the change was made.
+![Screen recording of a user editing a PR's title](https://user-images.githubusercontent.com/2313998/150868914-6af36067-39a6-4fec-adb9-518c5abd595d.gif)
+
+It's strongly recommended to have a single save button for all of the inputs on the page. If you're designing a page with pieces of content that can be separately toggled into an edit mode (such as editing an issue title), only allow one edit mode toggled on at a time so that only one save button is visible. When there is on save button per section of a page or form, users may be confused about whether the save button will save all of the inputs or just the subset of the inputs. This confusion is even more likely for visually impaired users because they can't see if each save button is visually grouped with a set of inputs.
+
+{/* 
+TODO: find an example of this, mock one up (if that's allowed), or exclude this visual example
+
+![🖼 Include a DO example with image to reinforce message]()
+*/}
+
+{/* TODO: reference the case where there's a declaratively saved form on a page with inherently saved inputs (such as user Profile settings) */}
+
+### State
+
+Do not disable or hide a form's save button if the form is invalid or has not been changed. The only time the save button should be disabled is in cases where you need to prevent the user from taking further action while the request completes (such as updating notification preferences). In these cases, disable the save button and the form inputs. While the form is disabled, update the save button's label with the present continuous form of the action's verb (for example, "Save" becomes "Saving...", "Follow" becomes "Following...") to indicate that they shouldn't navigate away from the current page which may cause the request to fail silently in the event of an error. In most cases, these actions should take minimal time, but in cases where it takes longer than normal, this clear indication is invaluable.
+
+![Screenshot of a CTA label that changes from "Update" to "Updating..."](https://user-images.githubusercontent.com/2313998/150868916-ea209d7c-136e-4f6a-a1b0-51d1e54faf46.png)
+
+## Explicit saving
+An explicit save does not apply changes until the user explicitly takes an action to submit the changes.
+
+If you're designing a form, start with an explicit saving pattern. Avoid mixing paradigms on a single page with multiple forms, and never mix paradigms in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
+
+If there was an error saving the data, the user's data should be preserved in the form and they should be given [feedback](#feedback) about the failure.
+
+{/*
+TODO: determine if we should include the following guidance:
+
+If a user tries to navigate away from a page with an unsaved form, we should warn them that their changes will be lost.
+*/}
+
+### Declarative inputs
+
+When designing a form that is saved explicitly, use the following inputs:
+- Text inputs
+- Checkbox groups
+- Radio button groups
+- Dropdown menus
+
+To maintain consistent interaction patterns across your app, do not use toggle switches or segmented controls in an explicitly saved form. They should only be used when they automatically change based on user input.
+
+## Automatic saving
+
+Automatic saving applies changes as they are made.
+
+Automatic saving should be used when the user expects instant feedback from the change they made. Changes should only be saved automatically using[imperitive inputs](#imperitive-inputs) and for individual settings that are not changed via separate flows.
+
+If a field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for a field that has been "saved" or has an error "error" could be mistaken as a validation status.
+
+![Screen recording of a user changing their theme in the 'Appearance' settings tab](https://user-images.githubusercontent.com/2313998/150868921-afc2b8b8-e39f-478f-b17d-398b790bda89.gif)
+
+
+### Imperitive inputs
+
+When user input is automatically saved, use the following inputs:
+- Toggle switches
+- Segmented controls
+- Single-select dropdowns
+
+These inputs are designed to reduce UI by giving instant feedback. The toggle switch behaves like a light switch: the light just switches on and off without you having to confirm each time you flip the switch. Segmented controls and single-select dropdowns behave like a soda machine: the soda comes out as soon as you press the buttons without you confirming which soda you wanted.
+
+To build an accessible and consistent app, do not automatically save declarative inputs.
+
+### Inputs that are problematic for autosaving:
+**Text inputs**
+- Users are expecting to set a value and then submit
+- Sensitive information could be unintentionally submitted. For example: a change password input
+
+**Checkbox groups**
+- It could be unclear whether or not their selections have been saved
+- Users may accidentally submit a selection that they clicked by accident
+
+**Radio button groups**
+Screenreader users can't read the options without selecting them. This could accidentally apply a selection the user didn't want.
+
+**Browser-native `<select>` dropdowns**
+On Windows, a select dropdown has a similar problem as a radio button group. 
+Options are selected when a user focuses the select and uses their arrow keys to read through each option
+
+## Feedback
+
+If the change may not be obvious in the UI within the user's viewport, provide feedback to let the user know that the change occurred successfully. If the change occured without a redirect or page refresh, you could use a toast message. If the change occured and the page refreshes or redirects, you could use a flash banner message.
+
+<img width="1787" alt="Screenshot of the user's activity feed page with a flash banner confirming that a repository has been deleted" src="https://user-images.githubusercontent.com/2313998/150868934-b96e6d9d-d022-433f-87ab-189baf1776fa.png">
+
+
+If an imperitive input did not automatically save, show an error message that explains why the change wasn't saved.
+
+{/*
+TODO: find an example of this, mock one up (if that's allowed), or exclude this visual example
+
+![🖼 Include a DO example with image to reinforce message]()
+*/}
+
+## Error forgiveness
+
+For risky changes, provide an option to "undo" after saving.
+
+![Screenshot of a user hovering the 'Revert' button after merging a PR](https://user-images.githubusercontent.com/2313998/150870681-349185eb-342a-49f2-a7d3-6e58132e86a0.png)
+
+
+Before submitting a form with very dangerous consequences (for example, delete a repository), ask the to user confirm they want to submit the form.
+
+![Screen recording of a user confirming that they want to delete a repository](https://user-images.githubusercontent.com/2313998/150868926-f99d23f6-6e31-4333-9545-2625451dae99.gif)
+
+{/*
+TODO: come up with some helpful guidance on tabbed forms, or just exclude these guidelines until an issue comes up
+
+## Saving multi-page forms
+
+### Sequential pages
+If a form is broken up into steps using sequential pages, wait until the last step has been completed to submit the form. However, a user should be able to go back to any step's page without losing data.
+
+### Non-sequential pages
+If a form is broken up into non-sequential pages (for example, form tabs),
+*/}
+
+
+## Redirecting
+When creating new content like issues, discussions, or even larger entities such as repositories or organizations, you may redirect the user to the entity they just created at the end of the flow.
+
+In some cases, such as forking or using a template, you may need to hold the user at a waiting page while the entity is generated. In these cases, make the user feel confident that something is happening and that their configuration details will not be lost. 
+
+![Screen recording of a user forking a repository](https://user-images.githubusercontent.com/2313998/150868932-6c7ba5a0-3eac-4fcb-826f-08459c6efa30.gif)
+
+{/*
+TODO: find an example of this, mock one up (if that's allowed), or exclude this visual example
+
+![🖼 Include a DO example with image to reinforce message]()
+*/}

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -14,8 +14,6 @@ When defining these calls to actions, make sure to:
 1. Keep the text as succinct and clear as possible
 2. Add the item’s name to the button text in cases where it may be unclear to the user what is being changed
 
-![Create a new repository form with "Create repository" button submission text](https://user-images.githubusercontent.com/2313998/150868902-a8514e84-5cd4-4081-b13d-46f00f404625.png)
-
 ### Placement
 
 Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidlines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
@@ -62,7 +60,7 @@ If you encounter a case where your submit button would not be intuitive or easil
 
 ### State
 
-Do not disable or hide a form's save button even if the form is invalid or has not been changed.
+Do not disable or hide a form's save button even if the form is invalid or has not been changed. Disabled buttons cannot be focused using the Tab key, and disabled button styles are typically low-contrast and difficult to read.
 
 ## Explicit saving
 An explicit save does not apply changes until the user explicitly takes an action to submit the changes.

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -155,9 +155,3 @@ When creating new content like issues, discussions, or even larger entities such
 In some cases, such as forking or using a template, you may need to hold the user at a waiting page while the entity is generated. In these cases, make the user feel confident that something is happening and that their configuration details will not be lost. 
 
 ![Screen recording of a user forking a repository](https://user-images.githubusercontent.com/2313998/150868932-6c7ba5a0-3eac-4fcb-826f-08459c6efa30.gif)
-
-{/*
-TODO: find an example of this, mock one up (if that's allowed), or exclude this visual example
-
-![🖼 Include a DO example with image to reinforce message]()
-*/}

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -114,7 +114,7 @@ Options are selected when a user focuses the select and uses their arrow keys to
 
 If the change may not be obvious in the UI within the user's viewport, provide feedback to let the user know that the change occurred successfully. If the change occured without a redirect or page refresh, you could use a toast message. If the change occured and the page refreshes or redirects, you could use a flash banner message.
 
-<img width="1787" alt="Screenshot of the user's activity feed page with a flash banner confirming that a repository has been deleted" src="https://user-images.githubusercontent.com/2313998/150868934-b96e6d9d-d022-433f-87ab-189baf1776fa.png">
+<img width="1787" alt="Flash banner on activity feed page confirming a successful repository deletion" src="https://user-images.githubusercontent.com/2313998/150868934-b96e6d9d-d022-433f-87ab-189baf1776fa.png">
 
 
 If an imperitive input did not automatically save, show an error message that explains why the change wasn't saved.

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -5,12 +5,14 @@ title: Saving
 import {Box} from '@primer/components'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
-    Save patterns help users to store and update their content and configuration throughout GitHub. These changes should be represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
+    Save patterns help users store and update their content and configuration throughout GitHub. These changes should be represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
 </Box>
 
 ## Calls to action
 
-### Label
+When data is not automatically saved after the user make changes, buttons are used to submit or cancel the changes.
+
+### Text
 
 All configuration flows should have calls to action that include an obvious active verb such as "Create", "Save", "Delete", or "Update" (for example, "Create" a new repository, "Add" an SSH key to your profile, "Save" security preferences, "Update" a repository's description, "Delete" an old email address).
 
@@ -28,11 +30,15 @@ If the save button only refers to a segment of inputs on the page, use the _seco
 
 For more guidance on button usage, see the [button interface guidelines](/ui-patterns/button-usage).
 
+### State
+
+Do not disable or hide a form's save button even if the form is invalid or has not been changed. Disabled buttons cannot be focused using the Tab key, and disabled button styles are typically low-contrast and difficult to read.
+
 ### Placement
 
-Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidlines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
+Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidelines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
 
-It's strongly recommended to have only one save button on a page. Allow only one edit mode activated at a time if you're designing a page with content that can be edited separately (such as an Issue title). Pages that contain multiple save buttons can cause confusion about which save button saves which group. Multiple save buttons with the same label can cause confusion for people who use assistive technologies like screen readers and voice recognition software.
+There should only be one save button on a page.Allow only one edit mode activated at a time if you're designing a page with content that can be edited separately (such as an issue title). Pages that contain multiple save buttons can cause confusion about which save button saves which group. Multiple save buttons with the same label can cause confusion for people who use assistive technologies like screen readers and voice recognition software.
 
 <img width="960" src="https://user-images.githubusercontent.com/2313998/151448415-24fc9f15-627f-47b7-abab-2020d285b770.png" />
 
@@ -46,7 +52,7 @@ If there is a button to submit and a button to cancel, the cancel button should 
         alt="A form with the inputs and save button left aligned"
         src="https://user-images.githubusercontent.com/2313998/151623721-2cbe406b-ee3d-4bef-85f2-7f671771308a.png"
     />
-    <Box as="p" mt="0">Default to placing the submit button at the bottom left of the form. Field labels and inputs are left-aligned and run from top-to-bottom, so users would naturally move their eyes down and to the left.</Box>
+    <Box as="p" mt="0">Default to placing the submit button at the bottom left of the form. Labels and inputs are left-aligned and run from top-to-bottom, so users would naturally move their eyes down and to the left.</Box>
 </Box>
 
 #### Bottom-right
@@ -59,7 +65,7 @@ If there is a button to submit and a button to cancel, the button to cancel shou
         alt="A small form in a dialog that has 'Cancel' and 'Save' buttons at the bottom right"
         src="https://user-images.githubusercontent.com/2313998/151623724-d59d5967-5484-4e81-a4c2-1109409956ee.png"
     />
-    <Box as="p" mt="0">If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog buttons feel familiar because it's a very common pattern. For example: Windows, macOS, and Android.</Box>
+    <Box as="p" mt="0">If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog buttons feel familiar because it's a common pattern across various platforms such as Windows, macOS, and Android.</Box>
 </Box>
 
 <Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
@@ -68,7 +74,7 @@ If there is a button to submit and a button to cancel, the button to cancel shou
         alt="A multi-line text input with 'Close with Comment' and 'Comment' buttons right-aligned below the input"
         src="https://user-images.githubusercontent.com/2313998/151623722-96b6f25d-d8b7-4de7-affe-cd202d6282f1.png"
     />
-    <Box as="p" mt="0">If the button is used to send a message such as a comment on an issue, right-align the button below the text area. This is where GitHub has traditionally placed the "submit" button for issues and pull requests, and it's common to place a "send" button to the right. For example: iMessage, Facebook (mobile web), Twitter, Reddit.</Box>
+    <Box as="p" mt="0">If the button is used to send a message such as a comment on an issue, right-align the button below the text area. This is where GitHub has traditionally placed the **Submit** button for issues and pull requests, and it's common practice in other apps to place a **Send** button to the right. </Box>
 </Box>
 
 
@@ -83,7 +89,7 @@ TODO:
 
 #### Adjacent to inline editing input
 
-To minimize UI, some content may be edited inline without taking the user to a separate flow.
+To simplify the interface, some content may be edited inline without taking the user to a separate flow. An input used for inline editing should have a save button placed very close to visually connect the input with the button.
 
 An input used for inline editing should have a save button placed very close to visually group the input with the button.
 
@@ -95,11 +101,7 @@ An input used for inline editing should have a save button placed very close to 
 
 #### Other
 
-If you encounter a case where your submit button would not be intuitive or easily accessible using any of the placement options described above, then consider alternatives and optinally propose a new Primer pattern.
-
-### State
-
-Do not disable or hide a form's save button even if the form is invalid or has not been changed. Disabled buttons cannot be focused using the Tab key, and disabled button styles are typically low-contrast and difficult to read.
+If you believe your submit button will not be intuitive or easily accessible using any of the placement options listed here, you may consider alternatives and optionally propose a new Primer pattern.
 
 <DoDontContainer>
   <Do>
@@ -113,13 +115,12 @@ Do not disable or hide a form's save button even if the form is invalid or has n
 </DoDontContainer>
 
 ## Explicit saving
-An explicit save does not apply changes until the user explicitly takes an action to submit the changes. If you're designing a form, start with an explicit saving pattern.
 
-Explicitly saved forms can be saved by clicking a submit button or by pressing the "Enter" key while focused on an input.
+When designing a form, start with an explicit saving pattern. Avoid mixing explicit and automatic save patterns on a single page with multiple forms, and never mix save patterns in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
 
-If there was an error saving the data, the user's data should be preserved in the form and they should be given [feedback](#feedback) about the failure.
+Explicitly saved forms can be saved by clicking a submit button or by pressing Enter while focused on an input.
 
-Avoid mixing explicit and automatic save patterns on a single page with multiple forms, and never mix save patterns in a single form. For example: if I upload a profile photo in the "Public profile" form, that change should not be saved until I explicitly submit the whole form.
+If there is an error saving the data, the user's data should be preserved in the form and they should be given [feedback](#feedback) about the failure.
 
 <DoDontContainer>
   <Do>
@@ -136,7 +137,7 @@ Avoid mixing explicit and automatic save patterns on a single page with multiple
 
 With the addition of the command palette there are additional opportunities to accidentally navigate away from a page with unpublished edits.
 
-If a user tries to navigate away from a page with a form that has unsaved changes, you can optionally warn them that their changes will be lost using the [beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event). Modern browsers prevent developers from customizing the alrt message, so we're limited to a generic message like "Do you want to leave this site? Changes you made may not be saved."
+If a user tries to navigate away from a page with a form that has unsaved changes, you can optionally warn them that their changes will be lost using the [`beforeunload` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event). Modern browsers prevent developers from customizing the `alert` message, so we're limited to a generic message like "Do you want to leave this site? Changes you made may not be saved."
 
 ### Declarative controls
 
@@ -146,9 +147,9 @@ If a user tries to navigate away from a page with a form that has unsaved change
 - Browser-native `<select>` dropdown menus
 - Multi-select dropdown menus
 
-To maintain consistent interaction patterns across your app, do not use toggle switches or segmented controls in an explicitly saved form. They should only be used when they automatically change based on user input.
+To maintain consistent interaction patterns across your app, do not use toggle switches or segmented controls in an explicitly saved form. These should only be used with automatic saving.
 
-To build an accessible and consistent app, do not automatically save declarative inputs.
+To ensure your forms are accessible, do not automatically save declarative inputs.
 
 #### Problems with autosaving declarative inputs:
 **Text inputs**
@@ -180,7 +181,7 @@ To build an accessible and consistent app, do not automatically save declarative
 
 Automatic saving applies changes as they are made.
 
-Automatic saving should be used when the user expects instant feedback from the change they made. Changes should only be saved automatically using [imperitive inputs](#imperitive-inputs) and for individual settings that are not changed via separate flows.
+Automatic saving should be used when the user expects instant feedback from the change they made. Changes should only be saved automatically using [imperative inputs](#imperative-inputs).
 
 <Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
     <img
@@ -189,19 +190,19 @@ Automatic saving should be used when the user expects instant feedback from the 
         src="https://user-images.githubusercontent.com/2313998/151448402-69b15752-65d2-4d93-8b5c-e2456e1fb802.png"
     />
     <div>
-        <Box as="p" mt="0">If a field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for a field that has been "saved" or has an error "error" could be mistaken as a validation status.</Box>
+        <Box as="p" mt="0">If a form field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for whether or not a form field has been saved successfully could be mistaken as a validation status.</Box>
     </div>
 </Box>
 
 
-### Imperitive controls
+### Imperative controls
 
-When user input is automatically saved, use the following inputs:
+Imperative inputs are designed to reduce UI by giving instant feedback. When user input is automatically saved, use the following inputs:
 - Toggle switches
 - Segmented controls
 - Single-select dropdowns that are not native `<select>` dropdowns or part of an explicitly saved form
 
-These inputs are designed to reduce UI by giving instant feedback. The toggle switch behaves like a light switch: the light just switches on and off without you having to confirm each time you flip the switch. Segmented controls and single-select dropdowns behave like a soda machine: the soda comes out as soon as you press the buttons without you confirming which soda you wanted.
+The toggle switch behaves like a light switch: the light just switches on and off without you having to confirm each time you flip the switch. Segmented controls and single-select dropdowns behave like a soda machine: the soda comes out as soon as you press the button to select which soda you want.
 
 <Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
     <img
@@ -209,14 +210,14 @@ These inputs are designed to reduce UI by giving instant feedback. The toggle sw
         alt="A switching being turned off, reverting back to on due to an error, then being turned off again"
         src="https://user-images.githubusercontent.com/2313998/151624246-76c19631-9a63-4feb-85ec-1d1abdb8e519.gif"
     />
-    <Box as="p" mt="0">If an imperitive input did not automatically save, show the original value and an error message.</Box>
+    <Box as="p" mt="0">If an imperative input did not automatically save, show the original value and an error message.</Box>
 </Box>
 
 ## Feedback
 
-If the change may not be obvious in the UI within the user's viewport, provide feedback to let the user know that the change occurred successfully. If the change occured without a redirect or page refresh, you could use a toast message. If the change occured and the page refreshes or redirects, you could use a flash banner message.
+If the change is not obvious within the user's viewport, provide feedback to let the user know that the change occurred successfully. If the change occurred without a redirect or page refresh, you can use the toast component. If the change occurred and the page refreshes or redirects, you can use a flash banner component.
 
-**A note on toasts:** If your design is being implemented in github.com, avoid using a toast for now. They have accessibility issues that need to be fixed.
+<Note>If your design is being implemented in github.com, avoid using a toast for now. They have accessibility issues that need to be fixed.</Note>
 
 ## Error forgiveness
 

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -14,7 +14,7 @@ When defining these calls to actions, make sure to:
 1. Keep the text as succinct and clear as possible
 2. Add the item’s name to the button text in cases where it may be unclear to the user what is being changed
 
-![Screenshot of the 'Create a new repository' form](https://user-images.githubusercontent.com/2313998/150868902-a8514e84-5cd4-4081-b13d-46f00f404625.png)
+![Create a new repository form with "Create repository" button submission text](https://user-images.githubusercontent.com/2313998/150868902-a8514e84-5cd4-4081-b13d-46f00f404625.png)
 
 ### Placement
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -29,6 +29,8 @@
       url: /ui-patterns/messaging
     - title: Progressive disclosure
       url: /ui-patterns/progressive-disclosure    
+    - title: Saving
+      url: /ui-patterns/saving
 - title: Components
   url: /components
   children:


### PR DESCRIPTION
## TODO
- [x] Replace current screenshot examples with mocks that are more "zoomed in" and specific to what is being demonstrated
- [x] Try to simplify the button placement guidelines
- [x] Page formatting/layout
- [ ] Try a version that doesn't mention controls that don't exist yet (segmented control, toggle switch)
- [ ] Confirm that all the questions under the "Questions these docs aim to answer" heading are answered
- [ ] Proofread

---

## Use cases I looked at when developing these guidelines
- Settings forms (repo, user)
- Editing an issue from the Memex table
- Creating a PR review
- Changing assignees/labels/milestones/etc on an issue
- Creating a repo
- Creating a gist
- Configuring a GitHub Action

## Questions these docs aim to answer
- When is it ok to save a change without explicitly clicking a CTA? When is that ok and when isn't it ok?
- What do I do with a save CTA button when no data has been changed?
- How do I keep the user informed that the form submission is still in progress?
- How do I prevent changes or multiple submissions while an entry is bing submitted?
- Can I save a form in segments? When is it ok or not ok to do?
- How do I decide what happens after I've saved?
- When do we need to give feedback that something has been saved successfully or that there was an error saving?
    - How should we show that feedback? 
    - How does the way we show that feedback change depending on whether there is a page refresh required? For example: We can't show something fleeting (like a toast) if the page requires a refresh to save
- Where do "Save" buttons get placed?
    - When it's saving an inline edit?
    - When it's for a small form within a dialog?
    - When it's for a full-page form?
- How do we make sure people don't accidentally lose data?
- What considerations do we make for keyboard-only users?
    - Should all forms be submit-able using the "enter" key?
    - Should a multiselect dropdown's values be canceled if I hit the "Esc" key?
- Where should focus go after I save/submit?
    - Keep it on the button unless:
        - The button is no longer there (e.g.: 1. leaving a comment and the form disappears, 2. after submission I get navigated to a new page)
        - The button becomes disabled
        - There is an important message (like an error message) that the user needs to see. Then, focus the message
- How do I handle saving a form inside of a dropdown?
    - A11y team is recommending we don't automatically save/submit forms in a dropdown - the user must explicitly submit the form with a button
    - What are the cases where we don't require the user to explicitly submit the form with a button?

## What is out-of-scope for now
- Autosaving documents
- Previewing the effects of the changes
- Saved drafts

---

## Related
- https://github.com/github/accessibility/issues/415
- [Google Doc with content revisions](https://docs.google.com/document/d/1-l-_3bmJMqNTqUXUear3rhSRnkkgVdtw6cdhkbDJoNw/edit#)
- https://github.com/github/design-systems/pull/309 includes examples ([new link to the .md with user stories](https://github.com/github/design-systems/blob/master/archive/interaction-guidelines/user-stories.md))
- 🔍 [Figma audit file](https://www.figma.com/file/ldm5ZGxRgrQ1KCiDY7qvdh/Saving-models?node-id=1%3A3)