### PR TITLE
Accessible links documentation

### DIFF
--- a/content/accessibility/headings.mdx
+++ b/content/accessibility/headings.mdx
@@ -36,11 +36,11 @@ to verify the heading structure. You may also inspect the DOM structure of your 
 <DoDontContainer stacked>
     <Do>
        <Caption>Do follow a clear heading hierarchy</Caption>
-       <img src="https://user-images.githubusercontent.com/40274682/157987430-cc1d6c6b-b63b-4e2a-9ccc-b9dc3ddcb746.png" alt="A GitHub discussions page with sequential, h1, h2, h3, and h4 headings" />
+       <img src="https://user-images.githubusercontent.com/40274682/157987874-e415dcc6-887f-4d8d-ab8a-bcdfbdad5e77.png" alt="A GitHub discussions page with sequential, h1, h2, h3, and h4 headings" />
     </Do>
     <Dont>
        <Caption>Don't use multiple h1s, skip over heading hierarchy for visual effect, or forget to label sections of information with headings</Caption>
-       <img src="https://user-images.githubusercontent.com/40274682/157987439-c45e75f8-019a-4a68-b0cd-b12072e4a8d2.png" alt="A GitHub discussion page with two h1 headings, which display an h3 before h2 headings" />
+       <img src="https://user-images.githubusercontent.com/40274682/157987882-edb92d5a-1fd3-4ef6-b5bb-bd08851eacd8.png" alt="A GitHub discussion page with two h1 headings, which display an h3 before h2 headings" />
     </Dont>
 </DoDontContainer>
 

--- a/content/accessibility/headings.mdx
+++ b/content/accessibility/headings.mdx
@@ -36,11 +36,11 @@ to verify the heading structure. You may also inspect the DOM structure of your 
 <DoDontContainer stacked>
     <Do>
        <Caption>Do follow a clear heading hierarchy</Caption>
-       <img src="https://user-images.githubusercontent.com/40274682/102531820-d54f2b80-4057-11eb-9361-9b90b001fc67.png" alt="A GitHub pull requests page with sequential, h1, h2, and h3 headings" />
+       <img src="https://user-images.githubusercontent.com/40274682/157987430-cc1d6c6b-b63b-4e2a-9ccc-b9dc3ddcb746.png" alt="A GitHub discussions page with sequential, h1, h2, h3, and h4 headings" />
     </Do>
     <Dont>
        <Caption>Don't use multiple h1s, skip over heading hierarchy for visual effect, or forget to label sections of information with headings</Caption>
-       <img src="https://user-images.githubusercontent.com/40274682/102531812-d1bba480-4057-11eb-8f25-31df20e36039.png" alt="A GitHub pull requests page with two h1 headings, which then skip to h5" />
+       <img src="https://user-images.githubusercontent.com/40274682/157987439-c45e75f8-019a-4a68-b0cd-b12072e4a8d2.png" alt="A GitHub discussion page with two h1 headings, which display an h3 before h2 headings" />
     </Dont>
 </DoDontContainer>
 

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -1,0 +1,38 @@
+---
+title: Accessibility
+---
+
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+
+
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
+    
+    <div>
+        <Link href="/design/content/accessibility/accessibility-at-github.mdx" fontWeight="bold">Accessibility at GitHub</Link>
+        <Box as="p">GitHub's aim is to be the home for all developers. To be inclusive means we must consider accessibility at the core of how we design. GitHub aims for Web Content Accessibility Guidelines (WCAG) 2.1 AA compliance. This includes all of WCAG 2.0 AA plus additional considerations.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/guidelines.mdx" fontWeight="bold">Guidelines</Link>
+        <Box as="p">Basic guidelines for designers to follow when designing new or updating features.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/tools.mdx" fontWeight="bold">Tools</Link>
+        <Box as="p">A selection of tools to help product designers create accessible designs.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/focus-management.mdx" fontWeight="bold">Focus management</Link>
+        <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/headings.mdx" fontWeight="bold">Headings</Link>
+        <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/semantic-html.mdx" fontWeight="bold">Semantic HTML</Link>
+        <Box as="p">Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.</Box>
+    </div>
+    <div>
+        <Link href="/design/content/accessibility/links.mdx" fontWeight="bold">Links</Link>
+        <Box as="p">Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. </Box>
+    </div>
+</Grid>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -8,31 +8,31 @@ import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr']} gridGap={4}>
     
     <div>
