### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/content/accessibility/ @primer/accessibility-reviewers


### PR DESCRIPTION
This PR adds @primer/accessibility-reviewers as an owner of https://github.com/primer/design/tree/main/content/accessibility, so that the team can review additions/updates to the accessibility-related docs there.