### PR TITLE
remove green from React link

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -15,7 +15,7 @@ import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link
     as="a"
     href="https://primer.style/react/ActionList"
     variant="xl"
-    color="text.success"
+    color="fg.muted"
     outline
     style="text-decoration: none; line-height: 20px;"
   >


### PR DESCRIPTION
![React link in ActionList header with green label text](https://user-images.githubusercontent.com/10384315/154319688-170d5c35-eccd-447e-ba2e-8e7f6120468d.png)

The green label text is a 🐛 . This PR fixes this and defaults back to `fg.muted` for the secondary text.