### PR TITLE
docs: Add “Assistive technology announcements” guidance

### DIFF
--- a/content/accessibility/announcements.mdx
+++ b/content/accessibility/announcements.mdx
@@ -1,0 +1,20 @@
+---
+title: Announcements
+---
+
+## Overview
+
+The guidelines below help answer the question “Should I ensure assistive tools output a message in _<this_situation>_?”
+
+## Guidelines
+
+- **Always: Announce location changes** — Help users understand where they are on a page. Maintain positional awareness.
+- **Always: Announce results of user actions** — Give feedback about the success or failure directly following a user action.
+- **Sometimes: Announce other changes** — Explore case-by-case when changes are disconnected from the user’s place and the success or failure of the user’s actions. For example:
+  - Distracting change announcements: When other users add issue comments; when presence indicators appear
+  - Essential change announcements: When log lines stream in on the GitHub Actions workflow run page
+
+## Additional resources
+
+- [Deep Dive: Page and Navigation transitions, Dynamic Content, and SPAs](https://github.com/github/accessibility/blob/main/docs/deep-dive-notes/2022-03-02-page-transitions.md) (only accessible to GitHub staff)
+- [Deep Dive: Save Patterns & Status Messages](https://github.com/github/accessibility/blob/main/docs/deep-dive-notes/2021-11-19-save-patterns-and-status-messages.md) (only accessible to GitHub staff)

--- a/content/accessibility/announcements.mdx
+++ b/content/accessibility/announcements.mdx
@@ -1,5 +1,5 @@
 ---
-title: Announcements
+title: Assistive technology announcements
 ---
 
 ## Overview

--- a/content/accessibility/announcements.mdx
+++ b/content/accessibility/announcements.mdx
@@ -4,7 +4,7 @@ title: Announcements
 
 ## Overview
 
-The guidelines below help answer the question “Should I ensure assistive tools output a message in _<this_situation>_?”
+These guidelines will help you determine when assistive tools should output a message.
 
 ## Guidelines
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -26,6 +26,8 @@
       url: /accessibility/alternative-text-for-images
     - title: Describing a button’s purpose
       url: /accessibility/button-purpose
+    - title: Announcements
+      url: /accessibility/announcements
     - title: Tools
       url: /accessibility/tools
 - title: UI patterns

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -14,6 +14,8 @@
       url: /accessibility/accessibility-at-github
     - title: Guidelines
       url: /accessibility/guidelines
+    - title: Tools
+      url: /accessibility/tools
     - title: Semantic HTML
       url: /accessibility/semantic-html
     - title: Headings
@@ -28,8 +30,6 @@
       url: /accessibility/focus-management
     - title: Describing a button’s purpose
       url: /accessibility/button-purpose
-    - title: Tools
-      url: /accessibility/tools
 - title: UI patterns
   url: /ui-patterns
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -12,22 +12,22 @@
   children:
     - title: Accessibility at GitHub
       url: /accessibility/accessibility-at-github
-    - title: Focus management
-      url: /accessibility/focus-management
     - title: Guidelines
       url: /accessibility/guidelines
-    - title: Headings
-      url: /accessibility/headings
     - title: Semantic HTML
       url: /accessibility/semantic-html
-    - title: Text resize and respacing
-      url: /accessibility/text-resize-and-respacing
+    - title: Headings
+      url: /accessibility/headings
     - title: Alternative text for images
       url: /accessibility/alternative-text-for-images
-    - title: Describing a button’s purpose
-      url: /accessibility/button-purpose
+    - title: Text resize and respacing
+      url: /accessibility/text-resize-and-respacing
     - title: Assistive technology announcements
       url: /accessibility/announcements
+    - title: Focus management
+      url: /accessibility/focus-management
+    - title: Describing a button’s purpose
+      url: /accessibility/button-purpose
     - title: Tools
       url: /accessibility/tools
 - title: UI patterns

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -26,7 +26,7 @@
       url: /accessibility/alternative-text-for-images
     - title: Describing a button’s purpose
       url: /accessibility/button-purpose
-    - title: Announcements
+    - title: Assistive technology announcements
       url: /accessibility/announcements
     - title: Tools
       url: /accessibility/tools


### PR DESCRIPTION
Supersedes https://github.com/github/accessibility/pull/881 (only accessible to GitHub staff)

🔍 Preview: [announcements.mdx](https://github.com/primer/design/blob/announcements/content/accessibility/announcements.mdx)