### PR TITLE
docs: add heading guidance

### DIFF
--- a/content/accessibility/guidelines.mdx
+++ b/content/accessibility/guidelines.mdx
@@ -73,27 +73,6 @@ A great way to test for this is to navigate that experience in greyscale mode.
 </DoDontContainer>
 
 ### Typography
-#### Headings
-Properly labeled headings are one of the most important things a designer can do for developer handoff. [68% of 1207 surveyed screen reader users](https://webaim.org/projects/screenreadersurvey8/) responded that they are first likely to navigate via the headings when trying to find information on a lengthy web page.
-
-**Why?** This makes it easier for visual scanning and screen readers to get a map of the page's content.
-
-Use the semantic structure for headings whenever possible on paragraphs and sections (`h1`-`h6`). 
-
-There should only be one `h1` per web page (Markdown on a page is an exception).
-
-**Note:** Headings don't need to visually match their semantic meaning, but should follow the correct level and order (`h1` through to `h6`), without skipping levels or being removed altogether. 
-
-<DoDontContainer stacked>
-    <Do>
-       <img src="https://user-images.githubusercontent.com/40274682/102531820-d54f2b80-4057-11eb-9361-9b90b001fc67.png" alt="" />
-       <Caption>Follow a clear heading hierarchy</Caption>
-    </Do>
-    <Dont>
-       <img src="https://user-images.githubusercontent.com/40274682/102531812-d1bba480-4057-11eb-8f25-31df20e36039.png" alt="" />
-       <Caption>Don't use multiple `h1`s, skip over heading hierarchy for visual effect, or forget to label sections of information with headings</Caption>
-    </Dont>
-</DoDontContainer>
 
 #### Links
 Assistive technology users will frequently browse a list of links for easy navigation. For this reason, make sure that the link text is meaningful and unique. There should be as few duplicated references as possible to prevent confusion.

--- a/content/accessibility/headings.mdx
+++ b/content/accessibility/headings.mdx
@@ -50,6 +50,6 @@ to verify the heading structure. You may also inspect the DOM structure of your 
 - [W3: Headings](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 - [Medium: Headings for the visually inclined](https://medium.com/@inkblotty/headings-for-the-visually-inclined-c537e87865f)
 
-### Related WCAG guidelines & Success criteria:
+### Related WCAG guidelines and success criteria:
 
 - [1.3.1: Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)

--- a/content/accessibility/headings.mdx
+++ b/content/accessibility/headings.mdx
@@ -1,0 +1,55 @@
+---
+title: Headings
+---
+
+## Overview
+
+Headings play a critical role in communicating the structure of a page. Heading levels range from `<h1>` to `<h6>`. 
+
+### Best practices
+
+- Avoid skipping heading levels. `<h1>` should be followed by `<h2>` and so on.
+- Do not use heading elements solely for resizing text.
+- Avoid setting more than one `<h1>` per page. `<h1>` should be reserved to describe the page as a whole, similar to a page `<title>`.
+
+## Why?
+
+A correct heading structure is critical for enabling users to navigate quickly within a page. Headings are by far the most common navigation technique for screen reader users.
+[67.7% of surveyed screen reader users](https://webaim.org/projects/screenreadersurvey9/#finding) responded that they are first likely to navigate via the headings when trying 
+to find information on a lengthy web page. A proper heading structure also allows sighted users to visually scan and find what they want on a page quickly.
+
+An improper heading structure can cause a confusing navigation experience.
+
+## Guidelines
+
+### For designers
+
+In your designs, annotate the heading level. Properly labeled headings are one of the most important things a designer can do for developer handoff.
+
+### For engineers
+
+As you're developing a page, use tools like [Accessibility Insights](https://accessibilityinsights.io/docs/en/web/overview/) and [HeadingsMap](https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi/related?hl=en)
+to verify the heading structure. You may also inspect the DOM structure of your page using the browser inspector, but using an extension will surface heading levels more easily.
+
+## Examples
+
+<DoDontContainer stacked>
+    <Do>
+       <Caption>Do follow a clear heading hierarchy</Caption>
+       <img src="https://user-images.githubusercontent.com/40274682/102531820-d54f2b80-4057-11eb-9361-9b90b001fc67.png" alt="A GitHub pull requests page with sequential, h1, h2, and h3 headings" />
+    </Do>
+    <Dont>
+       <Caption>Don't use multiple h1s, skip over heading hierarchy for visual effect, or forget to label sections of information with headings</Caption>
+       <img src="https://user-images.githubusercontent.com/40274682/102531812-d1bba480-4057-11eb-8f25-31df20e36039.png" alt="A GitHub pull requests page with two h1 headings, which then skip to h5" />
+    </Dont>
+</DoDontContainer>
+
+## Additional resources
+
+- [WebAIM: Headings](https://webaim.org/techniques/semanticstructure/#headings)
+- [W3: Headings](https://www.w3.org/WAI/tutorials/page-structure/headings/)
+- [Medium: Headings for the visually inclined](https://medium.com/@inkblotty/headings-for-the-visually-inclined-c537e87865f)
+
+### Related WCAG guidelines & Success criteria:
+
+- [1.3.1: Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)

--- a/content/accessibility/headings.mdx
+++ b/content/accessibility/headings.mdx
@@ -10,7 +10,7 @@ Headings play a critical role in communicating the structure of a page. Heading 
 
 - Avoid skipping heading levels. `<h1>` should be followed by `<h2>` and so on.
 - Do not use heading elements solely for resizing text.
-- Avoid setting more than one `<h1>` per page. `<h1>` should be reserved to describe the page as a whole, similar to a page `<title>`.
+- Avoid setting more than one `<h1>` per page. `<h1>` should be reserved to describe the page as a whole, similar to a page `<title>`. (Dialog headings are excepted from this rule.)
 
 ## Why?
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -14,6 +14,8 @@
       url: /accessibility/accessibility-at-github
     - title: Guidelines
       url: /accessibility/guidelines
+    - title: Headings
+      url: /accessibility/headings
     - title: Tools
       url: /accessibility/tools
 - title: UI patterns


### PR DESCRIPTION
Closes https://github.com/github/accessibility/issues/734

This introduces guidance on headings. The content previously in `Accessibility guidelines` has been extracted.
This follows the structure precedence set by https://github.com/primer/design/pull/217.