### PR TITLE
Create accessibility menu page

### DIFF
--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -1,0 +1,38 @@
+---
+title: Accessibility
+---
+
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+
+
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
+    
+    <div>
+        <Link href="/design/content/accessibility/accessibility-at-github.mdx" fontWeight="bold">Accessibility at GitHub</Link>
+        <Box as="p">GitHub's aim is to be the home for all developers. To be inclusive means we must consider accessibility at the core of how we design. GitHub aims for Web Content Accessibility Guidelines (WCAG) 2.1 AA compliance. This includes all of WCAG 2.0 AA plus additional considerations.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/guidelines.mdx" fontWeight="bold">Guidelines</Link>
+        <Box as="p">Basic guidelines for designers to follow when designing new or updating features.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/tools.mdx" fontWeight="bold">Tools</Link>
+        <Box as="p">A selection of tools to help product designers create accessible designs.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/focus-management.mdx" fontWeight="bold">Focus management</Link>
+        <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/headings.mdx" fontWeight="bold">Headings</Link>
+        <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/semantic-html.mdx" fontWeight="bold">Semantic HTML</Link>
+        <Box as="p">Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/links.mdx" fontWeight="bold">Links</Link>
+        <Box as="p">Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. </Box>
+    </div>
+</Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -28,7 +28,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/semantic-html.mdx" fontWeight="bold">Semantic HTML</Link>
+        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
         <Box as="p">Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.</Box>
     </div>
     <div>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -20,21 +20,35 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
-        <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
+        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
+        <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
     </div>
-    <div>
+     <div>
         <Link href="/design/content/accessibility/headings" fontWeight="bold">Headings</Link>
         <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
-        <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
+        <Link href="/design/content/accessibility/alternative-text-for-images" fontWeight="bold">Alternative text for images</Link>
+        <Box as="p">Insert summary text</Box>
     </div>
-<!--    
+    <div>
+        <Link href="/design/content/accessibility/text-resize-and-respacing" fontWeight="bold">Text resize and respacing</Link>
+        <Box as="p">Insert summary text</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/announcements" fontWeight="bold">Assistive technology announcements</Link>
+        <Box as="p">Insert summary text</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
+        <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/button-purpose" fontWeight="bold">Describing a button’s purpose</Link>
+        <Box as="p">Insert summary text</Box>
+    </div>
     <div>
         <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
         <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
     </div>
--->
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -6,7 +6,8 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
-    
+    <h2>General</h2>
+
     <div>
         <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
         <Box as="p">Get started with accessibility at GitHub.</Box>
@@ -19,6 +20,8 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
         <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
+
+    <h2>Specific</h2>
     <div>
         <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
         <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -16,7 +16,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/tools.mdx" fontWeight="bold">Tools</Link>
+        <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
         <Box as="p">A selection of tools to help product designers create accessible designs.</Box>
     </div>
     <div>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -6,8 +6,6 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
-    <h2>General</h2>
-
     <div>
         <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
         <Box as="p">Get started with accessibility at GitHub.</Box>
@@ -20,8 +18,6 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
         <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
-
-    <h2>Specific</h2>
     <div>
         <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
         <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -20,7 +20,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/focus-management.mdx" fontWeight="bold">Focus management</Link>
+        <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
         <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
     </div>
     <div>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -29,7 +29,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
-        <Box as="p">Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.</Box>
+        <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -4,8 +4,11 @@ title: Accessibility
 
 import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 
+<Grid gridTemplateColumns="1fr" gridGap={4}>
 
-<Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
+
+<Grid gridTemplateColumns="1fr" gridGap={4}>
+    <h2>General</h2>
     <div>
         <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
         <Box as="p">Get started with accessibility at GitHub.</Box>
@@ -18,6 +21,11 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
         <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
+</Grid>
+
+
+<Grid gridTemplateColumns="1fr" gridGap={4}>
+    <h2>Specific</h2>
     <div>
         <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
         <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
@@ -50,4 +58,5 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
         <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
     </div>
+</Grid>
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -13,7 +13,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/design/content/accessibility/guidelines.mdx" fontWeight="bold">Guidelines</Link>
-        <Box as="p">Basic guidelines for designers to follow when designing new or updating features.</Box>
+        <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/tools.mdx" fontWeight="bold">Tools</Link>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -32,7 +32,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/links.mdx" fontWeight="bold">Links</Link>
+        <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
         <Box as="p">Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. </Box>
     </div>
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -17,7 +17,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
-        <Box as="p">A selection of tools to help product designers create accessible designs.</Box>
+        <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/focus-management.mdx" fontWeight="bold">Focus management</Link>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -31,8 +31,10 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
         <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
     </div>
