### PR TITLE
Fixing mistake in headline

### DIFF
--- a/content/accessibility/guidelines.mdx
+++ b/content/accessibility/guidelines.mdx
@@ -105,7 +105,7 @@ For more detail on accessible links, read the W3C's [Understanding 2.4.4 - Link 
 
 **Why?** Visible labels determine the purpose for inputs, and screen readers can read this information without extra code. If placeholder text contains important information and that information disappears when one starts to type, those with cognitive disabilities will have difficulty completing the form.
 
-#### Content hover on focus
+#### Content on hover or focus
 Hover cards and tool tips need to be approached with care. To meet the bare minimum for accessibility, tooltips need to be: 
 - **Dismissible**: Be able to dismiss tooltips without moving the pointer or keyboard focus (unless it's an input error or does not cover other content).
 - **Hoverable**: Pointer can move over the hover content without the content disappearing.


### PR DESCRIPTION
If I am not mistaking the headline: "Content hover on focus" should actually be "Content on hover or focus" (like the linked resource).

The current title got me slightly confused as I was expecting the section to talk about hover content that is disabled on focus. This hover does not quite fit to the content of the section.