### PR TITLE
Don't use title on links

### DIFF
--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -59,6 +59,8 @@ People who have low or colorblind vision may have trouble identifying links that
 	- [Link in Primer React](https://primer.style/react/Link)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard (reference: [Focus management](https://primer.style/design/accessibility/focus-management))
+- Don't use the `title` attribute
+  - Content within a `title` is inaccessible for many users, such as touch-only and keyboard-only users. If additional content needs to be associated with a link consider using a [tooltip](https://primer.style/view-components/components/alpha/tooltip) or [alternatives to a tooltip](https://primer.style/design/accessibility/tooltip-alternatives).
 - Avoid adding side effects to link click events. Links should navigate, not affect the page.
 
 ## Common mistakes


### PR DESCRIPTION
Added guidance on using the title attribute of a link.