### PR TITLE
Action list guidelines: replace Dropdown menu with Action menu

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -245,17 +245,17 @@ Action menus are used for disambiguation, navigation, or to display secondary op
 </Box>
     </div>
     <div>
-        <Link href="https://primer.style/react/DropdownMenu">
-            <img alt="Select panel" src="https://user-images.githubusercontent.com/293280/123881067-cdbaea00-d8f8-11eb-98e4-e57c64489308.png" />
+        <Link href="https://primer.style/react/ActionMenu#with-selection">
+            <img alt="Action Menu with selection" src="https://user-images.githubusercontent.com/293280/123881067-cdbaea00-d8f8-11eb-98e4-e57c64489308.png" />
         </Link>
     </div>
     <div>
-        <Heading fontSize={3}>Dropdown menu</Heading>
+        <Heading fontSize={3}>Action menu with selection</Heading>
         <Box as="p">
 
-Dropdown menus are used for making a single selection among a small list of options. The list is usually predefined with system values, but in some cases it can include user-provided data when those are known not to grow into too many items.
+ActionMenu can be used for making a single selection among a small list of options. The list is usually predefined with system values, but in some cases it can include user-provided data when those are known not to grow into too many items.
 
-[Primer React implementation](https://primer.style/react/DropdownMenu)
+[Primer React implementation](https://primer.style/react/ActionMenu#with-selection)
 
 </Box>
     </div>


### PR DESCRIPTION
We no longer have 2 different components. Dropdown menu has been replaced with an Action menu variant.

Question: should we merge the 2 sections or not? 

<img width="830" alt="2 sections for ActionMenu and ActionMenu with selection" src="https://user-images.githubusercontent.com/1863771/159326786-dcd27472-d42b-4aeb-a47f-45dc1bd9e50c.png">