+<!--    
     <div>
         <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
         <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
     </div>
+-->
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -33,6 +33,6 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
-        <Box as="p">Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. </Box>
+        <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
     </div>
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -27,36 +27,40 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns="1fr" gridGap={4}>
     <h2>Specific</h2>
     <div>
-        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
-        <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
-    </div>
-     <div>
-        <Link href="/design/content/accessibility/headings" fontWeight="bold">Headings</Link>
-        <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
-    </div>
-    <div>
         <Link href="/design/content/accessibility/alternative-text-for-images" fontWeight="bold">Alternative text for images</Link>
-        <Box as="p">Insert summary text</Box>
-    </div>
-    <div>
-        <Link href="/design/content/accessibility/text-resize-and-respacing" fontWeight="bold">Text resize and respacing</Link>
-        <Box as="p">Insert summary text</Box>
+        <Box as="p">Alternative text on images is what allows assitstive techonology like screen readers to understand the purpose of an image on a page or allow them to skip it because it's purely decorative. </Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/announcements" fontWeight="bold">Assistive technology announcements</Link>
-        <Box as="p">Insert summary text</Box>
+        <Box as="p">Things like toasts and status messages are visually communicated to GitHub users and making sure those announcements are read via assitstive technology allow users with low or no vision to get that status information.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/button-purpose" fontWeight="bold">Describing a button’s purpose</Link>
+        <Box as="p">Labeling buttons properly let's users know what will happen when they activate the control, lessens errors, and levels up confidence.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
         <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/button-purpose" fontWeight="bold">Describing a button’s purpose</Link>
-        <Box as="p">Insert summary text</Box>
+        <Link href="/design/content/accessibility/headings" fontWeight="bold">Headings</Link>
+        <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
         <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
+        <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/text-resize-and-respacing" fontWeight="bold">Text resize and respacing</Link>
+        <Box as="p">People on the web should be able to resize text to improve legibility without blocking or obsurcing any other part of the UI.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/tooltip-alternatives" fontWeight="bold">Tooltip alternatives</Link>
+        <Box as="p">Most UI cases don't call for tooltips. Learn some alternative methods to use in place of tooltips.</Box>
     </div>
 </Grid>
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -8,7 +8,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
     
     <div>
-        <Link href="/design/content/accessibility/accessibility-at-github.mdx" fontWeight="bold">Accessibility at GitHub</Link>
+        <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
         <Box as="p">GitHub's aim is to be the home for all developers. To be inclusive means we must consider accessibility at the core of how we design. GitHub aims for Web Content Accessibility Guidelines (WCAG) 2.1 AA compliance. This includes all of WCAG 2.0 AA plus additional considerations.</Box>
     </div>
     <div>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -12,7 +12,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">GitHub's aim is to be the home for all developers. To be inclusive means we must consider accessibility at the core of how we design. GitHub aims for Web Content Accessibility Guidelines (WCAG) 2.1 AA compliance. This includes all of WCAG 2.0 AA plus additional considerations.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/guidelines.mdx" fontWeight="bold">Guidelines</Link>
+        <Link href="/design/content/accessibility/guidelines" fontWeight="bold">Guidelines</Link>
         <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
     </div>
     <div>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -28,15 +28,15 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     <h2>Specific</h2>
     <div>
         <Link href="/design/content/accessibility/alternative-text-for-images" fontWeight="bold">Alternative text for images</Link>
-        <Box as="p">Alternative text on images is what allows assitstive techonology like screen readers to understand the purpose of an image on a page or allow them to skip it because it's purely decorative. </Box>
+        <Box as="p">Alternative text on images allows assistive technology like screen readers to understand the purpose of an image on a page or allow them to skip it if purely decorative. </Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/announcements" fontWeight="bold">Assistive technology announcements</Link>
-        <Box as="p">Things like toasts and status messages are visually communicated to GitHub users and making sure those announcements are read via assitstive technology allow users with low or no vision to get that status information.</Box>
+        <Box as="p">Events like toasts and status messages are visually communicated to GitHub users. Making sure those announcements are read via assistive technology allows users with low or no vision to get that status information.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/button-purpose" fontWeight="bold">Describing a button’s purpose</Link>
-        <Box as="p">Labeling buttons properly let's users know what will happen when they activate the control, lessens errors, and levels up confidence.</Box>
+        <Box as="p">Labeling buttons properly let's users know what will happen when they activate the control, lessens errors, and increases confidence.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
@@ -56,7 +56,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     </div>
     <div>
         <Link href="/design/content/accessibility/text-resize-and-respacing" fontWeight="bold">Text resize and respacing</Link>
