### PR TITLE
docs: adds semantic HTML accessibility documentation

### DIFF
--- a/content/accessibility/semantic-html.mdx
+++ b/content/accessibility/semantic-html.mdx
@@ -12,7 +12,7 @@ Many groups of people benefit from properly used semantic HTML. Using the correc
 
 ## How to test for semantic HTML
 
-HTML validators, automated tooling, unit tests, and linters are a few ways to test for proper HTML. Most automated tools can catch some incorrect usage of HTML elements. For example, if heading levels are out of order, it will be reported as a violation. Keep in mind that automated tools only catch around 15-20% of accessibility errors.
+HTML validators, automated tooling, unit tests, and linters are a few ways to test for proper HTML. Most automated tools can catch some incorrect usage of HTML elements. For example, if heading levels are out of order, it will be reported as a violation. Keep in mind that [automated tools only catch around 20-25% of accessibility errors](https://www.essentialaccessibility.com/blog/automated-accessibility-testing-tools-how-much-do-scans-catch#:~:text=For%20WCAG%202.1%20AA%20tests,by%20yes%20or%20no%20conditions.).
 
 This is a subset of the tools available:
 

--- a/content/accessibility/semantic-html.mdx
+++ b/content/accessibility/semantic-html.mdx
@@ -1,0 +1,71 @@
+---
+title: Semantic HTML
+---
+
+## Overview
+
+Semantic HTML provides meaning to the content of a web page. It involves using the correct HTML element for the job. Semantic HTML breaks the page up into meaningful sections.
+
+## Why?
+
+Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.
+
+## How to test for semantic HTML
+
+HTML validators, automated tooling, unit tests, and linters are a few ways to test for proper HTML. Most automated tools can catch some incorrect usage of HTML elements. For example, if heading levels are out of order, it will be reported as a violation. Keep in mind that automated tools only catch around 15-20% of accessibility errors.
+
+This is a subset of the tools available:
+
+- [HTML validator](https://validator.w3.org/)
+- Automated tools
+    - [aXe DevTools](https://www.deque.com/axe/devtools/)
+    - [Lighthouse](https://github.com/GoogleChrome/lighthouse)
+- Linting
+    - [Primer ViewComponents](https://github.com/primer/view_components/blob/main/docs/content/linting.md)
+    - [Primer React](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#linting)
+    - [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
+
+## Guidelines
+
+### For designers
+
+In your designs, annotate what HTML elements should be used for various parts of the design, if appropriate. Understand that most designs are achievable with CSS alone, agnostic of the HTML elements used. If a component has state, annotate the ARIA attributes needed for each state. For example, for an accordion, indicate that the header should have `aria-expanded="true"` when the panel is expanded, and `aria-expanded="false"` when collapsed.
+
+### For engineers
+
+Think about the content that will populate an element in order to determine what HTML element should be used. Are you building a navigation? Use the `<nav>` element instead of nested `<div>` elements. You may need to add interactivity to more complex elements, such as `<dialog>`. Some elements may require additional ARIA attributes to convey things such as state, but be careful to [use these only when necessary](https://www.w3.org/TR/using-aria/#notes2).
+
+## Common mistakes
+
+- Using improper elements to achieve the desired visual style
+    - Example: using an `<h1>` tag for a heading that should be an `<h3>` because the visual style of the `<h1>` is desired
+    - Solve: use CSS for visual styling
+- Using the `title` attribute
+    - It is inaccessible for many users, such as touch-only and keyboard-only users. Do not use.
+- Using improper markup
+    - Example: placing text in a `<div>` instead of a `<p>`
+    - Solve: use the proper element to depict the content that is inside
+- Using incorrect ARIA
+    - Example: using an `aria-label` on a non-interactive element such as a `<div>`
+    - Solve: only use ARIA when necessary, and if you *can* use a native HTML element, you should. [More information on ARIA](https://www.w3.org/TR/using-aria/#notes2)
+- Duplicate IDs
+    - Example: two elements on the page with `id="anchor"`
+    - Solve: use unique IDs for every element on the page
+- Decorative elements not marked as decorative
+    - Example: an `<hr>` element not being marked as decorative
+    - Solve: add `role="presentation"` or `aria-hidden="true"` to elements that are for decorative purposes only
+
+## Reading order
+
+Screen readers and other assistive technologies convey the information to the user in the order that it is marked up in the code, not necessarily how it looks on the page. Ensure the order matches a logical order of information presented. One way to verify this is to view the page without styles and see if the order of content is logical.
+
+## Additional resources
+
+- [Semantic HTML and ARIA Deep Dive](https://github.com/github/accessibility/blob/main/docs/deep-dive-notes/2022-02-16-semantic-html-and-aria.md)
+- [List of semantic elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
+
+### Related WCAG guidelines & success criteria
+
+- [1.3.2 Meaningful Sequence](https://www.w3.org/TR/WCAG21/#meaningful-sequence)
+- [2.4.10 Section Headings](https://www.w3.org/TR/WCAG21/#section-headings)
+- [4.1.2 Name, Role, Value](https://www.w3.org/TR/WCAG21/#name-role-value)

--- a/content/accessibility/semantic-html.mdx
+++ b/content/accessibility/semantic-html.mdx
@@ -29,7 +29,7 @@ This is a subset of the tools available:
 
 ### For designers
 
-In your designs, annotate what HTML elements should be used for various parts of the design, if appropriate. Understand that most designs are achievable with CSS alone, agnostic of the HTML elements used. If a component has state, annotate the ARIA attributes needed for each state. For example, for an accordion, indicate that the header should have `aria-expanded="true"` when the panel is expanded, and `aria-expanded="false"` when collapsed.
+In your designs, annotate what HTML elements should be used for various parts of the design, if appropriate. Understand that most designs are achievable with CSS alone, agnostic of the HTML elements used.
 
 ### For engineers
 

--- a/content/accessibility/semantic-html.mdx
+++ b/content/accessibility/semantic-html.mdx
@@ -64,7 +64,7 @@ Screen readers and other assistive technologies convey the information to the us
 - [Semantic HTML and ARIA Deep Dive](https://github.com/github/accessibility/blob/main/docs/deep-dive-notes/2022-02-16-semantic-html-and-aria.md)
 - [List of semantic elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
 
-### Related WCAG guidelines & success criteria
+### Related WCAG guidelines and success criteria
 
 - [1.3.2 Meaningful Sequence](https://www.w3.org/TR/WCAG21/#meaningful-sequence)
 - [2.4.10 Section Headings](https://www.w3.org/TR/WCAG21/#section-headings)

--- a/content/ui-patterns/semantic-html.mdx
+++ b/content/ui-patterns/semantic-html.mdx
@@ -1,0 +1,3 @@
+---
+title: Semantic HTML
+---

--- a/content/ui-patterns/semantic-html.mdx
+++ b/content/ui-patterns/semantic-html.mdx
@@ -1,3 +1,0 @@
----
-title: Semantic HTML
----

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -14,10 +14,10 @@
       url: /accessibility/accessibility-at-github
     - title: Guidelines
       url: /accessibility/guidelines
-    - title: Tools
-      url: /accessibility/tools
     - title: Semantic HTML
       url: /accessibility/semantic-html
+    - title: Tools
+      url: /accessibility/tools
 - title: UI patterns
   url: /ui-patterns
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -28,7 +28,9 @@
     - title: Messaging
       url: /ui-patterns/messaging
     - title: Progressive disclosure
-      url: /ui-patterns/progressive-disclosure    
+      url: /ui-patterns/progressive-disclosure
+    - title: Semantic HTML
+      url: /ui-patterns/semantic-html
 - title: Components
   url: /components
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -16,6 +16,8 @@
       url: /accessibility/guidelines
     - title: Tools
       url: /accessibility/tools
+    - title: Semantic HTML
+      url: /accessibility/semantic-html
 - title: UI patterns
   url: /ui-patterns
   children:
@@ -29,8 +31,6 @@
       url: /ui-patterns/messaging
     - title: Progressive disclosure
       url: /ui-patterns/progressive-disclosure
-    - title: Semantic HTML
-      url: /ui-patterns/semantic-html
 - title: Components
   url: /components
   children:


### PR DESCRIPTION
Closes https://github.com/github/accessibility/issues/750.

Adds documentation about using semantic HTML, why it's important, how to test, etc.

Please check for correctness, grammar, and if you feel anything is missing. Thanks!