### PR TITLE
Add `fg.subtle`

### DIFF
--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -63,6 +63,7 @@ Foreground elements are **text and icons**. You can apply color to them using an
 | :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.default) `fg.default`         | Primary color for text and icons in any given interface. It should be used for body content, titles and labels.                      |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.muted) `fg.muted`           | Use for content that is secondary or that provides additional context but is not critical to understanding the flow of an interface. |
+| ![](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`           | Use for placeholder text, icons or decorative elements. |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.onEmphasis) `fg.onEmphasis` | On emphasis is the text color designed to combine with `-emphasis` backgrounds for optimal contrast.                                 |
 
 | Color roles                                                                     | Usage                                                               |

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -63,7 +63,7 @@ Foreground elements are **text and icons**. You can apply color to them using an
 | :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.default) `fg.default`         | Primary color for text and icons in any given interface. It should be used for body content, titles and labels.                      |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.muted) `fg.muted`           | Use for content that is secondary or that provides additional context but is not critical to understanding the flow of an interface. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`           | Use for placeholder text, icons or decorative elements. |
+| ![](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`           | Use for placeholder text, icons or decorative foregrounds. |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.onEmphasis) `fg.onEmphasis` | On emphasis is the text color designed to combine with `-emphasis` backgrounds for optimal contrast.                                 |
 
 | Color roles                                                                     | Usage                                                               |


### PR DESCRIPTION
This is part of https://github.com/github/primer/issues/766 and adds `fg.subtle`:

![Screen Shot 2022-03-11 at 17 42 48](https://user-images.githubusercontent.com/378023/157832872-fe4061db-4ab0-44d2-80d3-caf6648654d2.png)

`fg.subtle` exists in Primitives and all other Primer libraries but is not documented here in the interface guidelines.

We also considered to remove `fg.subtle` everywhere but [decided against it](https://github.com/github/primer/issues/766#issuecomment-1063815089) because `fg.subtle` still seems useful for placeholder text, icons, dividers etc.

`fg.subtle` | `fg.muted`
--- | ---
![Screen Shot 2022-03-10 at 17 32 21](https://user-images.githubusercontent.com/378023/157625618-3ea6c906-4e4e-43d5-b1d5-42d0c147b22d.png) | ![Screen Shot 2022-03-10 at 17 32 30](https://user-images.githubusercontent.com/378023/157625629-7df35c08-a88e-44c3-b08c-f6c94bfa5a7a.png)
![Screen Shot 2022-03-10 at 17 46 48](https://user-images.githubusercontent.com/378023/157625632-31a9b215-d18d-4472-994f-8a6027537252.png) | ![Screen Shot 2022-03-10 at 17 50 13](https://user-images.githubusercontent.com/378023/157625637-3c31dbea-434e-40b0-8f4e-3fd3b6db4d40.png)
<img width="138" alt="Screen Shot 2022-03-10 at 22 33 08" src="https://user-images.githubusercontent.com/378023/157672535-ab150178-5213-4303-bdae-df92d88288f7.png"> | <img width="127" alt="Screen Shot 2022-03-10 at 22 34 04" src="https://user-images.githubusercontent.com/378023/157672545-3f5939b8-ab8b-4090-9339-2734a6ea22bd.png">
![Screen Shot 2022-03-11 at 16 27 21](https://user-images.githubusercontent.com/378023/157821999-1d5e6e38-dedd-4e05-931e-31df0fec55e4.png) | ![Screen Shot 2022-03-11 at 16 27 41](https://user-images.githubusercontent.com/378023/157822000-9b09290c-6eb4-4bb5-9116-cedf2a86c954.png)

Maybe in the next major release we could consider removing `fg.subtle` from the system and replacing existing use cases with a private `primer.fg.placeholder` or similar.