-        <Box as="p">People on the web should be able to resize text to improve legibility without blocking or obsurcing any other part of the UI.</Box>
+        <Box as="p">People on the web should be able to resize text to improve legibility without blocking or obscuring any other part of the UI.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/tooltip-alternatives" fontWeight="bold">Tooltip alternatives</Link>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -9,7 +9,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     
     <div>
         <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
-        <Box as="p">Get started with accessibility at GitHub</Box>
+        <Box as="p">Get started with accessibility at GitHub.</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/guidelines" fontWeight="bold">Guidelines</Link>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -24,7 +24,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
         <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/headings.mdx" fontWeight="bold">Headings</Link>
+        <Link href="/design/content/accessibility/headings" fontWeight="bold">Headings</Link>
         <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
     </div>
     <div>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -10,15 +10,15 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns="1fr" gridGap={4}>
     <h2>General</h2>
     <div>
-        <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
+        <Link href="/design/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
         <Box as="p">Get started with accessibility at GitHub.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/guidelines" fontWeight="bold">Guidelines</Link>
+        <Link href="/design/accessibility/guidelines" fontWeight="bold">Guidelines</Link>
         <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
+        <Link href="/design/accessibility/tools" fontWeight="bold">Tools</Link>
         <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
 </Grid>
@@ -27,39 +27,39 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns="1fr" gridGap={4}>
     <h2>Specific</h2>
     <div>
-        <Link href="/design/content/accessibility/alternative-text-for-images" fontWeight="bold">Alternative text for images</Link>
+        <Link href="/design/accessibility/alternative-text-for-images" fontWeight="bold">Alternative text for images</Link>
         <Box as="p">Alternative text on images allows assistive technology like screen readers to understand the purpose of an image on a page or allow them to skip it if purely decorative. </Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/announcements" fontWeight="bold">Assistive technology announcements</Link>
+        <Link href="/design/accessibility/announcements" fontWeight="bold">Assistive technology announcements</Link>
         <Box as="p">Events like toasts and status messages are visually communicated to GitHub users. Making sure those announcements are read via assistive technology allows users with low or no vision to get that status information.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/button-purpose" fontWeight="bold">Describing a button’s purpose</Link>
+        <Link href="/design/accessibility/button-purpose" fontWeight="bold">Describing a button’s purpose</Link>
         <Box as="p">Labeling buttons properly let's users know what will happen when they activate the control, lessens errors, and increases confidence.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
+        <Link href="/design/accessibility/focus-management" fontWeight="bold">Focus management</Link>
         <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/headings" fontWeight="bold">Headings</Link>
+        <Link href="/design/accessibility/headings" fontWeight="bold">Headings</Link>
         <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
+        <Link href="/design/accessibility/links" fontWeight="bold">Links</Link>
         <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
+        <Link href="/design/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
         <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/text-resize-and-respacing" fontWeight="bold">Text resize and respacing</Link>
+        <Link href="/design/accessibility/text-resize-and-respacing" fontWeight="bold">Text resize and respacing</Link>
         <Box as="p">People on the web should be able to resize text to improve legibility without blocking or obscuring any other part of the UI.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/tooltip-alternatives" fontWeight="bold">Tooltip alternatives</Link>
+        <Link href="/design/accessibility/tooltip-alternatives" fontWeight="bold">Tooltip alternatives</Link>
         <Box as="p">Most UI cases don't call for tooltips. Learn some alternative methods to use in place of tooltips.</Box>
     </div>
 </Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -9,7 +9,7 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
     
     <div>
         <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
-        <Box as="p">GitHub's aim is to be the home for all developers. To be inclusive means we must consider accessibility at the core of how we design. GitHub aims for Web Content Accessibility Guidelines (WCAG) 2.1 AA compliance. This includes all of WCAG 2.0 AA plus additional considerations.</Box>
+        <Box as="p">Get started with accessibility at GitHub</Box>
     </div>
     <div>
         <Link href="/design/content/accessibility/guidelines" fontWeight="bold">Guidelines</Link>

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -11,7 +11,7 @@ Primer's interface guidelines are a collection of principles, standards, and usa
 
 The fundamental parts of the design system, such as color and typography, that underpin all GitHub interfaces.
 