-        <Link href="/design/content/accessibility/accessibility-at-github.mdx" fontWeight="bold">Accessibility at GitHub</Link>
-        <Box as="p">GitHub's aim is to be the home for all developers. To be inclusive means we must consider accessibility at the core of how we design. GitHub aims for Web Content Accessibility Guidelines (WCAG) 2.1 AA compliance. This includes all of WCAG 2.0 AA plus additional considerations.</Box>
+        <Link href="/design/content/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
+        <Box as="p">Get started with accessibility at GitHub.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/guidelines.mdx" fontWeight="bold">Guidelines</Link>
-        <Box as="p">Basic guidelines for designers to follow when designing new or updating features.</Box>
+        <Link href="/design/content/accessibility/guidelines" fontWeight="bold">Guidelines</Link>
+        <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/tools.mdx" fontWeight="bold">Tools</Link>
-        <Box as="p">A selection of tools to help product designers create accessible designs.</Box>
+        <Link href="/design/content/accessibility/tools" fontWeight="bold">Tools</Link>
+        <Box as="p">A selection of tools to help designers create accessible designs.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/focus-management.mdx" fontWeight="bold">Focus management</Link>
+        <Link href="/design/content/accessibility/focus-management" fontWeight="bold">Focus management</Link>
         <Box as="p">Managing focus within a page or application is essential for users to successfully navigate, complete actions, and understand where they are.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/headings.mdx" fontWeight="bold">Headings</Link>
+        <Link href="/design/content/accessibility/headings" fontWeight="bold">Headings</Link>
         <Box as="p">Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to create an accessible hierarchy in your pages.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/semantic-html.mdx" fontWeight="bold">Semantic HTML</Link>
-        <Box as="p">Many groups of people benefit from properly used semantic HTML. Using the correct elements allows assistive technology to accurately convey the purpose of the content to the user. Without it, they will not be able to navigate easily. Other benefits of using semantic HTML are SEO and code readability.</Box>
+        <Link href="/design/content/accessibility/semantic-html" fontWeight="bold">Semantic HTML</Link>
+        <Box as="p">Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.</Box>
     </div>
     <div>
-        <Link href="/design/content/accessibility/links.mdx" fontWeight="bold">Links</Link>
-        <Box as="p">Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. </Box>
+        <Link href="/design/content/accessibility/links" fontWeight="bold">Links</Link>
+        <Box as="p">Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.</Box>
     </div>
 </Grid>

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -28,7 +28,7 @@ People who have low or colorblind vision may have trouble identifying links that
 - Make sure you're using the proper accent color for links in your mocks. Double check the color you're using if you're using it on anything other than a white background. For more context on color, check out our [Color | Interface guidelines (primer.style)](https://primer.style/design/foundations/color).
 - Make sure a link's purpose can be understood on its own without the surrounding context in concise words. 
 - Links should always be underlined if they're in body text. 
-- Links should look like links, not buttons.
+- Links should look like links, not buttons. In rare circumstances, links look like buttons (like calls to action). It's important to make sure that if the action takes you somewhere rather than does something on the page, it's semantically coded as a link regardless of the visual style.
 
 <DoDontContainer stacked>
     <Do>

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -47,6 +47,7 @@ People who have low or colorblind vision may have trouble identifying links that
 	- [Link | Primer React](https://primer.style/react/Link)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard.
+- Avoid adding side effects to link click events. Links should navigate, not affect the page.
 
 ## Common mistakes
 - Link underlines only on focus or hover

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -3,9 +3,7 @@ title: Links
 ---
 
 ## Overview
-Links are user interface elements that *navigate* you to a new place or new content. Contrast this with buttons, which are designed to *activate* a feature. Think of it this way: 
-- Links are transportation vehicles
-- Buttons are the ticket terminals 
+Links are user interface elements that *navigate* you to a new place or new content. Contrast this with buttons, which are designed to *activate* a feature.
 
 ## Why?
 Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through sites like Wikipedia. Links play a key part in your experience on the web, but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -41,18 +41,18 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ### For engineers
 - Use the Primer link components:
-	- [Link | Primer ViewComponents](https://primer.style/view-components/components/link)
-	- [Link | Primer React](https://primer.style/react/Link)
+	- [Primer ViewComponents | Link](https://primer.style/view-components/components/link)
+	- [Primer React | Link](https://primer.style/react/Link)
 - Don't override the link styling provided in the components
-- Make sure links receive our global focus indicator styling when navigating the page with a keyboard.
+- Make sure links receive our global focus indicator styling when navigating the page with a keyboard. (Reference: [Focus management | Primer](https://primer.style/design/accessibility/focus-management))
 - Avoid adding side effects to link click events. Links should navigate, not affect the page.
 
 ## Common mistakes
 - Only adding an underline to a link when it has focus or is hovered over
-- Adding underlines to *every link on the page*
+- Adding underlines to *every link on the page*. For example, a navigation list is a list of links but it is not required to have all of these navigational links underlined because the intent is understood and an underline is not needed to identify the interactive nature of the control.
 
 ## Additional resources
-- [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text)
+- [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text) (This link to Deque requires a subscription to access the content.)
 - Accessibility Insights plugin > Assessment > 7. Links
 - [WebAIM: Links and Hypertext - Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
 
@@ -60,4 +60,4 @@ People who have low or colorblind vision may have trouble identifying links that
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 - [Authoring Practices Guide - Links](https://www.w3.org/TR/wai-aria-practices-1.2/#link)
 - [Accessible Rich Internet Applications (WAI-ARIA) 1.2 (w3.org)](https://www.w3.org/TR/wai-aria-1.2/#link)
-- https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html
+- [Understanding Success Criterion 2.4.4: Link Purpose (In Context)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -42,7 +42,7 @@ People who have low or colorblind vision may have trouble identifying links that
 </DoDontContainer>
 
 ### For engineers
-- Use the primer link components:
+- Use the Primer link components:
 	- [Link | Primer ViewComponents](https://primer.style/view-components/components/link)
 	- [Link | Primer React](https://primer.style/react/Link)
 - Don't override the link styling provided in the components

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -57,7 +57,7 @@ People who have low or colorblind vision may have trouble identifying links that
 - [WebAIM: Links and Hypertext - Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
 
 ### Related WCAG guidelines and success criteria
-- https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html
+- [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 - https://www.w3.org/TR/wai-aria-practices-1.2/#link
 - [Accessible Rich Internet Applications (WAI-ARIA) 1.2 (w3.org)](https://www.w3.org/TR/wai-aria-1.2/#link)
 - https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -19,7 +19,7 @@ People who have low or colorblind vision may have trouble identifying links that
 ## How to test links
 - Check a link's function. If clicking a link instead activates a feature on the page, it should be a `<button>`, and vice versa. 
 - Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text needs updates. 
-- Check a link's contrast. Links being text supersede the widget contrast requirement, which means all links need to pass 4.5:1 against the background color that they are on. 
+- [Check a link's contrast](https://webaim.org/resources/contrastchecker/). Links being text supersede the widget contrast requirement, which means all links need to pass 4.5:1 against the background color that they are on. 
 - In body text, like a markdown file, check to make sure that all links have underline styling. 
 
 ## Guidelines

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -1,0 +1,64 @@
+---
+title: Links
+---
+
+## Overview
+Links are user interface elements that *navigate* you to a new place or new content. Contrast this with buttons, which are designed to *activate* a feature. Think of it this way: 
+- Links are transportation vehicles
+- Buttons are the ticket terminals 
+
+## Why?
+Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. 
+
+For screen reader assistive technology, links and buttons have expectations to function differently. If a link is activated and does not do what was expected that can be disorienting and frustrating. 
+
+A common way a screen reader might navigate the page is by going through a list of all the links on the page. Without context, "read more" or "click here" links won't be very helpful. 
+
+People who have low or colorblind vision may have trouble identifying links that just use color to distinguish between plain text, this is why keeping the underline styling on links within body text important for identification.
+
+## How to test links
+- Check a link's function. If clicking a link instead activates a feature on the page, it should be a `<button>`, and vice versa. 
+- Check a link's purpose. If you cant get an idea of where a link will take you based on the link text alone, the link text needs updates. 
+- Check a link's contrast. Links being text supersede the widget contrast requirement, which means all links need to pass 4.5:1 against the background color that they are on. 
+- In body text, like a markdown file, check to make sure that all links have underline styling. 
+
+## Guidelines
+
+### For designers
+- Make sure you're using the proper accent color for links in your mocks. Double check the color you're using if you're using it on anything other than a white background. For more context on color, check out our [Color | Interface guidelines (primer.style)](https://primer.style/design/foundations/color).
+- Make sure a link's purpose can be understood on its own without the surrounding context in concise words. 
+- Links should always be underlined if they're in body text. 
+- Links should look like links, not buttons.
+
+<DoDontContainer stacked>
+    <Do>
+        <Caption>Be sure to unlinder links in paragraphs and sentences</Caption>
+        <img src="https://user-images.githubusercontent.com/40274682/157987879-8762ad9c-c287-4360-b55f-9d85658e874b.png" alt="Appropriate underlined links in a GitHub issues post">
+    </Do>
+    <Dont>
+        <Caption>Underline every link, or forget to underline any links in paragraphs and sentences</Caption>
+        <img src="https://user-images.githubusercontent.com/40274682/157987884-d1ba14ca-9844-44af-b648-5236dc513a16.png" alt="GitHub issues post with no underlined links">
+    </Dont>
+</DoDontContainer>
+
+### For engineers
+- Use the primer link components:
+	- [Link | Primer ViewComponents](https://primer.style/view-components/components/link)
+	- [Link | Primer React](https://primer.style/react/Link)
+- Don't override the link styling provided in the components
+- Make sure links receive our global focus indicator styling when navigating the page with a keyboard.
+
+## Common mistakes
+- Link underlines only on focus or hover
+- Link underlines on *every link on the page*
+
+## Additional resources
+- [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text)
+- Accessibility Insights plugin > Assessment > 7. Links
+- [WebAIM: Links and Hypertext - Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
+
+### Related WCAG guidelines and success criteria
+- https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html
+- https://www.w3.org/TR/wai-aria-practices-1.2/#link
+- [Accessible Rich Internet Applications (WAI-ARIA) 1.2 (w3.org)](https://www.w3.org/TR/wai-aria-1.2/#link)
+- https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -32,7 +32,7 @@ People who have low or colorblind vision may have trouble identifying links that
 
 <DoDontContainer stacked>
     <Do>
-        <Caption>Be sure to unlinder links in paragraphs and sentences</Caption>
+        <Caption>Be sure to underline links in paragraphs and sentences</Caption>
         <img src="https://user-images.githubusercontent.com/40274682/157987879-8762ad9c-c287-4360-b55f-9d85658e874b.png" alt="Appropriate underlined links in a GitHub issues post">
     </Do>
     <Dont>

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -14,7 +14,7 @@ For screen reader assistive technology, links and buttons are expected to functi
 
 A common way a screen reader might navigate the page is by going through a list of all the links on the page. Without context, "read more" or "click here" links won't be very helpful. 
 
-People who have low or colorblind vision may have trouble identifying links that just use color to distinguish between plain text, this is why keeping the underline styling on links within body text important for identification.
+People who have low or colorblind vision may have trouble identifying links that just use color to distinguish between plain text, this is why keeping the underline styling on links within body text is important for identification.
 
 ## How to test links
 - Check a link's function. If clicking a link instead activates a feature on the page, it should be a `<button>`, and vice versa. 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -58,6 +58,6 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ### Related WCAG guidelines and success criteria
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
-- https://www.w3.org/TR/wai-aria-practices-1.2/#link
+- [Authoring Practices Guide - Links](https://www.w3.org/TR/wai-aria-practices-1.2/#link)
 - [Accessible Rich Internet Applications (WAI-ARIA) 1.2 (w3.org)](https://www.w3.org/TR/wai-aria-1.2/#link)
 - https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -18,7 +18,7 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ## How to test links
 - Check a link's function. If clicking a link instead activates a feature on the page, it should be a `<button>`, and vice versa. 
-- Check a link's purpose. If you cant get an idea of where a link will take you based on the link text alone, the link text needs updates. 
+- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text needs updates. 
 - Check a link's contrast. Links being text supersede the widget contrast requirement, which means all links need to pass 4.5:1 against the background color that they are on. 
 - In body text, like a markdown file, check to make sure that all links have underline styling. 
 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -49,7 +49,7 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ## Common mistakes
 - Only adding an underline to a link when it has focus or is hovered over
-- Link underlines on *every link on the page*
+- Adding underlines to *every link on the page*
 
 ## Additional resources
 - [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -48,7 +48,7 @@ People who have low or colorblind vision may have trouble identifying links that
 - Avoid adding side effects to link click events. Links should navigate, not affect the page.
 
 ## Common mistakes
-- Link underlines only on focus or hover
+- Only adding an underline to a link when it has focus or is hovered over
 - Link underlines on *every link on the page*
 
 ## Additional resources

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -8,7 +8,7 @@ Links are user interface elements that *navigate* you to a new place or new cont
 - Buttons are the ticket terminals 
 
 ## Why?
-Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through Wikipedia. Links play a key part in your experience on the web but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. 
+Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through sites like Wikipedia. Links play a key part in your experience on the web, but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. 
 
 For screen reader assistive technology, links and buttons have expectations to function differently. If a link is activated and does not do what was expected that can be disorienting and frustrating. 
 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -10,7 +10,7 @@ Links are user interface elements that *navigate* you to a new place or new cont
 ## Why?
 Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through sites like Wikipedia. Links play a key part in your experience on the web, but without proper consideration those links can be frustrating, skipped over, or completely unnoticed. 
 
-For screen reader assistive technology, links and buttons have expectations to function differently. If a link is activated and does not do what was expected that can be disorienting and frustrating. 
+For screen reader assistive technology, links and buttons are expected to function differently. If a link is activated and does not do what was expected, that can be disorienting and frustrating. 
 
 A common way a screen reader might navigate the page is by going through a list of all the links on the page. Without context, "read more" or "click here" links won't be very helpful. 
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -11,7 +11,7 @@ Primer's interface guidelines are a collection of principles, standards, and usa
 
 The fundamental parts of the design system, such as color and typography, that underpin all GitHub interfaces.
 
-## [Accessibility](https://primer.style/design/accessibility/accessibility-at-github)
+## [Accessibility](https://primer.style/design/accessibility)
 
 Standards, guidelines, and tools to design accessible GitHub interfaces.
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -8,7 +8,7 @@
     - title: Content
       url: /foundations/content
 - title: Accessibility
-  url: /accessibility/accessibility-at-github
+  url: /accessibility
   children:
     - title: Accessibility at GitHub
       url: /accessibility/accessibility-at-github

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -12,16 +12,18 @@
   children:
     - title: Accessibility at GitHub
       url: /accessibility/accessibility-at-github
-    - title: Focus management
-      url: /accessibility/focus-management
     - title: Guidelines
       url: /accessibility/guidelines
+    - title: Tools
+      url: /accessibility/tools
+    - title: Focus management
+      url: /accessibility/focus-management
     - title: Headings
       url: /accessibility/headings
     - title: Semantic HTML
       url: /accessibility/semantic-html
-    - title: Tools
-      url: /accessibility/tools
+    - title: Links
+      url: /accessibility/links
 - title: UI patterns
   url: /ui-patterns
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -8,22 +8,28 @@
     - title: Content
       url: /foundations/content
 - title: Accessibility
-  url: /accessibility
+  url: /accessibility/accessibility-at-github
   children:
     - title: Accessibility at GitHub
       url: /accessibility/accessibility-at-github
-    - title: Guidelines
-      url: /accessibility/guidelines
-    - title: Tools
-      url: /accessibility/tools
     - title: Focus management
       url: /accessibility/focus-management
+    - title: Guidelines
+      url: /accessibility/guidelines
     - title: Headings
       url: /accessibility/headings
     - title: Semantic HTML
       url: /accessibility/semantic-html
+    - title: Text resize and respacing
+      url: /accessibility/text-resize-and-respacing
+    - title: Alternative text for images
+      url: /accessibility/alternative-text-for-images
+    - title: Describing a button’s purpose
+      url: /accessibility/button-purpose
     - title: Links
       url: /accessibility/links
+    - title: Tools
+      url: /accessibility/tools
 - title: UI patterns
   url: /ui-patterns
   children:
@@ -36,7 +42,9 @@
     - title: Messaging
       url: /ui-patterns/messaging
     - title: Progressive disclosure
-      url: /ui-patterns/progressive-disclosure
+      url: /ui-patterns/progressive-disclosure    
+    - title: Saving
+      url: /ui-patterns/saving
 - title: Components
   url: /components
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -26,8 +26,6 @@
       url: /accessibility/alternative-text-for-images
     - title: Describing a button’s purpose
       url: /accessibility/button-purpose
-    - title: Links
-      url: /accessibility/links
     - title: Tools
       url: /accessibility/tools
 - title: UI patterns


### PR DESCRIPTION
Creating accessible link documentation for within primer. 

We will also need to fix our link build pages in CSS specifically with styles that are out for use, which means deprecating some styles. 

Linked (lol) issue: https://github.com/github/accessibility/issues/587