-## [Accessibility](https://primer.style/design/accessibility/accessibility-at-github)
+## [Accessibility](https://primer.style/design/accessibility)
 
 Standards, guidelines, and tools to design accessible GitHub interfaces.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "primer-design",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "yarn": {
+      "version": "1.22.18",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
+      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "gatsby": "^2.32.13",
     "gatsby-plugin-alias-imports": "^1.0.5",
     "react": "16.9.x",
-    "react-dom": "16.9.x"
+    "react-dom": "16.9.x",
+    "yarn": "^1.22.18"
   },
   "private": true
 }

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -8,7 +8,7 @@
     - title: Content
       url: /foundations/content
 - title: Accessibility
-  url: /accessibility/accessibility-at-github
+  url: /accessibility
   children:
     - title: Accessibility at GitHub
       url: /accessibility/accessibility-at-github

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -16,26 +16,24 @@
       url: /accessibility/guidelines
     - title: Tools
       url: /accessibility/tools
-    - title: Tooltip alternatives
-      url: /accessibility/tooltip-alternatives
-    - title: Semantic HTML
-      url: /accessibility/semantic-html
-    - title: Headings
-      url: /accessibility/headings
     - title: Alternative text for images
       url: /accessibility/alternative-text-for-images
-    - title: Text resize and respacing
-      url: /accessibility/text-resize-and-respacing
     - title: Assistive technology announcements
       url: /accessibility/announcements
-    - title: Focus management
-      url: /accessibility/focus-management
     - title: Describing a button’s purpose
       url: /accessibility/button-purpose
+    - title: Focus management
+      url: /accessibility/focus-management
+    - title: Headings
+      url: /accessibility/headings 
     - title: Links
       url: /accessibility/links
-    - title: Tools
-      url: /accessibility/tools
+    - title: Semantic HTML
+      url: /accessibility/semantic-html
+    - title: Text resize and respacing
+      url: /accessibility/text-resize-and-respacing
+    - title: Tooltip alternatives
+      url: /accessibility/tooltip-alternatives
 - title: UI patterns
   url: /ui-patterns
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -12,16 +12,16 @@
   children:
     - title: Accessibility at GitHub
       url: /accessibility/accessibility-at-github
-    - title: Focus management
-      url: /accessibility/focus-management
     - title: Guidelines
       url: /accessibility/guidelines
+    - title: Tools
+      url: /accessibility/tools
+    - title: Focus management
+      url: /accessibility/focus-management
     - title: Headings
       url: /accessibility/headings
     - title: Semantic HTML
       url: /accessibility/semantic-html
-    - title: Tools
-      url: /accessibility/tools
 - title: UI patterns
   url: /ui-patterns
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -16,20 +16,20 @@
       url: /accessibility/guidelines
     - title: Tools
       url: /accessibility/tools
-    - title: Focus management
-      url: /accessibility/focus-management
-    - title: Headings
-      url: /accessibility/headings
     - title: Semantic HTML
       url: /accessibility/semantic-html
-    - title: Text resize and respacing
-      url: /accessibility/text-resize-and-respacing
+    - title: Headings
+      url: /accessibility/headings
     - title: Alternative text for images
       url: /accessibility/alternative-text-for-images
+    - title: Text resize and respacing
+      url: /accessibility/text-resize-and-respacing
+    - title: Assistive technology announcements
+      url: /accessibility/announcements
+    - title: Focus management
+      url: /accessibility/focus-management
     - title: Describing a button’s purpose
       url: /accessibility/button-purpose
-    - title: Tools
-      url: /accessibility/tools
 - title: UI patterns
   url: /ui-patterns
   children:

--- a/yarn.lock
+++ b/yarn.lock
@@ -16027,6 +16027,11 @@ yargs@^16.1.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yarn@^1.22.18:
+  version "1.22.18"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.18.tgz#05b822ade8c672987bab8858635145da0850f78a"
+  integrity sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==
+
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"


### PR DESCRIPTION
Selecting "Accessibility" on the side of the Interface guidelines page is the only section heading that doesn't have a menu. This PR adds in a menu and descriptions as well as rearranges the accessibility side nav links by type (generic or specific) and then by alphabetical order. 

![""](https://user-images.githubusercontent.com/40274682/160946611-2e7321b0-7f0a-4b29-92a0-b31c6d3f5934.png)

This PR adds a menu page for the Accessibility sections.
