### PR TITLE
Bump Doctocat to next major

### DIFF
--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -3,8 +3,8 @@ title: Accessibility
 ---
 
 import {Box, Link, Text, Label} from '@primer/react'
-import {Grid} from '@primer/react/deprecated'
-import {Flex} from '@primer/react/deprecated'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
 <Grid gridTemplateColumns="1fr" gridGap={4}>
 <Grid gridTemplateColumns="1fr" gridGap={4}>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -2,27 +2,31 @@
 title: Accessibility
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
 
 <Grid gridTemplateColumns="1fr" gridGap={4}>
 
-
 <Grid gridTemplateColumns="1fr" gridGap={4}>
-    <h2>General</h2>
-    <div>
-        <Link href="/design/accessibility/accessibility-at-github" fontWeight="bold">Accessibility at GitHub</Link>
-        <Box as="p">Get started with accessibility at GitHub.</Box>
-    </div>
-    <div>
-        <Link href="/design/accessibility/guidelines" fontWeight="bold">Guidelines</Link>
-        <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
-    </div>
-    <div>
-        <Link href="/design/accessibility/tools" fontWeight="bold">Tools</Link>
-        <Box as="p">A selection of tools to help designers create accessible designs.</Box>
-    </div>
+  <h2>General</h2>
+  <div>
+    <Link href="/design/accessibility/accessibility-at-github" fontWeight="bold">
+      Accessibility at GitHub
+    </Link>
+    <Box as="p">Get started with accessibility at GitHub.</Box>
+  </div>
+  <div>
+    <Link href="/design/accessibility/guidelines" fontWeight="bold">
+      Guidelines
+    </Link>
+    <Box as="p">Basic guidelines for designers when creating or updating features.</Box>
+  </div>
+  <div>
+    <Link href="/design/accessibility/tools" fontWeight="bold">
+      Tools
+    </Link>
+    <Box as="p">A selection of tools to help designers create accessible designs.</Box>
+  </div>
 </Grid>
-
 
 <Grid gridTemplateColumns="1fr" gridGap={4}>
     <h2>Specific</h2>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -2,9 +2,13 @@
 title: Accessibility
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
+import { Grid, Box, Link, Text, Label } from '@primer/react'
 
-<Grid gridTemplateColumns="1fr" gridGap={4}>
+<Grid gridTemplateColumns
+
+import { Flex } from '@primer/react/deprecated';
+
+="1fr" gridGap={4}>
 
 <Grid gridTemplateColumns="1fr" gridGap={4}>
   <h2>General</h2>

--- a/content/accessibility/index.mdx
+++ b/content/accessibility/index.mdx
@@ -2,14 +2,11 @@
 title: Accessibility
 ---
 
-import { Grid, Box, Link, Text, Label } from '@primer/react'
+import {Box, Link, Text, Label} from '@primer/react'
+import {Grid} from '@primer/react/deprecated'
+import {Flex} from '@primer/react/deprecated'
 
-<Grid gridTemplateColumns
-
-import { Flex } from '@primer/react/deprecated';
-
-="1fr" gridGap={4}>
-
+<Grid gridTemplateColumns="1fr" gridGap={4}>
 <Grid gridTemplateColumns="1fr" gridGap={4}>
   <h2>General</h2>
   <div>

--- a/content/accessibility/tooltip-alternatives.mdx
+++ b/content/accessibility/tooltip-alternatives.mdx
@@ -2,7 +2,7 @@
 title: Tooltip alternatives
 ---
 
-import {Box, Text} from '@primer/components'
+import {Box, Text} from '@primer/react'
 
 ## Overview
 
@@ -15,34 +15,51 @@ Always consider **not** using a tooltip for an improved user experience.
 - Tooltips are never accessible on mobile devices.
 - Tooltips should **never** be set on non-interactive elements (for example, `div`, `span`, `p`), and should only ever be set on interactive elements (for example, `button`, `a`). Tooltips on non-interactive elements are not accessible to keyboard users and screen reader users.
 
-## Guidelines 
+## Guidelines
 
 ### For designers
 
-- Reserve tooltips for components like icon buttons. 
+- Reserve tooltips for components like icon buttons.
 - Keep your tooltip text minimal.
 - Only include tooltips on other components as a last resort.
-- **Never** include tooltips on non-interactive components (`div`, `span`, `p`).  
+- **Never** include tooltips on non-interactive components (`div`, `span`, `p`).
 
 <DoDontContainer>
-   <Do>
-      <img width="456" alt="Icon buttons with tooltips for edit, favorite, and sponsor" src="https://user-images.githubusercontent.com/40274682/160182083-a97ba63f-a297-4613-bb52-d4a8ef10cc10.png"/>
-      <Caption>Use a tooltip to give a text label to an icon button</Caption>
-   </Do>
-   <Dont>
-      <img width="456" alt="Non-interactive text element activating a long and wordy tooltip on hover" src="https://user-images.githubusercontent.com/40274682/160182084-948a7969-9c84-4c08-8801-4d8a5253b1ce.png"/>
-      <Caption>Don't use tooltips on non-interactive elements</Caption>
-   </Dont>
+  <Do>
+    <img
+      width="456"
+      alt="Icon buttons with tooltips for edit, favorite, and sponsor"
+      src="https://user-images.githubusercontent.com/40274682/160182083-a97ba63f-a297-4613-bb52-d4a8ef10cc10.png"
+    />
+    <Caption>Use a tooltip to give a text label to an icon button</Caption>
+  </Do>
+  <Dont>
+    <img
+      width="456"
+      alt="Non-interactive text element activating a long and wordy tooltip on hover"
+      src="https://user-images.githubusercontent.com/40274682/160182084-948a7969-9c84-4c08-8801-4d8a5253b1ce.png"
+    />
+    <Caption>Don't use tooltips on non-interactive elements</Caption>
+  </Dont>
 </DoDontContainer>
 
-<Box mb={3} display="flex" alignItems="flex-start" alignItems="center" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <Box as="p" mt="0">
-       <h4>Annotations</h4>If you have an appropriate tooltip in your design, annotate the tooltip carefully with the preferred type (whether it's a label or description) to ensure proper semantics.</Box>
-    <img
-        width="456"
-        alt="Mock of an icon button and its tooltip with an annotation pointing to the tooltip with 'label' text"
-        src="https://user-images.githubusercontent.com/40274682/160183578-4f66e628-c207-47a4-8520-00a37e26def4.png"
-    />
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  alignItems="center"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <Box as="p" mt="0">
+    <h4>Annotations</h4>If you have an appropriate tooltip in your design, annotate the tooltip carefully with the
+    preferred type (whether it's a label or description) to ensure proper semantics.
+  </Box>
+  <img
+    width="456"
+    alt="Mock of an icon button and its tooltip with an annotation pointing to the tooltip with 'label' text"
+    src="https://user-images.githubusercontent.com/40274682/160183578-4f66e628-c207-47a4-8520-00a37e26def4.png"
+  />
 </Box>
 
 ### For developers
@@ -58,14 +75,22 @@ If you determine that tooltips are appropriate for your use case, make sure to c
 If possible, persist the content so it's always available rather than using a tooltip, which hides content by default. This ensures that the content is always discovered and surfaced to users regardless of device.
 
 <DoDontContainer>
-   <Do>
-      <img width="456" alt="Information about how many discussions can be pinned added to the confirmation dialog" src="https://user-images.githubusercontent.com/40274682/160192785-13764229-7c42-4fa9-b752-b2ec741d4d4a.png"/>
-      <Caption>Find an appropriate permanent place to display additional information.</Caption>
-   </Do>
-   <Dont>
-      <img width="456" alt="Information about how many discussions can be pinned within tooltip on non-interactive element" src="https://user-images.githubusercontent.com/40274682/160192791-2d69905a-bd1f-4508-9c0a-9e968b6d4ac3.png"/>
-      <Caption>Don't use a tooltip to add additional helpful information</Caption>
-   </Dont>
+  <Do>
+    <img
+      width="456"
+      alt="Information about how many discussions can be pinned added to the confirmation dialog"
+      src="https://user-images.githubusercontent.com/40274682/160192785-13764229-7c42-4fa9-b752-b2ec741d4d4a.png"
+    />
+    <Caption>Find an appropriate permanent place to display additional information.</Caption>
+  </Do>
+  <Dont>
+    <img
+      width="456"
+      alt="Information about how many discussions can be pinned within tooltip on non-interactive element"
+      src="https://user-images.githubusercontent.com/40274682/160192791-2d69905a-bd1f-4508-9c0a-9e968b6d4ac3.png"
+    />
+    <Caption>Don't use a tooltip to add additional helpful information</Caption>
+  </Dont>
 </DoDontContainer>
 
 ### 2. Don't duplicate content
@@ -73,14 +98,22 @@ If possible, persist the content so it's always available rather than using a to
 If the tooltip duplicates content that is already available on the page, remove it.
 
 <DoDontContainer>
-   <Do>
-      <img width="456" alt="Pointer hovering over a link with no tooltip" src="https://user-images.githubusercontent.com/40274682/160201665-0f3bf527-fef7-4d79-b81b-af194385be5d.png"/>
-      <Caption>Remove any duplicate tooltip text.</Caption>
-   </Do>
-    <Dont>
-       <img width="456" alt="Screenshot of tooltip with GitHub username, @inkblotty, on a static span that says @inkblotty" src="https://user-images.githubusercontent.com/40274682/160201667-d90e076d-7441-45f4-b0b6-620693921105.png"/>
-       <Caption>Don't set tooltips that duplicate the trigger element content.</Caption>
-    </Dont>
+  <Do>
+    <img
+      width="456"
+      alt="Pointer hovering over a link with no tooltip"
+      src="https://user-images.githubusercontent.com/40274682/160201665-0f3bf527-fef7-4d79-b81b-af194385be5d.png"
+    />
+    <Caption>Remove any duplicate tooltip text.</Caption>
+  </Do>
+  <Dont>
+    <img
+      width="456"
+      alt="Screenshot of tooltip with GitHub username, @inkblotty, on a static span that says @inkblotty"
+      src="https://user-images.githubusercontent.com/40274682/160201667-d90e076d-7441-45f4-b0b6-620693921105.png"
+    />
+    <Caption>Don't set tooltips that duplicate the trigger element content.</Caption>
+  </Dont>
 </DoDontContainer>
 
 ### 3. Use a modal
@@ -88,14 +121,22 @@ If the tooltip duplicates content that is already available on the page, remove 
 Consider using a modal, which is accessible for mobile users and allows you to structure content that may otherwise be crammed into a tooltip.
 
 <DoDontContainer>
-    <Do>
-       <img width="456" alt="Screenshot of GitHub Actions page with a modal that conveys workflow file information about a runner" src="https://user-images.githubusercontent.com/40274682/160210527-2319e408-d433-407f-aac2-66eaf9e63246.png" />
-       <Caption>Do use a pattern that is accessible to a larger number of users such as a modal</Caption>
-    </Do>
-    <Dont>
-       <img width="456" alt="Screenshot of GitHub Actions page using a tooltip on a static element to convey long workflow file information" src="https://user-images.githubusercontent.com/40274682/160210534-52361d76-8dad-480e-b7a8-eb9332370a53.png" />
-       <Caption>Don't place long content inside a tooltip</Caption>
-    </Dont>
+  <Do>
+    <img
+      width="456"
+      alt="Screenshot of GitHub Actions page with a modal that conveys workflow file information about a runner"
+      src="https://user-images.githubusercontent.com/40274682/160210527-2319e408-d433-407f-aac2-66eaf9e63246.png"
+    />
+    <Caption>Do use a pattern that is accessible to a larger number of users such as a modal</Caption>
+  </Do>
+  <Dont>
+    <img
+      width="456"
+      alt="Screenshot of GitHub Actions page using a tooltip on a static element to convey long workflow file information"
+      src="https://user-images.githubusercontent.com/40274682/160210534-52361d76-8dad-480e-b7a8-eb9332370a53.png"
+    />
+    <Caption>Don't place long content inside a tooltip</Caption>
+  </Dont>
 </DoDontContainer>
 
 ### 4. Use a summary disclosure
@@ -103,21 +144,29 @@ Consider using a modal, which is accessible for mobile users and allows you to s
 Consider using a summary disclosure that is accessible for mobile users and also offers the ability to show or hide content.
 
 <DoDontContainer>
-    <Do>
-       <img width="800" alt="Screenshot of GitHub pricing page that uses a summary disclosure to hide and show additional information on each point" src="https://user-images.githubusercontent.com/40274682/160211684-6c102dd6-4039-4c7b-8c52-eeeb71a27db5.png" />
-       <Caption>Do use a pattern that is accessible to a larger number of users such as a summary disclosure</Caption>
-    </Do>
-    <Dont>
-       <img width="800" alt="Screenshot of GitHub pricing page using a tooltip to hide and show long descriptions on each point" src="https://user-images.githubusercontent.com/40274682/160211686-c0cc0dd5-8659-4e72-b9dd-d60369ffa1d7.png" />
-       <Caption>Don't use tooltips on non-interactive elements</Caption>
-    </Dont>
+  <Do>
+    <img
+      width="800"
+      alt="Screenshot of GitHub pricing page that uses a summary disclosure to hide and show additional information on each point"
+      src="https://user-images.githubusercontent.com/40274682/160211684-6c102dd6-4039-4c7b-8c52-eeeb71a27db5.png"
+    />
+    <Caption>Do use a pattern that is accessible to a larger number of users such as a summary disclosure</Caption>
+  </Do>
+  <Dont>
+    <img
+      width="800"
+      alt="Screenshot of GitHub pricing page using a tooltip to hide and show long descriptions on each point"
+      src="https://user-images.githubusercontent.com/40274682/160211686-c0cc0dd5-8659-4e72-b9dd-d60369ffa1d7.png"
+    />
+    <Caption>Don't use tooltips on non-interactive elements</Caption>
+  </Dont>
 </DoDontContainer>
 
 ### Other
 
 If you are unsure which alternative is more suited to your scenario and need help, consult a designer or the GitHub Accessibility team (if you are GitHub staff) for advice.
 
-## Additional resources 
+## Additional resources
 
 - [Your tooltips are bogus](https://heydonworks.com/article/your-tooltips-are-bogus/)
 - [erb lint rule: NoAriaLabelMisuseCounter](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/no-aria-label-misuse-counter.md#no-aria-label-misuse-counter)

--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -4,8 +4,8 @@ status: Alpha
 ---
 
 import {Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
-import {Grid} from '@primer/react/deprecated'
-import {Flex} from '@primer/react/deprecated'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
   An action list is a vertical list of interactive actions or options. It’s composed of items presented in a consistent

--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -3,7 +3,7 @@ title: Action list
 status: Alpha
 ---
 
-import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/components'
+import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
   An action list is a vertical list of interactive actions or options. It’s composed of items presented in a consistent
@@ -195,7 +195,7 @@ Use an [`arrow-right`](https://primer.style/octicons/arrow-right-16) octicon in 
                 alt="Multi-selection"
                 src="https://user-images.githubusercontent.com/293280/126000062-3fc62e04-670d-4346-b65b-57c2e70ceeb0.png"
             />
-        </Flex>        
+        </Flex>
     </div>
     <div>
         <Heading fontSize={3}>Selection states</Heading>
@@ -214,7 +214,7 @@ Action list items can be selected. Single selections are represented with a [`ch
                 alt="Action list item in danger variation"
                 src="https://user-images.githubusercontent.com/293280/125999384-b2a322db-8ec3-4a69-a414-10050544813b.png"
             />
-        </Flex>        
+        </Flex>
     </div>
     <div>
         <Heading fontSize={3}>Danger items</Heading>

--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -3,9 +3,13 @@ title: Action list
 status: Alpha
 ---
 
-import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
+import { Grid, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link } from '@primer/react'
 
-<Box sx={{fontSize: 3}} class="lead" as="p">
+<Box sx
+
+import { Flex } from '@primer/react/deprecated';
+
+={{fontSize: 3}} class="lead" as="p">
   An action list is a vertical list of interactive actions or options. It’s composed of items presented in a consistent
   single-column format, with room for icons, descriptions, side information, and other rich visuals.
 </Box>
@@ -14,14 +18,13 @@ import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link
   <Label
     as="a"
     href="https://primer.style/react/ActionList"
-    variant="xl"
-    color="fg.muted"
-    outline
-    style="text-decoration: none; line-height: 20px;"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
   >
     <img
-      width="20"
-      height="20"
+      width="16"
+      height="16"
       alt=" "
       src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
       style="vertical-align: middle; margin-right: 4px;"
@@ -31,13 +34,13 @@ import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link
   <Label
     as="a"
     href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0"
-    variant="xl"
-    outline
-    style="text-decoration: none; line-height: 20px;"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
   >
     <img
-      width="20"
-      height="20"
+      width="16"
+      height="16"
       alt=" "
       src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
       style="vertical-align: middle; margin-right: 4px;"

--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -3,13 +3,11 @@ title: Action list
 status: Alpha
 ---
 
-import { Grid, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link } from '@primer/react'
+import {Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
+import {Grid} from '@primer/react/deprecated'
+import {Flex} from '@primer/react/deprecated'
 
-<Box sx
-
-import { Flex } from '@primer/react/deprecated';
-
-={{fontSize: 3}} class="lead" as="p">
+<Box sx={{fontSize: 3}} class="lead" as="p">
   An action list is a vertical list of interactive actions or options. It’s composed of items presented in a consistent
   single-column format, with room for icons, descriptions, side information, and other rich visuals.
 </Box>

--- a/content/components/autocomplete.mdx
+++ b/content/components/autocomplete.mdx
@@ -61,7 +61,7 @@ The autocomplete component is an enhanced text input that makes it easier to cho
 
 Autocomplete is made up of a form input field, label, and overlay of menu options. The label is required but may be visually hidden. Optionally, a leading visual and/or clear button may be displayed.
 
-![autocomplete component diagram with an input label stating "pick a branch", empty focused input field with a search icon and clear button, and an overlay menu listing search options](https://user-images.githubusercontent.com/18661030/170589956-7c0f2498-b55c-4013-8c99-ef5bc1844218.png)
+![autocomplete component diagram with an input label stating pick a branch, empty focused input field with a search icon and clear button, and an overlay menu listing search options](https://user-images.githubusercontent.com/18661030/170589956-7c0f2498-b55c-4013-8c99-ef5bc1844218.png)
 
 ## Usage
 

--- a/content/components/autocomplete.mdx
+++ b/content/components/autocomplete.mdx
@@ -3,86 +3,143 @@ title: Autocomplete
 status: Alpha
 ---
 
-import {LabelGroup, Label, Box} from '@primer/components'
+import {LabelGroup, Label, Box} from '@primer/react'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
-    Autocomplete inputs allow users to quickly filter through a list of options to pick one or more values for a field.
+  Autocomplete allows users to quickly filter through a list of options and pick one or more values for a field.
 </Box>
 
 <LabelGroup display="block" mb={4}>
-    <Label as="a" href="https://primer.style/components/Autocomplete" variant="xl" color="text.success" outline style="text-decoration: none; line-height: 20px;">
-        <img width="20" height="20" alt=" " src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png" style="vertical-align: middle; margin-right: 4px;" />
-        React
-    </Label>
-    {/* TODO: uncomment once Figma docs are live
-    <Label as="a" href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0" variant="xl" outline style="text-decoration: none; line-height: 20px;">
-        <img width="20" height="20" alt=" " src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png" style="vertical-align: middle; margin-right: 4px;" />
-        Figma
-    </Label> */}
+  <Label
+    as="a"
+    href="https://primer.style/components/Autocomplete"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
+  >
+    <img
+      width="16"
+      height="16"
+      alt=" "
+      src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    React
+  </Label>
+  <Label
+    as="a"
+    href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
+  >
+    <img
+      width="16"
+      height="16"
+      alt=" "
+      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    Figma
+  </Label>
+  <Label
+    as="a"
+    href="https://primer.style/view-components/components/beta/autocomplete"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
+  >
+    Rails
+  </Label>
 </LabelGroup>
 
 ## Overview
 
-The autocomplete component is an enhanced text input that makes it easier to choose one or more values from a long list of options. The list of options is displayed when a user focuses the input. It is similar to a SelectPanel, except the text input is rendered inline instead of being shown after clicking a button.
+The autocomplete component is an enhanced text input that makes it easier to choose one or more values from a long list of options. The list of options is displayed when a user focuses the input.
 
 ## Anatomy
-An autocomplete is made up of an input and a menu of options.
 
-![autocomplete anatomy diagram](https://user-images.githubusercontent.com/2313998/137769316-20c07a68-0d7e-46cc-940e-7aec5a2e0ad8.png)
+Autocomplete is made up of a form input field, label, and overlay of menu options. The label is required but may be visually hidden. Optionally, a leading visual and/or clear button may be displayed.
 
+![autocomplete component diagram with an input label stating "pick a branch", empty focused input field with a search icon and clear button, and an overlay menu listing search options](https://user-images.githubusercontent.com/18661030/170589956-7c0f2498-b55c-4013-8c99-ef5bc1844218.png)
 
 ## Usage
+
 ### Text input
 
-![open autocomplete with menu de-emphasized](https://user-images.githubusercontent.com/2313998/137768284-0f267d5e-c299-4ab5-91d9-cd9ed0735edc.png)
+![two side by side autocomplete inputs, one showing a single select filled state, and another showing a multi select filled state with clearable tokens](https://user-images.githubusercontent.com/18661030/170590638-b7868803-6558-4df9-b462-20d00420b9f5.png)
 
-The text input is used to filter the options in the menu. It is also used to show the selected value (or values).
-
-This input follows the same design guidelines as a text input that is not part of an autocomplete.
+The Autocomplete text input has all the same design functionality and properties as a regular text input including size options, width, leading visual, trailing action, and states. When a single item is selected from the menu, it will display in the input as regular text. If multiple items are selected, they will display as clearable tokens within the input.
 
 ### Menu
 
-The menu is a list of options for the field's value. It appears as a list in a non-modal dialog that the user may select one or more values from.
+![two side by side autocomplete inputs focused with open menus. One shows a single select menu, the second shows a multi select menu with checkboxes](https://user-images.githubusercontent.com/18661030/170590641-42b27a3a-799a-4c1e-aaef-774990aed345.png)
 
-![open autocomplete with text input de-emphasized](https://user-images.githubusercontent.com/2313998/138128820-df4db151-5e28-473f-a341-03391e1b9afd.png)
-
-
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="menu opened, showing an empty state"
-        src="https://user-images.githubusercontent.com/2313998/138128784-4cdadb38-3b3e-4fbe-accb-772949d958de.png"
-    />
-    <Box as="p" mt="0">When there are no possible selections that can be made, a message is displayed that explains there are no possible options to select. The default message is "No selectable options".</Box>
-</Box>
-
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="menu opened, showing an empty state"
-        src="https://user-images.githubusercontent.com/2313998/138128776-6cad977d-b2b7-4661-9ff8-d9dda6bcaed2.png"
-    />
-    <Box as="p" mt="0">If a user is not limited to a pre-defined list of options, an additional item can be rendered in the menu to select the value that has been typed into the text input.</Box>
-</Box>
-
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="menu opened, showing an empty state"
-        src="https://user-images.githubusercontent.com/2313998/138128811-5542f1e0-2177-4741-af5b-c4bf52c65401.png"
-    />
-    <Box as="p" mt="0">A loading indicator should be displayed while the data for the list of options is being populated. The loading indicator helps the user understand that the list is not empty, it's just not done loading.</Box>
-</Box>
+The menu is a list of options for the field's value. It appears as a list in a non-modal dialog that the user may select one or more values from. The menu uses Overlay and ActionList designs for size, structure and interaction.
 
 #### Menu item rendering
 
 By default, menu items are rendered as a single line of text. The list in the menu is rendered using the [Action List](/action-list) component, so menu items can be rendered with all of the same options as Action List items.
 
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="opened autocomplete menu stating: no selectable options"
+    src="https://user-images.githubusercontent.com/18661030/170601327-97307d21-a33c-4a9f-9e2f-ad9e444a161d.png"
+  />
+  <Box as="p" mt="0">
+    If no options are available based on the search term, the menu will display a message that says "No selectable
+    options". A concise, custom message may be used in place of the default.
+  </Box>
+</Box>
+
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="opened autocomplete menu with an add item action"
+    src="https://user-images.githubusercontent.com/18661030/170589959-73608127-771d-4f7e-a78d-11b31433141d.png"
+  />
+  <Box as="p" mt="0">
+    If a user is not limited to a pre-defined list of options, an additional item can be rendered in the menu to select
+    the value that has been typed into the text input.
+  </Box>
+</Box>
+
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="opened autocomplete menu with a loading spinner"
+    src="https://user-images.githubusercontent.com/18661030/170589963-ab3e211b-1082-4fdb-928e-eddd2b773ba3.png"
+  />
+  <Box as="p" mt="0">
+    A loading indicator should be displayed while the data for the list of options is being populated. The loading
+    indicator helps the user understand that the list is not empty, it's just not done loading.
+  </Box>
+</Box>
+
 ## Sort and filter behavior
 
 ### Sorting
 
-The order of the items should not be random: they should be ordered in a way that makes it easy for a user to find a specific value. This could mean items may be ranked by how likely a user is to pick that option (for example, ordering labels by the number of times they've been used in that repository), or it could simply be in alphabetical order.
+The order of the items should not be random– they should be ordered in a way that makes it easy for a user to find a specific value. This could mean items may be ranked by how likely a user is to pick that option (for example, ordering labels by the number of times they've been used in that repository), or it could simply be in alphabetical order.
 
 If multiple values can be selected, the default behavior is to move the selected items to the top of the list after the menu is closed. If this sorting logic is not helpful for your use case, you may override this behavior with a more appropriate sorting logic.
 

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -3,8 +3,8 @@ title: Components
 ---
 
 import {Box, Link, Text, Label} from '@primer/react'
-import {Grid} from '@primer/react/deprecated'
-import {Flex} from '@primer/react/deprecated'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -2,13 +2,11 @@
 title: Components
 ---
 
-import { Grid, Box, Link, Text, Label } from '@primer/react'
+import {Box, Link, Text, Label} from '@primer/react'
+import {Grid} from '@primer/react/deprecated'
+import {Flex} from '@primer/react/deprecated'
 
-<Grid gridTemplateColumns
-
-import { Flex } from '@primer/react/deprecated';
-
-={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
     <Link href="/design/components/action-list">
       <img

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -2,48 +2,74 @@
 title: Components
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
-
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
-    <div>
-        <Link href="/design/components/action-list">
-            <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/components/action-list" fontWeight="bold">Action list</Link>
-        <Box as="p">An action list is a vertical list of interactive actions or options. It’s composed of items presented in a consistent single-column format, with room for icons, descriptions, side information, and other rich visuals.</Box>
-    </div>
-    <div>
-        <Link href="/design/components/autocomplete">
-            <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png" />
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/components/autocomplete" fontWeight="bold">Autocomplete</Link>
-        <Box as="p">Autocomplete inputs allow users to quickly filter through a list of options to pick one or more values for a field.</Box>
-    </div>
-    <div>
-        <Link href="/design/components/toggle-switch">
-            <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png" />
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/components/toggle-switch" fontWeight="bold">Toggle switch</Link>
-        <Box as="p">A toggle switch is used to immediately toggle a setting on or off.</Box>
-    </div>
-    <div>
-        <Link href="/design/components/tokens">
-            <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/components/tokens" fontWeight="bold">Tokens</Link>
-        <Box as="p">A token is a compact representation of an object, and is typically used to show a collection of related metadata.</Box>
-    </div>
+  <div>
+    <Link href="/design/components/action-list">
+      <img
+        role="presentation"
+        src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png"
+      />
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/components/action-list" fontWeight="bold">
+      Action list
+    </Link>
+    <Box as="p">
+      An action list is a vertical list of interactive actions or options. It’s composed of items presented in a
+      consistent single-column format, with room for icons, descriptions, side information, and other rich visuals.
+    </Box>
+  </div>
+  <div>
+    <Link href="/design/components/autocomplete">
+      <img
+        role="presentation"
+        src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png"
+      />
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/components/autocomplete" fontWeight="bold">
+      Autocomplete
+    </Link>
+    <Box as="p">
+      Autocomplete inputs allow users to quickly filter through a list of options to pick one or more values for a
+      field.
+    </Box>
+  </div>
+  <div>
+    <Link href="/design/components/toggle-switch">
+      <img
+        role="presentation"
+        src="https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png"
+      />
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/components/toggle-switch" fontWeight="bold">
+      Toggle switch
+    </Link>
+    <Box as="p">A toggle switch is used to immediately toggle a setting on or off.</Box>
+  </div>
+  <div>
+    <Link href="/design/components/tokens">
+      <img
+        role="presentation"
+        src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png"
+      />
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/components/tokens" fontWeight="bold">
+      Tokens
+    </Link>
+    <Box as="p">
+      A token is a compact representation of an object, and is typically used to show a collection of related metadata.
+    </Box>
+  </div>
 </Grid>
-
 
 <!--
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -2,9 +2,13 @@
 title: Components
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
+import { Grid, Box, Link, Text, Label } from '@primer/react'
 
-<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+<Grid gridTemplateColumns
+
+import { Flex } from '@primer/react/deprecated';
+
+={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
     <Link href="/design/components/action-list">
       <img

--- a/content/components/toggle-switch.mdx
+++ b/content/components/toggle-switch.mdx
@@ -3,7 +3,7 @@ title: Toggle switch
 description: A toggle switch is used to immediately toggle a setting on or off.
 ---
 
-import {Box, Text} from '@primer/components'
+import {Box, Text} from '@primer/react'
 
 ## Anatomy
 
@@ -17,81 +17,138 @@ import {Box, Text} from '@primer/components'
 
 ### Label and description
 
-<Box mb={5} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <div>
-    <Box as="p" mt="0">Every toggle switch should have a label that says what is being turned on or off. Optionally, you may include a description about the setting that is being turned on or off.</Box>
-    <Box as="p" mt="0">Labels should be succinct, and can describe an object or an action (for example: "Discussions" or "Automatically watch repositories"). Don't use phrases that describe the switch's state in your label.</Box>
-    </div>
-    <img
-        width="456"
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/159587115-5ffcdefb-f5e9-4180-8dc3-5328b0440f7f.png"
-    />
+<Box
+  mb={5}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <div>
+    <Box as="p" mt="0">
+      Every toggle switch should have a label that says what is being turned on or off. Optionally, you may include a
+      description about the setting that is being turned on or off.
+    </Box>
+    <Box as="p" mt="0">
+      Labels should be succinct, and can describe an object or an action (for example: "Discussions" or "Automatically
+      watch repositories"). Don't use phrases that describe the switch's state in your label.
+    </Box>
+  </div>
+  <img
+    width="456"
+    role="presentation"
+    src="https://user-images.githubusercontent.com/2313998/159587115-5ffcdefb-f5e9-4180-8dc3-5328b0440f7f.png"
+  />
 </Box>
 
 <DoDontContainer>
   <Do>
-    <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159587088-99e8fe4c-59a3-4452-836d-bd6f2297045a.png" />
+    <img
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587088-99e8fe4c-59a3-4452-836d-bd6f2297045a.png"
+    />
     <Caption>Use succinct phrases with verbs or nouns</Caption>
   </Do>
   <Dont>
-    <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159587096-5f8a6913-df95-4ea0-9838-a366faf95e52.png" />
+    <img
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587096-5f8a6913-df95-4ea0-9838-a366faf95e52.png"
+    />
     <Caption>Don't use phrases that describe the switch's state</Caption>
   </Dont>
 </DoDontContainer>
 
 ### Layout
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <div>
-        <Box as="p" mt="0">By default, lay out a toggle switch horizontally justified with its label and optional description.</Box>
-        <Box as="p" mt="0">You may use a vertical layout when a toggle switch is layed out inline with other content, or if a horizontal layout would put the switch too far from its label. If the vertical layout is left-aligned, the "on"/"off" text may be moved to the right of the switch.</Box>
-    </div>
-    <Box display="flex" flexDirection="column" sx={{gap: 2, flexGrow: 1, flexShrink: 0}}>
-        <img
-            width="456"
-            role="presentation"
-            src="https://user-images.githubusercontent.com/2313998/159587115-5ffcdefb-f5e9-4180-8dc3-5328b0440f7f.png"
-        />
-        <img
-            width="456"
-            role="presentation"
-            src="https://user-images.githubusercontent.com/2313998/159587126-8d30ff26-33a8-4b84-87db-13dcfdff9dac.png"
-        />
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <div>
+    <Box as="p" mt="0">
+      By default, lay out a toggle switch horizontally justified with its label and optional description.
     </Box>
+    <Box as="p" mt="0">
+      You may use a vertical layout when a toggle switch is layed out inline with other content, or if a horizontal
+      layout would put the switch too far from its label. If the vertical layout is left-aligned, the "on"/"off" text
+      may be moved to the right of the switch.
+    </Box>
+  </div>
+  <Box display="flex" flexDirection="column" sx={{gap: 2, flexGrow: 1, flexShrink: 0}}>
+    <img
+      width="456"
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587115-5ffcdefb-f5e9-4180-8dc3-5328b0440f7f.png"
+    />
+    <img
+      width="456"
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587126-8d30ff26-33a8-4b84-87db-13dcfdff9dac.png"
+    />
+  </Box>
 </Box>
 
 ### Size
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <Box as="p" mt="0">A small variant is provided to maintain visual hierarchy, or for dense areas where the default size will not fit.</Box>
-    <img
-        width="456"
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/159587124-e7ef0a16-fd42-4614-be3e-80c985332ef7.png"
-    />
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <Box as="p" mt="0">
+    A small variant is provided to maintain visual hierarchy, or for dense areas where the default size will not fit.
+  </Box>
+  <img
+    width="456"
+    role="presentation"
+    src="https://user-images.githubusercontent.com/2313998/159587124-e7ef0a16-fd42-4614-be3e-80c985332ef7.png"
+  />
 </Box>
 
 ### Loading
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <Box as="p" mt="0">When a toggle switch is waiting for something to load before toggling, a loading indicator should be displayed. The switch should not prematurely toggle from "on" to "off". Wait until loading is complete before showing a change.</Box>
-    <img
-        width="456"
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/159587116-aa07a847-a633-4515-82b3-20ebe2349914.png"
-    />
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <Box as="p" mt="0">
+    When a toggle switch is waiting for something to load before toggling, a loading indicator should be displayed. The
+    switch should not prematurely toggle from "on" to "off". Wait until loading is complete before showing a change.
+  </Box>
+  <img
+    width="456"
+    role="presentation"
+    src="https://user-images.githubusercontent.com/2313998/159587116-aa07a847-a633-4515-82b3-20ebe2349914.png"
+  />
 </Box>
 
 ### Progressive disclosure
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <Box as="p" mt="0">The <a href="/ui-patterns/progressive-disclosure">progressive disclosure pattern</a> may be used to hide or show content based on whether a toggle switch is on. Content revealed on toggle switch activation should always come <em>after</em> the toggle switch.</Box>
-    <img
-        width="456"
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/159591632-f604ec1d-aca9-42f7-ad65-16f8811f192f.png"
-    />
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <Box as="p" mt="0">
+    The <a href="/ui-patterns/progressive-disclosure">progressive disclosure pattern</a> may be used to hide or show
+    content based on whether a toggle switch is on. Content revealed on toggle switch activation should always come{' '}
+    <em>after</em> the toggle switch.
+  </Box>
+  <img
+    width="456"
+    role="presentation"
+    src="https://user-images.githubusercontent.com/2313998/159591632-f604ec1d-aca9-42f7-ad65-16f8811f192f.png"
+  />
 </Box>
 
 ## Accessibility
@@ -114,14 +171,19 @@ If you have a group of configuration options that can be disabled, use a button 
 
 ![Configuration options section that can be enabled or disabled. Configuration controls are hidden when it is disabled.](https://user-images.githubusercontent.com/2313998/159587120-2d842830-18c7-4429-bd10-f5424f6fac9e.png)
 
-
 <DoDontContainer>
   <Do>
-    <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159587100-1a1af5b2-dd19-456a-a0ed-c2f9fa7f7c2e.png" />
+    <img
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587100-1a1af5b2-dd19-456a-a0ed-c2f9fa7f7c2e.png"
+    />
     <Caption>Use a button to affect multiple related toggles</Caption>
   </Do>
   <Dont>
-    <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159587101-446548c2-41c3-45c1-b710-db3149e2ebe4.png" />
+    <img
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587101-446548c2-41c3-45c1-b710-db3149e2ebe4.png"
+    />
     <Caption>Don't use a toggle switch to represent mixed values</Caption>
   </Dont>
 </DoDontContainer>
@@ -135,11 +197,17 @@ A toggle switch should never be used as a replacement for a checkbox. See [savin
 
 <DoDontContainer>
   <Do>
-    <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159587105-45d50974-eb76-46cd-a3fd-c1e0f605f3ef.png" />
+    <img
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587105-45d50974-eb76-46cd-a3fd-c1e0f605f3ef.png"
+    />
     <Caption>Use a toggle switch like a button</Caption>
   </Do>
   <Dont>
-    <img role="presentation" src="https://user-images.githubusercontent.com/2313998/159587113-6c8461f7-3d4d-4e6a-b3a5-c585c5143fba.png" />
+    <img
+      role="presentation"
+      src="https://user-images.githubusercontent.com/2313998/159587113-6c8461f7-3d4d-4e6a-b3a5-c585c5143fba.png"
+    />
     <Caption>Don't use a toggle switch as a replacement for a checkbox</Caption>
   </Dont>
 </DoDontContainer>

--- a/content/components/tokens.mdx
+++ b/content/components/tokens.mdx
@@ -13,26 +13,35 @@ import {LabelGroup, Label, Box} from '@primer/react'
   <Label
     as="a"
     href="https://primer.style/components/Token"
-    variant="xl"
-    color="text.success"
-    outline
-    style="text-decoration: none; line-height: 20px;"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
   >
     <img
-      width="20"
-      height="20"
+      width="16"
+      height="16"
       alt=" "
       src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
       style="vertical-align: middle; margin-right: 4px;"
     />
     React
   </Label>
-  {/* TODO: uncomment once React and Figma docs are live
-    <Label as="a" href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0" variant="xl" outline style="text-decoration: none; line-height: 20px;">
-        <img width="20" height="20" alt=" " src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png" style="vertical-align: middle; margin-right: 4px;" />
-        Figma
-    </Label>
-    */}
+  <Label
+    as="a"
+    href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0"
+    variant="secondary"
+    size="large"
+    style="text-decoration: none;"
+  >
+    <img
+      width="16"
+      height="16"
+      alt=" "
+      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    Figma
+  </Label>
 </LabelGroup>
 
 ## Overview

--- a/content/components/tokens.mdx
+++ b/content/components/tokens.mdx
@@ -3,18 +3,31 @@ title: Tokens
 status: Alpha
 ---
 
-import {LabelGroup, Label, Box} from '@primer/components'
+import {LabelGroup, Label, Box} from '@primer/react'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
-    A token is a compact representation of an object, and is typically used to show a collection of related metadata.
+  A token is a compact representation of an object, and is typically used to show a collection of related metadata.
 </Box>
 
 <LabelGroup display="block" mb={4}>
-    <Label as="a" href="https://primer.style/components/Token" variant="xl" color="text.success" outline style="text-decoration: none; line-height: 20px;">
-        <img width="20" height="20" alt=" " src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png" style="vertical-align: middle; margin-right: 4px;" />
-        React
-    </Label>
-    {/* TODO: uncomment once React and Figma docs are live
+  <Label
+    as="a"
+    href="https://primer.style/components/Token"
+    variant="xl"
+    color="text.success"
+    outline
+    style="text-decoration: none; line-height: 20px;"
+  >
+    <img
+      width="20"
+      height="20"
+      alt=" "
+      src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    React
+  </Label>
+  {/* TODO: uncomment once React and Figma docs are live
     <Label as="a" href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0" variant="xl" outline style="text-decoration: none; line-height: 20px;">
         <img width="20" height="20" alt=" " src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png" style="vertical-align: middle; margin-right: 4px;" />
         Figma
@@ -23,6 +36,7 @@ import {LabelGroup, Label, Box} from '@primer/components'
 </LabelGroup>
 
 ## Overview
+
 Tokens almost always appear in a group. A group of tokens may be read-only, or they may be used as a way to input data.
 
 A read-only group of tokens organizes information in a way that helps users quickly scan and understand the view they're on. For example, a list of topics associated with a repository.
@@ -30,20 +44,33 @@ A read-only group of tokens organizes information in a way that helps users quic
 Tokens may be used for data input to quickly add and remove items to a list of related attributes. For example, defining a list of GitHub users who can access a private repo.
 
 ## Anatomy
-<Box display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 2}}>
-    <img
-        width="456"
-        alt="token anatomy diagram"
-        src="https://user-images.githubusercontent.com/2313998/137778682-ee35f8e0-72de-4a24-b1bd-e4ea02e2ac49.png"
-    />
-    <Box as="ul" mt="0">
-        <Box as="li" mt="0"><strong>Leading visual</strong> (optional): Provides additional context (e.g.: user avatar)</Box>
-        <Box as="li"><strong>Label</strong> (required): Concise text label</Box>
-        <Box as="li"><strong>Remove button</strong> (optional): Removes the token from an editable group of tokens</Box>
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 2}}
+>
+  <img
+    width="456"
+    alt="token anatomy diagram"
+    src="https://user-images.githubusercontent.com/2313998/137778682-ee35f8e0-72de-4a24-b1bd-e4ea02e2ac49.png"
+  />
+  <Box as="ul" mt="0">
+    <Box as="li" mt="0">
+      <strong>Leading visual</strong> (optional): Provides additional context (e.g.: user avatar)
     </Box>
+    <Box as="li">
+      <strong>Label</strong> (required): Concise text label
+    </Box>
+    <Box as="li">
+      <strong>Remove button</strong> (optional): Removes the token from an editable group of tokens
+    </Box>
+  </Box>
 </Box>
 
 ## Interactivity
+
 Tokens are almost always interactive. When a token is interactive, it will react to cursor hover and keyboard focus.
 
 While tokens may have the same interactivity as a button or a link, a token should not be used as a replacement for a button.
@@ -51,71 +78,125 @@ While tokens may have the same interactivity as a button or a link, a token shou
 If a token is a link or button _and_ it has a remove button, keyboard focus will only go to the link/button. Keyboard users can remove a token by focusing the link/button and pressing "Backspace" or "Delete". When a screen reader is focused on a removable token, it will read the token's label and tell users to press "Backspace" or "Delete" to remove it.
 
 Examples of interactions:
+
 - An issue label token that links to a list of issues with that label
 - A user token that shows a profile summary dialog on hover
 
 ## Sizing
 
-<Box display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="tokens rendered at all sizes"
-        src="https://user-images.githubusercontent.com/2313998/137771748-ee4d796a-7bf0-4384-bb75-a239f358ede6.png"
-    />
-    <Box>
-        <Box as="p" mt="0">Different token sizes can be used to maintain visual harmony with the other content on the screen or to maintain a comfortable touch target for interactive tokens.</Box>
-        <Box as="p">Keep visual hierarchy in mind. Large tokens should not visually compete with elements that have a higher priority.</Box>
-        <Box as="p">A group of tokens should not have tokens of different sizes.</Box>
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="tokens rendered at all sizes"
+    src="https://user-images.githubusercontent.com/2313998/137771748-ee4d796a-7bf0-4384-bb75-a239f358ede6.png"
+  />
+  <Box>
+    <Box as="p" mt="0">
+      Different token sizes can be used to maintain visual harmony with the other content on the screen or to maintain a
+      comfortable touch target for interactive tokens.
     </Box>
+    <Box as="p">
+      Keep visual hierarchy in mind. Large tokens should not visually compete with elements that have a higher priority.
+    </Box>
+    <Box as="p">A group of tokens should not have tokens of different sizes.</Box>
+  </Box>
 </Box>
 
 ## Grouping tokens
-<Box display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="tokens rendered at all sizes"
-        src="https://user-images.githubusercontent.com/2313998/137771744-ee968841-8b5c-437c-83cc-9f693e35e5f0.png"
-    />
-    <Box>
-        <Box as="p" mt="0">A group of tokens should flow like words in a paragraph, not a vertical list. This keeps the group compact to improve scannability.</Box>
-        <Box as="p">Tokens that represent different types of data should not be grouped together.</Box>
-        <Box as="p">Interactive tokens should not be grouped with non-interactive tokens.</Box>
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="tokens rendered at all sizes"
+    src="https://user-images.githubusercontent.com/2313998/137771744-ee968841-8b5c-437c-83cc-9f693e35e5f0.png"
+  />
+  <Box>
+    <Box as="p" mt="0">
+      A group of tokens should flow like words in a paragraph, not a vertical list. This keeps the group compact to
+      improve scannability.
     </Box>
+    <Box as="p">Tokens that represent different types of data should not be grouped together.</Box>
+    <Box as="p">Interactive tokens should not be grouped with non-interactive tokens.</Box>
+  </Box>
 </Box>
 
 ### Within a text input field
-<Box display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="tokens rendered at all sizes"
-        src="https://user-images.githubusercontent.com/2313998/137771745-049129e6-5a79-4940-bf1b-633e0c203109.png"
-    />
-    <Box>
-        <Box as="p" mt="0">By default, tokens wrap to the next line and expand the height of the input. This allows users to see many tokens at once.</Box>
-        <Box as="p">To limit how large the input can grow, a maximum height can be defined. After the input grows past that maximum height, it will scroll vertically.</Box>
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="tokens rendered at all sizes"
+    src="https://user-images.githubusercontent.com/2313998/137771745-049129e6-5a79-4940-bf1b-633e0c203109.png"
+  />
+  <Box>
+    <Box as="p" mt="0">
+      By default, tokens wrap to the next line and expand the height of the input. This allows users to see many tokens
+      at once.
     </Box>
+    <Box as="p">
+      To limit how large the input can grow, a maximum height can be defined. After the input grows past that maximum
+      height, it will scroll vertically.
+    </Box>
+  </Box>
 </Box>
 
-<Box display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="tokens rendered at all sizes"
-        src="https://user-images.githubusercontent.com/2313998/137771747-6ed54c3b-ddc7-42d2-ad55-db702c8d8093.png"
-    />
-    <Box as="p" mt="0">If the input is being used in a spot where the input height cannot grow, tokens can be forced to a single line that scrolls horizontally.</Box>
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="tokens rendered at all sizes"
+    src="https://user-images.githubusercontent.com/2313998/137771747-6ed54c3b-ddc7-42d2-ad55-db702c8d8093.png"
+  />
+  <Box as="p" mt="0">
+    If the input is being used in a spot where the input height cannot grow, tokens can be forced to a single line that
+    scrolls horizontally.
+  </Box>
 </Box>
-
 
 ## Tokens as a way to enter information
-<Box display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 4}}>
-    <img
-        width="456"
-        alt="text input with tokens inside with an autocomplete menu below it"
-        src="https://user-images.githubusercontent.com/2313998/137771742-0d6553f2-1d34-44c2-bfcb-f39c56b5b3d1.png"
-    />
-    <Box>
-        <Box as="p" mt="0">If tokens are being used for data input, it should be obvious that the user is in an edit or creation context.</Box>
-        <Box as="p">Tokens can be added or removed from a group in the way that makes the most sense for your use case. We recommend using an <a href="/autocomplete">autocomplete</a> component to allow users to sort through a list to pick options.</Box>
-        <Box as="p">The remove button is the recommended way for removing a token from a group, but you can hide it if there is a simple alternative that makes more sense for your use case. You can also keep the remove button visible while still providing other ways to remove the button from a group.</Box>
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 4}}
+>
+  <img
+    width="456"
+    alt="text input with tokens inside with an autocomplete menu below it"
+    src="https://user-images.githubusercontent.com/2313998/137771742-0d6553f2-1d34-44c2-bfcb-f39c56b5b3d1.png"
+  />
+  <Box>
+    <Box as="p" mt="0">
+      If tokens are being used for data input, it should be obvious that the user is in an edit or creation context.
     </Box>
+    <Box as="p">
+      Tokens can be added or removed from a group in the way that makes the most sense for your use case. We recommend
+      using an <a href="/autocomplete">autocomplete</a> component to allow users to sort through a list to pick options.
+    </Box>
+    <Box as="p">
+      The remove button is the recommended way for removing a token from a group, but you can hide it if there is a
+      simple alternative that makes more sense for your use case. You can also keep the remove button visible while
+      still providing other ways to remove the button from a group.
+    </Box>
+  </Box>
 </Box>

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -7,12 +7,15 @@ title: Color
   patterns, and abstractions that make Primer’s color system.
 </Box>
 
-import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
+import { Grid, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link } from '@primer/react'
 
 ## Get started
 
 <img
   width="960"
+
+import { Flex } from '@primer/react/deprecated';
+
   alt="Image showing the two different types of color modes: light mode and dark mode"
   src="https://user-images.githubusercontent.com/6951037/146927448-cb518377-114a-4ab8-a37e-1eeffc8732c7.png"
 />

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -7,13 +7,14 @@ title: Color
   patterns, and abstractions that make Primer’s color system.
 </Box>
 
-import { Grid, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link } from '@primer/react'
+import { Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link } from '@primer/react'
 
 ## Get started
 
 <img
   width="960"
 
+import { Grid } from '@primer/react/deprecated';
 import { Flex } from '@primer/react/deprecated';
 
   alt="Image showing the two different types of color modes: light mode and dark mode"

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -2,21 +2,20 @@
 title: Color
 ---
 
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
+
 <Box sx={{fontSize: 3}} class="lead" as="p">
   Color is a fundamental piece in the Primer visual language. In this guide you will learn about the principles,
   patterns, and abstractions that make Primer’s color system.
 </Box>
 
-import { Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link } from '@primer/react'
+import {Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
 
 ## Get started
 
 <img
   width="960"
-
-import { Grid } from '@primer/react/deprecated';
-import { Flex } from '@primer/react/deprecated';
-
   alt="Image showing the two different types of color modes: light mode and dark mode"
   src="https://user-images.githubusercontent.com/6951037/146927448-cb518377-114a-4ab8-a37e-1eeffc8732c7.png"
 />

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -7,11 +7,15 @@ title: Color
   patterns, and abstractions that make Primer’s color system.
 </Box>
 
-import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/components'
+import {Grid, Flex, Box, Button, ButtonOutline, Heading, Label, LabelGroup, Link} from '@primer/react'
 
 ## Get started
 
-<img width="960" alt="Image showing the two different types of color modes: light mode and dark mode" src="https://user-images.githubusercontent.com/6951037/146927448-cb518377-114a-4ab8-a37e-1eeffc8732c7.png" />
+<img
+  width="960"
+  alt="Image showing the two different types of color modes: light mode and dark mode"
+  src="https://user-images.githubusercontent.com/6951037/146927448-cb518377-114a-4ab8-a37e-1eeffc8732c7.png"
+/>
 
 GitHub's UI offers a variety of different color modes. When designing product interfaces, you should design in light mode by default. Every pattern in Primer is built to work across all color modes out of the box.
 
@@ -27,7 +31,7 @@ Primer delivers colors in the form of [variables](https://primer.style/primitive
 
 - **Functional:** To convey a meaning or a state. For example, from a functional perspective the color green is used to reinforce positive messaging. In a functional system, green variables are named with the suffix `.success`.
 - **Presentational:** To represent a color. For example, the color steps in the Primer scale are named by color and lightness, such as `scale.blue.5`. These variables don't currently support color modes.
-As the system grows, it will provide more APIs that fit different color needs. Check the [Primer Primitives](https://github.com/primer/primitives/releases/) repository to follow along as we release new variables and systems.
+  As the system grows, it will provide more APIs that fit different color needs. Check the [Primer Primitives](https://github.com/primer/primitives/releases/) repository to follow along as we release new variables and systems.
 
 ### Functional system
 
@@ -36,9 +40,9 @@ The functional system is based on the meaning, or purpose, that colors have in t
 - **Foundations:** Foregrounds, backgrounds, and borders that make up most of a product interface. Each variable is generated based on visual weight.
 
 <img
-width="960"
-alt="Dark gray, midtone gray and light gray swatches as example of foundational colors"
-src="https://user-images.githubusercontent.com/6951037/146926823-b8489e82-978d-4aed-b186-2dcc70691fc7.png"
+  width="960"
+  alt="Dark gray, midtone gray and light gray swatches as example of foundational colors"
+  src="https://user-images.githubusercontent.com/6951037/146926823-b8489e82-978d-4aed-b186-2dcc70691fc7.png"
 />
 
 - **Color roles:** Foregrounds, backgrounds, and borders that highlight affordance or the meaning of elements in the UI.
@@ -61,9 +65,9 @@ Foreground elements are **text and icons**. You can apply color to them using an
 
 | Foundations                                                                       | Usage                                                                                                                                |
 | :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.default) `fg.default`         | Primary color for text and icons in any given interface. It should be used for body content, titles and labels.                      |
+| ![](https://swatch-sid.vercel.app?mode=light&token=fg.default) `fg.default`       | Primary color for text and icons in any given interface. It should be used for body content, titles and labels.                      |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.muted) `fg.muted`           | Use for content that is secondary or that provides additional context but is not critical to understanding the flow of an interface. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`           | Use for placeholder text, icons or decorative foregrounds. |
+| ![](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`         | Use for placeholder text, icons or decorative foregrounds.                                                                           |
 | ![](https://swatch-sid.vercel.app?mode=light&token=fg.onEmphasis) `fg.onEmphasis` | On emphasis is the text color designed to combine with `-emphasis` backgrounds for optimal contrast.                                 |
 
 | Color roles                                                                     | Usage                                                               |
@@ -73,54 +77,52 @@ Foreground elements are **text and icons**. You can apply color to them using an
 | ![](https://swatch-sid.vercel.app?mode=light&token=attention.fg) `fg.attention` | Use to highlight text or icons that require the user's attention.   |
 | ![](https://swatch-sid.vercel.app?mode=light&token=danger.fg) `fg.danger`       | Use to emphasize an error or a blocking status. Action is required. |
 | ![](https://swatch-sid.vercel.app?mode=light&token=severe.fg) `fg.severe`       | Use to emphasize a level of severity between attention and danger.  |
-| ![](https://swatch-sid.vercel.app?mode=light&token=open.fg) `fg.open`           | Use to style text that refers to open tasks or workflows.      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=closed.fg) `fg.closed`       | Use to style text that refers to closed tasks or workflows.      |
+| ![](https://swatch-sid.vercel.app?mode=light&token=open.fg) `fg.open`           | Use to style text that refers to open tasks or workflows.           |
+| ![](https://swatch-sid.vercel.app?mode=light&token=closed.fg) `fg.closed`       | Use to style text that refers to closed tasks or workflows.         |
 | ![](https://swatch-sid.vercel.app?mode=light&token=done.fg) `fg.done`           | Use to style text that refers to completed tasks or workflows.      |
 
 ### Backgrounds
 
 Background colors apply to surfaces of components or UI elements, such as pages, boxes, and overlays.
 
-| Foundations     | Usage                                                                                                              |
-| :-------------- | :----------------------------------------------------------------------------------------------------------------- |
+| Foundations                                                                            | Usage                                                                                                              |
+| :------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
 | ![](https://swatch-sid.vercel.app?mode=light&token=neutral.emphasisPlus) `bg.emphasis` | Provides the highest contrast against the default background, such as in tooltips.                                 |
-| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.default) `bg.default`    | Primary background color.                                                                                          |
-| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.subtle) `bg.subtle`     | Provides visual rest and contrast against the default background.                                                  |
-| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.inset) `bg.inset`      | Can be used instead of the default background to create a focal point, such as in conversations or activity feeds. |
+| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.default) `bg.default`        | Primary background color.                                                                                          |
+| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.subtle) `bg.subtle`          | Provides visual rest and contrast against the default background.                                                  |
+| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.inset) `bg.inset`            | Can be used instead of the default background to create a focal point, such as in conversations or activity feeds. |
 
-
-
-| Color roles                                                    | Usage                                                                          |
-| :------------------------------------------------------------- | :----------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.subtle) `bg.accent`| Use to accentuate interactive areas in the UI like selected elements.          |
-| ![](https://swatch-sid.vercel.app?mode=light&token=success.subtle) `bg.success`                                                   | Use to highlight a positive message.                                           |
-| ![](https://swatch-sid.vercel.app?mode=light&token=attention.subtle) `bg.attention`                                                 | Use to highlight elements that require a user's attention or pending statuses. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=danger.subtle) `bg.danger`                                                    | Use to emphasize an error or a blocking status, where action is required.      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=severe.subtle) `bg.severe`                                                    | Use to emphasize an extra level of severity between attention and danger.      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=open.subtle) `bg.open`                                                      | Use to style text that refers to open tasks or workflows.                 |
-| ![](https://swatch-sid.vercel.app?mode=light&token=closed.subtle) `bg.closed`                                                  | Use to style text that refers to closed tasks or workflows.                 |
-| ![](https://swatch-sid.vercel.app?mode=light&token=done.subtle) `bg.done`                                                      | Use to style text that refers to completed tasks or workflows.                 |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `bg.[ANY_OF_ABOVE].emphasis`                                   | Use to highlight the most important item of a view or an interface.            |
+| Color roles                                                                                      | Usage                                                                          |
+| :----------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| ![](https://swatch-sid.vercel.app?mode=light&token=accent.subtle) `bg.accent`                    | Use to accentuate interactive areas in the UI like selected elements.          |
+| ![](https://swatch-sid.vercel.app?mode=light&token=success.subtle) `bg.success`                  | Use to highlight a positive message.                                           |
+| ![](https://swatch-sid.vercel.app?mode=light&token=attention.subtle) `bg.attention`              | Use to highlight elements that require a user's attention or pending statuses. |
+| ![](https://swatch-sid.vercel.app?mode=light&token=danger.subtle) `bg.danger`                    | Use to emphasize an error or a blocking status, where action is required.      |
+| ![](https://swatch-sid.vercel.app?mode=light&token=severe.subtle) `bg.severe`                    | Use to emphasize an extra level of severity between attention and danger.      |
+| ![](https://swatch-sid.vercel.app?mode=light&token=open.subtle) `bg.open`                        | Use to style text that refers to open tasks or workflows.                      |
+| ![](https://swatch-sid.vercel.app?mode=light&token=closed.subtle) `bg.closed`                    | Use to style text that refers to closed tasks or workflows.                    |
+| ![](https://swatch-sid.vercel.app?mode=light&token=done.subtle) `bg.done`                        | Use to style text that refers to completed tasks or workflows.                 |
+| ![](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `bg.[ANY_OF_ABOVE].emphasis` | Use to highlight the most important item of a view or an interface.            |
 
 ### Borders
 
 Borders can be used to group content or to create a visible separation between sections or items. They’re most commonly used on tables, side sections, and cards.
 
-| Foundations      | Usage                                                                                                                                 |
-| :--------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| Foundations                                                                         | Usage                                                                                                                                 |
+| :---------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
 | ![](https://swatch-sid.vercel.app?mode=light&token=border.default) `border.default` | Use to create bounds around content, for example elements inside a card. Default borders are critical to understanding a page layout. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=border.muted) `border.muted`   | Use for dividers to emphasize the separation between items, columns or sections.                                                      |
+| ![](https://swatch-sid.vercel.app?mode=light&token=border.muted) `border.muted`     | Use for dividers to emphasize the separation between items, columns or sections.                                                      |
 
-| Color roles              | Usage                                                                         |
-| :----------------------- | :---------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.muted) `border.accent`          | Use to accentuate interactive areas in the UI like selected elements.         |
-| ![](https://swatch-sid.vercel.app?mode=light&token=success.muted) `border.success`         | Use to highlight a positive message.                                          |
+| Color roles                                                                                  | Usage                                                                         |
+| :------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| ![](https://swatch-sid.vercel.app?mode=light&token=accent.muted) `border.accent`             | Use to accentuate interactive areas in the UI like selected elements.         |
+| ![](https://swatch-sid.vercel.app?mode=light&token=success.muted) `border.success`           | Use to highlight a positive message.                                          |
 | ![](https://swatch-sid.vercel.app?mode=light&token=attention.muted) `border.attention`       | Use to highlight elements that require a users attention or pending statuses. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=danger.muted) `border.danger`          | Use to emphasize an error or a blocking status. Action is required.           |
-| ![](https://swatch-sid.vercel.app?mode=light&token=severe.muted) `border.severe`          | Use to emphasize an extra level of severity between attention and danger.     |
-| ![](https://swatch-sid.vercel.app?mode=light&token=open.muted) `border.open`            | Use to style text that refers to open tasks or workflows.                |
-| ![](https://swatch-sid.vercel.app?mode=light&token=closed.muted) `border.closed`        | Use to style text that refers to closed tasks or workflows.                |
-| ![](https://swatch-sid.vercel.app?mode=light&token=done.muted) `border.done`            | Use to style text that refers to completed tasks or workflows.                |
+| ![](https://swatch-sid.vercel.app?mode=light&token=danger.muted) `border.danger`             | Use to emphasize an error or a blocking status. Action is required.           |
+| ![](https://swatch-sid.vercel.app?mode=light&token=severe.muted) `border.severe`             | Use to emphasize an extra level of severity between attention and danger.     |
+| ![](https://swatch-sid.vercel.app?mode=light&token=open.muted) `border.open`                 | Use to style text that refers to open tasks or workflows.                     |
+| ![](https://swatch-sid.vercel.app?mode=light&token=closed.muted) `border.closed`             | Use to style text that refers to closed tasks or workflows.                   |
+| ![](https://swatch-sid.vercel.app?mode=light&token=done.muted) `border.done`                 | Use to style text that refers to completed tasks or workflows.                |
 | ![](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `border.[ROLE].emphasis` | Use to highlight the most important item of a view or an interface.           |
 
 ## Functional system in action
@@ -172,7 +174,6 @@ Borders can be used to group content or to create a visible separation between s
 ## Combining colors
 
 Not all colors pair well with each other. There are combinations of backgrounds and foregrounds that guarantee compliance with WCAG contrast guidelines and a wide range of hierarchical relationships between elements. Never use color on its own to convey a message or meaning. Pair it with explicit text and icons instead.
-
 
 ### Pairing color roles
 

--- a/content/foundations/content.mdx
+++ b/content/foundations/content.mdx
@@ -2,8 +2,8 @@
 title: Content
 ---
 
-import {Box} from '@primer/components'
-import {Text} from '@primer/components'
+import {Box} from '@primer/react'
+import {Text} from '@primer/react'
 import Code from '@primer/gatsby-theme-doctocat/src/components/code'
 
 These guidelines are specific to and focused on GitHub product interfaces. Your first port of call for general content guidelines should be [GitHub’s Content Style Guide](https://brand.github.com/content/), followed by the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
@@ -13,18 +13,23 @@ These guidelines are specific to and focused on GitHub product interfaces. Your 
 Keep the following principles in mind when creating UI content for GitHub.
 
 ### 1. Keep it clear
+
 Aim for a seventh-grade or below reading level. This means you should write text that is straightforward, without trying to be creative with words.
 
 There are some useful tools you can use to test your content for simplicity and reading level:
+
 - [Grammarly](https://www.grammarly.com/)
 - [Hemingway](http://www.hemingwayapp.com/)
 - [Automatic Readability Checker](https://www.readabilityformulas.com/free-readability-formula-tests.php)
 
 ### 2. Keep it consistent
+
 Refer to the same actions, sections, labels, landing pages, and so on, the same way across the product. But don’t sacrifice clarity over consistency.
 
 ## Voice and tone
+
 GitHub’s voice is:
+
 - Clear but not cold
 - Conversational but not jargon-y
 - Inclusive but not disingenuous
@@ -32,13 +37,15 @@ GitHub’s voice is:
 
 Tone is how you express personality and mood depending on the situation. GitHub’s tone is almost always **informal and positive**, with adjustments when needed depending on the channel, audience, and emotional state of the audience.
 
-You should consider the context of when a user will read something, keeping in mind that: 
+You should consider the context of when a user will read something, keeping in mind that:
+
 - Humor isn’t welcome in all situations, for example: in errors, when waiting, or when something fails.
 - Error messages should be understandable by humans.
 
 Read more about GitHub’s voice and tone in the [Brand Guide](https://brand.github.com/content/voice).
 
 ## Top 10 rules
+
 If you’re in a hurry, these are the most important content guidelines to keep in mind, in no particular order.
 
 - Write in plain English, don’t sound like a robot.
@@ -55,8 +62,9 @@ If you’re in a hurry, these are the most important content guidelines to keep 
 ## Content guidelines
 
 ### Acronyms and abbreviations
+
 Use acronyms when they are more widely used than the spelled out term.
- 
+
 “Pull request” should never be abbreviated. It’s always lowercase unless it’s starting a sentence.
 
 <!-- TODO: Where do we abbreviate? Months -->
@@ -68,13 +76,16 @@ TODO: In which cases should the UI include alternative text that doesn’t come 
 Do not replace text with emojis.
 -->
 
-### Dates and time 
+### Dates and time
+
 When referring to times, use am and pm, and not any other variation (a.m., A.M., AM).
 
 <!-- TODO: Dates. -->
 
 ### Emojis
+
 Avoid using emojis, but when you do:
+
 - Use them only at the end of a sentence
 - Use only well-recognized emojis
 - Do not repeat emojis
@@ -83,112 +94,182 @@ Avoid using emojis, but when you do:
 <!-- See also alternative text. -->
 
 ### Error messages
+
 Be friendly and helpful, and avoid jargon. Do not blame the user.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Be friendly and helpful. Example: Enter a name, Your name must be between 2 and 20 characters" src="https://user-images.githubusercontent.com/10384315/125705639-f7b1633b-0292-4244-b89e-77bfc319fd5c.png"/>
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Blame the user and use jargon. Example: You forgot to add your name, Error 1234567890" src="https://user-images.githubusercontent.com/10384315/125705637-46f0f425-ce56-4cf1-a270-0cba9be2a0e6.png"/>
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Be friendly and helpful. Example: Enter a name, Your name must be between 2 and 20 characters"
+      src="https://user-images.githubusercontent.com/10384315/125705639-f7b1633b-0292-4244-b89e-77bfc319fd5c.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Blame the user and use jargon. Example: You forgot to add your name, Error 1234567890"
+      src="https://user-images.githubusercontent.com/10384315/125705637-46f0f425-ce56-4cf1-a270-0cba9be2a0e6.png"
+    />
+  </Dont>
 </DoDontContainer>
 
 Be specific.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Be specific. Example: Enter a credit card number" src="https://user-images.githubusercontent.com/10384315/125707971-28e57b6a-c236-4aa1-afc2-dccda4dd1902.png"/>   
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Be vague. Example: Field required" src="https://user-images.githubusercontent.com/10384315/125707969-a1ddcf5a-58e9-410b-81cf-a6433ace8420.png"/>    
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Be specific. Example: Enter a credit card number"
+      src="https://user-images.githubusercontent.com/10384315/125707971-28e57b6a-c236-4aa1-afc2-dccda4dd1902.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Be vague. Example: Field required"
+      src="https://user-images.githubusercontent.com/10384315/125707969-a1ddcf5a-58e9-410b-81cf-a6433ace8420.png"
+    />
+  </Dont>
 </DoDontContainer>
 
 In most cases, apologizing won't fix the problem. As a rule, do not apologize too much in any situation in the UI.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: State what has happened. Example: All checks failed" src="https://user-images.githubusercontent.com/10384315/125705636-24363aa4-a064-4242-86fa-e315ca72f8ed.png"/>  
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Do not apologize excessively in the UI. Example: Sorry, all checks failed" src="https://user-images.githubusercontent.com/10384315/125705635-c1910a2e-6810-4b56-b29f-f918a4543bef.png"/>   
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: State what has happened. Example: All checks failed"
+      src="https://user-images.githubusercontent.com/10384315/125705636-24363aa4-a064-4242-86fa-e315ca72f8ed.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Do not apologize excessively in the UI. Example: Sorry, all checks failed"
+      src="https://user-images.githubusercontent.com/10384315/125705635-c1910a2e-6810-4b56-b29f-f918a4543bef.png"
+    />
+  </Dont>
 </DoDontContainer>
 
 Do not try to be funny or humorous.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Clearly state the outcome. Example: Some checks failed" src="https://user-images.githubusercontent.com/10384315/125705634-aa90dfb2-afb8-4023-97f6-98682a0ac1c3.png"/> 
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Try to be humorous or funny. Example: Oops, some checks failed" src="https://user-images.githubusercontent.com/10384315/125705633-d4b75c6d-7299-4192-b15c-88e9f9b36eac.png"/>   
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Clearly state the outcome. Example: Some checks failed"
+      src="https://user-images.githubusercontent.com/10384315/125705634-aa90dfb2-afb8-4023-97f6-98682a0ac1c3.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Try to be humorous or funny. Example: Oops, some checks failed"
+      src="https://user-images.githubusercontent.com/10384315/125705633-d4b75c6d-7299-4192-b15c-88e9f9b36eac.png"
+    />
+  </Dont>
 </DoDontContainer>
 
-### Feedback 
+### Feedback
+
 Feedback should be clear and reassuring, using the same terms used by the UI elements that triggered it. Don't try to be funny, and avoid jargon.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Write feedback to be clear and reassuring. Example: Issue transfer in progress" src="https://user-images.githubusercontent.com/10384315/125705630-b26ef02a-6110-4b58-8bce-d4a45bfc7c05.png"/>
-  <Caption>Feedback message when transferring an issue, using the same term ("transfer") as the trigger button</Caption>
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Use language in feedback that is different from its trigger. Example: Moving the issue" src="https://user-images.githubusercontent.com/10384315/125705629-78c436df-76ab-4dab-9ca8-966835c4de10.png"/> 
-  <Caption>Feedback message that uses a different term ("moving") than the trigger button</Caption>
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Write feedback to be clear and reassuring. Example: Issue transfer in progress"
+      src="https://user-images.githubusercontent.com/10384315/125705630-b26ef02a-6110-4b58-8bce-d4a45bfc7c05.png"
+    />
+    <Caption>
+      Feedback message when transferring an issue, using the same term ("transfer") as the trigger button
+    </Caption>
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Use language in feedback that is different from its trigger. Example: Moving the issue"
+      src="https://user-images.githubusercontent.com/10384315/125705629-78c436df-76ab-4dab-9ca8-966835c4de10.png"
+    />
+    <Caption>Feedback message that uses a different term ("moving") than the trigger button</Caption>
+  </Dont>
 </DoDontContainer>
 
 <!-- TODO: More confirmation messages. Save, close, dismiss. -->
 
 ### Forms
+
 Use sentence case for form titles, labels, and fields.
 Do not include colons in form labels.
 
 <!-- TODO: Error messages, form validation examples. -->
 
 ### Labels and buttons
+
 All labels and button text should be in sentence case, and not include punctuation.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Leave out punctuation in labels and buttons. Example: Save email preferences, 1 linked pull request, 12 days ago" src="https://user-images.githubusercontent.com/10384315/125705627-5396a0fc-891f-4e22-8add-ead2a1a621f1.png"/>   
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Include punctuation in labels and buttons. Example: Save email preferences., 1 Linked pull request, 12 Days ago" src="https://user-images.githubusercontent.com/10384315/125705625-1ecfde99-9d8f-4566-97b3-3959e78b2c45.png"/> 
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Leave out punctuation in labels and buttons. Example: Save email preferences, 1 linked pull request, 12 days ago"
+      src="https://user-images.githubusercontent.com/10384315/125705627-5396a0fc-891f-4e22-8add-ead2a1a621f1.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Include punctuation in labels and buttons. Example: Save email preferences., 1 Linked pull request, 12 Days ago"
+      src="https://user-images.githubusercontent.com/10384315/125705625-1ecfde99-9d8f-4566-97b3-3959e78b2c45.png"
+    />
+  </Dont>
 </DoDontContainer>
 
-<Note>When a sentence or label starts with a number (for example, “2 references”), the number is the first word, and the rest of the sentence should be in lowercase.</Note>
+<Note>
+  When a sentence or label starts with a number (for example, “2 references”), the number is the first word, and the
+  rest of the sentence should be in lowercase.
+</Note>
 
 Action labels should start with an imperative verb that clearly indicates what to expect.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Start action labels with an imperative verb. Example: Save preferences" src="https://user-images.githubusercontent.com/10384315/125705622-1b7f24d2-423a-4616-9b43-2c48e01c2ca1.png"/>
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Start action labels with an imperative verb. Example: Save preferences"
+      src="https://user-images.githubusercontent.com/10384315/125705622-1b7f24d2-423a-4616-9b43-2c48e01c2ca1.png"
+    />
+  </Do>
 </DoDontContainer>
 
 Action labels can be shortened to only include an adjective and a noun.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Shorten action labels. Example: New issue" src="https://user-images.githubusercontent.com/10384315/125705620-379acdd5-2e62-4e30-8e2d-ad2211e768b9.png"/>
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Shorten action labels. Example: New issue"
+      src="https://user-images.githubusercontent.com/10384315/125705620-379acdd5-2e62-4e30-8e2d-ad2211e768b9.png"
+    />
+  </Do>
 </DoDontContainer>
 
 Use “sign in” rather than “log in”.
 
 ### Links
+
 Link text should be meaningful and unique, with as few duplicated references as possible to prevent confusion. Ideally the link itself, or, alternatively, its programmatically determined context, should provide information about where the link will take you, and help users decide whether to follow the link. Examples of programmatically determined context can be aria labels, or text within the same paragraph as the link.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Set context and provide information that relates the link's location. Example: You can find out more about our speakers at the GitHub Universe site" src="https://user-images.githubusercontent.com/10384315/125705618-334a5169-fcbd-460f-a8b6-7b05c6ed6254.png"/>
-  <Caption>Set the context within the paragraph.</Caption>
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Set context and provide information that relates the link's location. Example: You can find out more about our speakers at the GitHub Universe site"
+      src="https://user-images.githubusercontent.com/10384315/125705618-334a5169-fcbd-460f-a8b6-7b05c6ed6254.png"
+    />
+    <Caption>Set the context within the paragraph.</Caption>
+  </Do>
 </DoDontContainer>
 
 <DoDontContainer>
@@ -200,14 +281,18 @@ Link text should be meaningful and unique, with as few duplicated references as 
 </a>`}
     </Code>
     <Caption>Set the context of the image link from the text within the same container.</Caption>
- </Do>
+  </Do>
 </DoDontContainer>
 
 Never say “here” or “click here”.
 
 <DoDontContainer>
   <Dont>
-    <img width="420" alt="Don't: Never say 'here' or 'click here' in links. Example: Click here to find out more about our speakers at GitHub Universe." src="https://user-images.githubusercontent.com/10384315/125705617-56dc3569-b388-43af-b80a-db43e406450d.png"/>
+    <img
+      width="420"
+      alt="Don't: Never say 'here' or 'click here' in links. Example: Click here to find out more about our speakers at GitHub Universe."
+      src="https://user-images.githubusercontent.com/10384315/125705617-56dc3569-b388-43af-b80a-db43e406450d.png"
+    />
   </Dont>
 </DoDontContainer>
 
@@ -217,60 +302,95 @@ TODO: Commas, truncation, rounding up or down. Do units have a space, KB, MB, et
 -->
 
 ### Punctuation
+
 Headings, labels and buttons should not include punctuation. In most cases, exclamation marks are not appropriate — most things aren't _that_ exciting.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Remove punctuation from headings and labels. Example: No code scanning alerts found" src="https://user-images.githubusercontent.com/10384315/125705616-d066fdb3-dcb2-4b88-b154-45dc4e8396f1.png"/>
- </Do>
- <Dont>
-  <img width="420" alt="Don't: In most cases don't use exclamation marks. Example: No code scanning alerts found!" src="https://user-images.githubusercontent.com/10384315/125705615-b800023a-d39b-4d6f-aca2-6a5cf488938f.png"/>
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Remove punctuation from headings and labels. Example: No code scanning alerts found"
+      src="https://user-images.githubusercontent.com/10384315/125705616-d066fdb3-dcb2-4b88-b154-45dc4e8396f1.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: In most cases don't use exclamation marks. Example: No code scanning alerts found!"
+      src="https://user-images.githubusercontent.com/10384315/125705615-b800023a-d39b-4d6f-aca2-6a5cf488938f.png"
+    />
+  </Dont>
 </DoDontContainer>
 
 ### References to UI
+
 When referring to unclickable page names and sections, write them as they appear in the interface in quotation marks.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Refer to unclickable sections as they are written in the UI and wrapped in quotes. Example: Go to the 'Email notifications settings' section." src="https://user-images.githubusercontent.com/10384315/125705614-5c6c9ead-7cae-4129-b812-7eb0fd1908bd.png"/>
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Refer to unclickable sections as they are written in the UI and wrapped in quotes. Example: Go to the 'Email notifications settings' section."
+      src="https://user-images.githubusercontent.com/10384315/125705614-5c6c9ead-7cae-4129-b812-7eb0fd1908bd.png"
+    />
+  </Do>
 </DoDontContainer>
 
 When referring to button or link text that a user should click on, use bold text without quotation marks. Make sure all UI references match the capitalization in the interface. If you’re writing for a mobile app experience, use “tap”, instead of “click”.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Write button and links in bold. Example: Click Save with Save in bold" src="https://user-images.githubusercontent.com/10384315/125705613-96de4bcf-cf6d-4c12-886e-a8ad8619d84c.png"/>
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Write button and links in bold. Example: Click Save with Save in bold"
+      src="https://user-images.githubusercontent.com/10384315/125705613-96de4bcf-cf6d-4c12-886e-a8ad8619d84c.png"
+    />
+  </Do>
 </DoDontContainer>
 
 When referring to a folder, use a code tag.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Write a folder name with the code tag. Example: Open the <code>docs</code> folder" src="https://user-images.githubusercontent.com/10384315/125705612-77cb3dc3-5445-4440-a2c9-bbe761fdd1e3.png"/>
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Write a folder name with the code tag. Example: Open the <code>docs</code> folder"
+      src="https://user-images.githubusercontent.com/10384315/125705612-77cb3dc3-5445-4440-a2c9-bbe761fdd1e3.png"
+    />
+  </Do>
 </DoDontContainer>
 
 ### Subject
+
 In most instances, address the user as "you" and items "owned" by the user as "your" or "yours".
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Address the user as you. Example: Update your profile" src="https://user-images.githubusercontent.com/10384315/125705611-3a5d082d-324b-415a-9c77-5aa59adde753.png"/>
- </Do>
- <Dont>
-  <img width="420" alt="Don't: Address the user or things they own with 'I' or 'my'. Example: Update my profile" src="https://user-images.githubusercontent.com/10384315/125705610-58bf0f25-b63e-41db-bc35-40328653ab11.png"/>
- </Dont>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Address the user as you. Example: Update your profile"
+      src="https://user-images.githubusercontent.com/10384315/125705611-3a5d082d-324b-415a-9c77-5aa59adde753.png"
+    />
+  </Do>
+  <Dont>
+    <img
+      width="420"
+      alt="Don't: Address the user or things they own with 'I' or 'my'. Example: Update my profile"
+      src="https://user-images.githubusercontent.com/10384315/125705610-58bf0f25-b63e-41db-bc35-40328653ab11.png"
+    />
+  </Dont>
 </DoDontContainer>
 
 Some exceptions exist and are usually related to legal language, such as when a user needs to agree to terms, or confirm a destructive action.
 
 <DoDontContainer>
- <Do>
-  <img width="420" alt="Do: Exception to address the user as I with legal terms. Example: I have read the Terms of Service, I understand, convert this issue to a discussion" src="https://user-images.githubusercontent.com/10384315/125705608-aa8660aa-ec67-4fb0-a4cf-b69ef0b442aa.png" />
- </Do>
+  <Do>
+    <img
+      width="420"
+      alt="Do: Exception to address the user as I with legal terms. Example: I have read the Terms of Service, I understand, convert this issue to a discussion"
+      src="https://user-images.githubusercontent.com/10384315/125705608-aa8660aa-ec67-4fb0-a4cf-b69ef0b442aa.png"
+    />
+  </Do>
 </DoDontContainer>
 
 <!--
@@ -279,6 +399,7 @@ TODO: Examples of truncation: dates, large numbers, long file names.
 -->
 
 ## What to avoid
+
 - Do not say that something is “easy”, “quick”, or that the user “just” needs to do something.
 - Do not capitalize common terms. Only proper nouns and product names should be capitalized.
 - Do not use emoji in UI content, or to replace words.
@@ -288,4 +409,5 @@ TODO: Examples of truncation: dates, large numbers, long file names.
 - Do not use semicolons: they are hard to get right and can be replaced by a period most times.
 
 ## How to get help
-If you need clarification and can’t find an answer in the [GitHub’s Content Style Guide](https://brand.github.com/content/) or the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), or would like your UI content to be reviewed, please start a discussion in github/primer and someone in the team will get back to you. If your query is urgent, you can ask directly in the [#primer](https://github.slack.com/archives/CSGAVNZ19) channel. 
+
+If you need clarification and can’t find an answer in the [GitHub’s Content Style Guide](https://brand.github.com/content/) or the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), or would like your UI content to be reviewed, please start a discussion in github/primer and someone in the team will get back to you. If your query is urgent, you can ask directly in the [#primer](https://github.slack.com/archives/CSGAVNZ19) channel.

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -2,35 +2,40 @@
 title: Foundations
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
-
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
-    <div>
-        <Link href="/design/foundations/color">
-            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/foundations/color" fontWeight="bold">Color</Link>
-        <Box as="p">How to work with color modes and themes, and how to apply color to GitHub interfaces.</Box>
-    </div>
   <div>
-        <Link href="/design/foundations/typography">
-            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/foundations/typography" fontWeight="bold">Typography</Link>
-        <Box as="p">How to use and apply typography to GitHub interfaces.</Box>
-    </div>
+    <Link href="/design/foundations/color">
+      {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
+    </Link>
+  </div>
   <div>
-        <Link href="/design/foundations/content">
-            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/foundations/content" fontWeight="bold">Content</Link>
-        <Box as="p">How to create interfaces that follow GitHub's content guidelines.</Box>
-    </div>
-  </Grid>
+    <Link href="/design/foundations/color" fontWeight="bold">
+      Color
+    </Link>
+    <Box as="p">How to work with color modes and themes, and how to apply color to GitHub interfaces.</Box>
+  </div>
+  <div>
+    <Link href="/design/foundations/typography">
+      {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/foundations/typography" fontWeight="bold">
+      Typography
+    </Link>
+    <Box as="p">How to use and apply typography to GitHub interfaces.</Box>
+  </div>
+  <div>
+    <Link href="/design/foundations/content">
+      {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/foundations/content" fontWeight="bold">
+      Content
+    </Link>
+    <Box as="p">How to create interfaces that follow GitHub's content guidelines.</Box>
+  </div>
+</Grid>

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -3,8 +3,8 @@ title: Foundations
 ---
 
 import {Box, Link, Text, Label} from '@primer/react'
-import {Grid} from '@primer/react/deprecated'
-import {Flex} from '@primer/react/deprecated'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -2,13 +2,11 @@
 title: Foundations
 ---
 
-import { Grid, Box, Link, Text, Label } from '@primer/react'
+import {Box, Link, Text, Label} from '@primer/react'
+import {Grid} from '@primer/react/deprecated'
+import {Flex} from '@primer/react/deprecated'
 
-<Grid gridTemplateColumns
-
-import { Flex } from '@primer/react/deprecated';
-
-={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
     <Link href="/design/foundations/color">
       {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -2,9 +2,13 @@
 title: Foundations
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
+import { Grid, Box, Link, Text, Label } from '@primer/react'
 
-<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+<Grid gridTemplateColumns
+
+import { Flex } from '@primer/react/deprecated';
+
+={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
     <Link href="/design/foundations/color">
       {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}

--- a/content/foundations/typography.mdx
+++ b/content/foundations/typography.mdx
@@ -7,7 +7,7 @@ import sfImage from '../../src/images/sf.svg'
 import sfMonoImage from '../../src/images/sfMono.svg'
 import interImage from '../../src/images/interUI.svg'
 import ubuntuImage from '../../src/images/ubuntu.svg'
-import {Box} from '@primer/components'
+import {Box} from '@primer/react'
 
 These guidelines summarize how we use typography at GitHub, and serve as guardrails for designers to design freely with best typographic practices in mind.
 
@@ -20,7 +20,7 @@ The first three typefaces listed below are the most commonly utilized system-fon
 | Example                                                | Description                                                                                                                                                                                                                                     |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <img src={sfImage} alt="San Francisco" width="1000" /> | [San Francisco](https://developer.apple.com/fonts/) is a neo-grotesque sans-serif typeface designed by Apple to replace Helvetica Neue for OSX and iOS                                                                                          |
-| <img src={segoeImage} alt="Segoe" width="1000" />      | [Segoe UI](https://developer.microsoft.com/en-us/fabric#/resources) is a humanist sans-serif adopted by Microsoft as its default operating system font since Windows Vista                                                                     |
+| <img src={segoeImage} alt="Segoe" width="1000" />      | [Segoe UI](https://developer.microsoft.com/en-us/fabric#/resources) is a humanist sans-serif adopted by Microsoft as its default operating system font since Windows Vista                                                                      |
 | <img src={ubuntuImage} alt="Ubuntu" width="1000" />    | [Ubuntu](https://design.ubuntu.com/font/) is an OpenType-based, humanist sans-serif typeface. It became the default system font for Ubuntu 10.10 and is commonly used on Linux distros                                                          |
 | <img src={interImage} alt="Inter" width="1000" />      | [Inter UI](https://rsms.me/inter/) is a typeface designed by Rasmus Andersson specially for user interfaces. Inter UI is used in our products as a display face in select circumstances                                                         |
 | <img src={sfMonoImage} alt="SF Mono" width="1000" />   | [SF Mono](https://developer.apple.com/fonts/) is a monospace typeface that is part of the San Francisco typeface family. SF Mono is monospaced across weights, so resetting SF Mono text into another font weight will not cause text to reflow |

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -2,13 +2,17 @@
 title: Figma
 ---
 
-import {Box, Grid, Flex, BorderBox, Text} from '@primer/components'
+import {Box, Grid, Flex, BorderBox, Text} from '@primer/react'
 
 <Flex mb={4} flexDirection="column">
-    <Flex bg="gray.1" justifyContent="center">
-        <img width="656" alt="Screenshot of the Primer profile within the Figma community" src="https://user-images.githubusercontent.com/10384315/93832644-3028e080-fc2b-11ea-88d1-a7515c04fe39.png" />
-    </Flex>
-    <Caption>Primer is a part of the Figma community and can be found using its Figma handle of @primer</Caption>
+  <Flex bg="gray.1" justifyContent="center">
+    <img
+      width="656"
+      alt="Screenshot of the Primer profile within the Figma community"
+      src="https://user-images.githubusercontent.com/10384315/93832644-3028e080-fc2b-11ea-88d1-a7515c04fe39.png"
+    />
+  </Flex>
+  <Caption>Primer is a part of the Figma community and can be found using its Figma handle of @primer</Caption>
 </Flex>
 
 Design teams at GitHub use Figma as the single source of truth, collaboration, and exploration. Access to the GitHub Figma organization is currently only available to members of the GitHub team. Public access to any shared libraries and files is available from the [Primer Figma Community page](https://www.figma.com/@primer).
@@ -25,10 +29,14 @@ GitHub uses Figma to distribute Primer through team libraries. Each library cove
 ## Interface templates
 
 <Flex mb={4} flexDirection="column">
-    <Flex bg="gray.1" justifyContent="center">
-        <img width="656" alt="screenshot of repo home page and email template" src="https://user-images.githubusercontent.com/10384315/93832849-d1b03200-fc2b-11ea-98ff-685f22236f6f.png" />
-    </Flex>
-    <Caption>Example templates from Primer Interfaces and Primer Email</Caption>
+  <Flex bg="gray.1" justifyContent="center">
+    <img
+      width="656"
+      alt="screenshot of repo home page and email template"
+      src="https://user-images.githubusercontent.com/10384315/93832849-d1b03200-fc2b-11ea-98ff-685f22236f6f.png"
+    />
+  </Flex>
+  <Caption>Example templates from Primer Interfaces and Primer Email</Caption>
 </Flex>
 
 In addition to asset libraries for components and styles, you can also use template libraries to jump-start the design process.
@@ -39,10 +47,14 @@ In addition to asset libraries for components and styles, you can also use templ
 ## Collaboration
 
 <Flex mb={4} flexDirection="column">
-    <Flex bg="gray.1" justifyContent="center">
-        <img width="656" alt="Screenshot demonstrating collaboration in Figma using Figma comments" src="https://user-images.githubusercontent.com/10384315/93832938-0f14bf80-fc2c-11ea-9e8b-e72bee3b4fdd.png" />
-    </Flex>
-    <Caption>Example communicating in Figma using comments</Caption>
+  <Flex bg="gray.1" justifyContent="center">
+    <img
+      width="656"
+      alt="Screenshot demonstrating collaboration in Figma using Figma comments"
+      src="https://user-images.githubusercontent.com/10384315/93832938-0f14bf80-fc2c-11ea-9e8b-e72bee3b4fdd.png"
+    />
+  </Flex>
+  <Caption>Example communicating in Figma using comments</Caption>
 </Flex>
 
 All GitHub members have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback and use [issues](https://help.github.com/en/articles/about-issues) to document design exploration, track decisions and progress. The design team values [incremental correctness](https://github.com/github/product-design/blob/master/principles-and-practices.md#incremental-correctness), so share early and share often.

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -2,10 +2,11 @@
 title: Figma
 ---
 
-import { Box, Grid, Text } from '@primer/react'
+import { Box, Text } from '@primer/react'
 
 <Flex mb
 
+import { Grid } from '@primer/react/deprecated';
 import { Flex } from '@primer/react/deprecated';
 
 ={4} flexDirection="column">

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -2,14 +2,11 @@
 title: Figma
 ---
 
-import { Box, Text } from '@primer/react'
+import {Box, Text} from '@primer/react'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
-<Flex mb
-
-import { Grid } from '@primer/react/deprecated';
-import { Flex } from '@primer/react/deprecated';
-
-={4} flexDirection="column">
+<Flex mb={4} flexDirection="column">
   <Flex bg="gray.1" justifyContent="center">
     <img
       width="656"

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -2,9 +2,13 @@
 title: Figma
 ---
 
-import {Box, Grid, Flex, BorderBox, Text} from '@primer/react'
+import { Box, Grid, Text } from '@primer/react'
 
-<Flex mb={4} flexDirection="column">
+<Flex mb
+
+import { Flex } from '@primer/react/deprecated';
+
+={4} flexDirection="column">
   <Flex bg="gray.1" justifyContent="center">
     <img
       width="656"

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -2,16 +2,18 @@
 title: Design tools
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
-    <div>
-        <Link href="/design/tools/figma">
-            {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
-        </Link>
-    </div>
-    <div>
-        <Link href="/design/tools/figma" fontWeight="bold">Figma</Link>
-        <Box as="p">A guide on how to get started using Figma to design interfaces at GitHub.</Box>
-    </div>
-  </Grid>
+  <div>
+    <Link href="/design/tools/figma">
+      {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/tools/figma" fontWeight="bold">
+      Figma
+    </Link>
+    <Box as="p">A guide on how to get started using Figma to design interfaces at GitHub.</Box>
+  </div>
+</Grid>

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -2,13 +2,11 @@
 title: Design tools
 ---
 
-import { Grid, Box, Link, Text, Label } from '@primer/react'
+import {Box, Link, Text, Label} from '@primer/react'
+import {Grid} from '@primer/react/deprecated'
+import {Flex} from '@primer/react/deprecated'
 
-<Grid gridTemplateColumns
-
-import { Flex } from '@primer/react/deprecated';
-
-={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
     <Link href="/design/tools/figma">
       {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -2,9 +2,13 @@
 title: Design tools
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
+import { Grid, Box, Link, Text, Label } from '@primer/react'
 
-<Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
+<Grid gridTemplateColumns
+
+import { Flex } from '@primer/react/deprecated';
+
+={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
     <Link href="/design/tools/figma">
       {/* <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" /> */}

--- a/content/tools/index.mdx
+++ b/content/tools/index.mdx
@@ -3,8 +3,8 @@ title: Design tools
 ---
 
 import {Box, Link, Text, Label} from '@primer/react'
-import {Grid} from '@primer/react/deprecated'
-import {Flex} from '@primer/react/deprecated'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
 <Grid gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>

--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -2,9 +2,13 @@
 title: Empty states
 ---
 
-import {Flex, Box, Text, BorderBox} from '@primer/react'
+import { Box, Text } from '@primer/react'
 
-Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the Blankslate component and designing empty states. If you're looking for guidelines on implementation, please refer to [Primer CSS](https://primer.style/css/components/blankslate).
+Empty
+
+import { Flex } from '@primer/react/deprecated';
+
+ states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the Blankslate component and designing empty states. If you're looking for guidelines on implementation, please refer to [Primer CSS](https://primer.style/css/components/blankslate).
 
 ## The Blankslate component
 

--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -2,13 +2,13 @@
 title: Empty states
 ---
 
-import { Box, Text } from '@primer/react'
+import {Box, Text} from '@primer/react'
 
 Empty
 
-import { Flex } from '@primer/react/deprecated';
+import {Flex} from '@primer/react'
 
- states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the Blankslate component and designing empty states. If you're looking for guidelines on implementation, please refer to [Primer CSS](https://primer.style/css/components/blankslate).
+states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the Blankslate component and designing empty states. If you're looking for guidelines on implementation, please refer to [Primer CSS](https://primer.style/css/components/blankslate).
 
 ## The Blankslate component
 

--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -2,52 +2,64 @@
 title: Empty states
 ---
 
-import {Flex, Box, Text, BorderBox} from '@primer/components'
+import {Flex, Box, Text, BorderBox} from '@primer/react'
 
 Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the Blankslate component and designing empty states. If you're looking for guidelines on implementation, please refer to [Primer CSS](https://primer.style/css/components/blankslate).
 
 ## The Blankslate component
+
 The Blankslate is made up of several elements that work together to inform the user about a feature and how to proceed forward. Below are the different elements of the component and how to modify them.
 
 ![Blankslate anatomy](https://user-images.githubusercontent.com/6846673/62806713-78795380-baa8-11e9-9cbd-1a56fef3247b.png)
 
 ### Graphic
+
 The graphic can bring delight, preview an interface element, or represent the goal of the feature. Graphics should be placed intentionally and with thought about the intention of the content. Graphics also differ in meaning and appeal to the user, which is why the Blankslate component has multiple variations. These variations are outlined later on this page.
 
 ### Primary Text
+
 Use primary text to explain the purpose of the empty state, help users feel comfortable to engage with the content, or begin a feature flow. Primary text should sound welcoming, human, and convey the intention of the feature.
 
 ### Secondary text
-This optional text is used to inform the user about the feature in more detail. Secondary text should be brief and non-redundant if possible. From the text, users should  be able to understand the general purpose of the feature and how it may help them accomplish a goal.
+
+This optional text is used to inform the user about the feature in more detail. Secondary text should be brief and non-redundant if possible. From the text, users should be able to understand the general purpose of the feature and how it may help them accomplish a goal.
 
 ### Primary action
+
 Blankslates can and are encouraged to use one primary action. This button should lead to a feature or component creation flow. Button copy should be kept brief and descriptive. If a button requires further specification, consider adding an Octicon.
 
 ### Secondary action
+
 Secondary actions are optional and are represented by a text link located below the primary action button. A secondary action is used to direct a user to additional content about the feature. This might look like "[Learn more about X](#)" or "[Check out the guide on X](#)" or simply "[Learn more](#)".
 
 ### Border
+
 The border is invisible by default, but can be added to help define the structure of the Blankslate component when needed. This can be particularly helpful in page layouts where the Blankslate is not the only content on the screen. For implementation, check out the [Primer CSS Blankslate component](https://primer.style/css/components/blankslate#add-border).
 
 ## Variations
+
 Empty states have multiple variations that can be used in different contexts.
 
 ### GitHub marketing icons
+
 [GitHub marketing icons](https://ghicons.github.com/) can be used to represent the feature where the Blankslate is found. Blankslates should default to using a GitHub marketing icon for graphic elements.
 
 ![GH Icon Blankslate](https://user-images.githubusercontent.com/6846673/62806619-39e39900-baa8-11e9-9de0-5b2f511d63da.png)
 
 ### Code block
+
 Blankslates that use a list of steps or offer instructions in the format of code to get started with a feature can insert a `code` block. This is the case for getting started with packages in GitHub:
 
 ![Code block Blankslate](https://user-images.githubusercontent.com/589285/64209577-b83c1c80-ce55-11e9-8b61-8d82713b56a6.png)
 
 ## Content and copy
+
 Empty states should explain features _in addition_ to conveying intention. In the example below, the primary text is used to provide a welcome invitation to creating a positive community while the secondary text supports this intent by informing the user on how to do this by providing a code of conduct.
 
 ![code of conduct illustration Blankslate](https://user-images.githubusercontent.com/6846673/62806616-394b0280-baa8-11e9-8a5e-45f0c51aaa22.png)
 
 ## First time user experiences
+
 For first time user experiences, use illustration Blankslates to playfully engage the user and introduce the Octocat as a symbol of GitHub. Primary text should welcome the user to the platform and feature. Secondary text should seek to educate the user, but at a simpler, less-technical level.
 
 ![first time user Blankslate](https://user-images.githubusercontent.com/6846673/62813307-efb9e200-babe-11e9-93e7-a6fd45d7f942.png)

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -2,7 +2,7 @@
 title: Feature onboarding
 ---
 
-import {Box, Flex, BorderBox, Text} from '@primer/components'
+import {Box, Flex, BorderBox, Text} from '@primer/react'
 
 Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
 
@@ -19,8 +19,8 @@ When designing a feature onboarding flow, remember to:
 ### Proximity and proportion
 
 - Onboarding elements should be close to where the feature will live in perpetuity.
-- Consider the primary task on a page before disrupting the user with a feature callout. 
-- Keep in mind the context, placement, and dominance of an onboarding element. 
+- Consider the primary task on a page before disrupting the user with a feature callout.
+- Keep in mind the context, placement, and dominance of an onboarding element.
 - Onboarding UI choices should be proportional to the functional hierarchy of the feature on the page.
 
 ### Do not derail or trap the user
@@ -42,7 +42,7 @@ Create a new feature release timeline with clear parameters and an appropriate r
 
 ### Avoid traffic collisions
 
-- Avoid showing too many alerts at the same time. Collisions are awkward and undesirable, no more than 2 alerts a time. 
+- Avoid showing too many alerts at the same time. Collisions are awkward and undesirable, no more than 2 alerts a time.
 - Consider what other alerts, teaching bubbles, or banners may be active on the page when crafting an onboarding experience.
 
 <Dont>
@@ -55,7 +55,7 @@ Create a new feature release timeline with clear parameters and an appropriate r
 
 ### Create efficient sequences
 
-Sequence tasks in a logical way to increase onboarding success. Clearly define when a user starts and successfully completes an onboarding flow. 
+Sequence tasks in a logical way to increase onboarding success. Clearly define when a user starts and successfully completes an onboarding flow.
 
 Treat feature onboarding as a story or a journey with a beginning, middle, and end.
 
@@ -93,7 +93,10 @@ Treat feature onboarding as a story or a journey with a beginning, middle, and e
 
 <Flex alignItems="center" flexDirection="column" my={3}>
   <BorderBox width={9 / 12} mb={2} overflow="hidden">
-    <img src="https://user-images.githubusercontent.com/6744014/89254411-e8df8580-d5d3-11ea-969f-5080a8c6b0d4.png" alt="Example of a checklist on GitHub with two uncompleted tasks and one completed task" />
+    <img
+      src="https://user-images.githubusercontent.com/6744014/89254411-e8df8580-d5d3-11ea-969f-5080a8c6b0d4.png"
+      alt="Example of a checklist on GitHub with two uncompleted tasks and one completed task"
+    />
   </BorderBox>
   <p>Example of a checklist.</p>
 </Flex>
@@ -105,7 +108,10 @@ Treat feature onboarding as a story or a journey with a beginning, middle, and e
 
 <Flex alignItems="center" flexDirection="column" my={3}>
   <BorderBox width={9 / 12} mb="0" overflow="hidden">
-    <img src="https://user-images.githubusercontent.com/66705495/92781977-7348a100-f359-11ea-9ed1-924f4ea8567a.png" alt="Example of the success state toast component " />
+    <img
+      src="https://user-images.githubusercontent.com/66705495/92781977-7348a100-f359-11ea-9ed1-924f4ea8567a.png"
+      alt="Example of the success state toast component "
+    />
   </BorderBox>
   <p>Example of a toast.</p>
 </Flex>
@@ -116,7 +122,7 @@ A teaching bubble is a [Primer popover](https://primer.style/css/components/popo
 
 ### Usage guidelines
 
-Teaching bubble Figma [sticker sheet](https://www.figma.com/file/FJtZyBeBfwDkByHPfDSN6k/Feature-onboarding?node-id=857%3A34). 
+Teaching bubble Figma [sticker sheet](https://www.figma.com/file/FJtZyBeBfwDkByHPfDSN6k/Feature-onboarding?node-id=857%3A34).
 
 <DoDontContainer>
 <Do>
@@ -148,40 +154,82 @@ Teaching bubble Figma [sticker sheet](https://www.figma.com/file/FJtZyBeBfwDkByH
   </tr>
   <tr>
     <th>Default</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89239384-dc483680-d5ad-11ea-9463-3c56e1feefd9.png" alt="Example of a default teaching bubble" /></td>
-    <td>Generally, use a descriptive dismiss button over a close icon. "OK, got it" is the default dismissal button copy.</td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89239384-dc483680-d5ad-11ea-9463-3c56e1feefd9.png"
+        alt="Example of a default teaching bubble"
+      />
+    </td>
+    <td>
+      Generally, use a descriptive dismiss button over a close icon. "OK, got it" is the default dismissal button copy.
+    </td>
   </tr>
   <tr>
     <th>Condensed</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89239379-db170980-d5ad-11ea-8327-fa8b035f5e0c.png" alt="Example of a condensed teaching bubble"/></td>
-    <td>Use a close icon for condensed messages. Remember to apply the correct tab order for screen readers to easily dismiss the teaching bubble at the end of the message.</td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89239379-db170980-d5ad-11ea-8327-fa8b035f5e0c.png"
+        alt="Example of a condensed teaching bubble"
+      />
+    </td>
+    <td>
+      Use a close icon for condensed messages. Remember to apply the correct tab order for screen readers to easily
+      dismiss the teaching bubble at the end of the message.
+    </td>
   </tr>
   <tr>
     <th>Multiple buttons</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89239536-58427e80-d5ae-11ea-9578-05c74c7701da.png" alt="Example of a teaching bubble with multiple buttons" /></td>
-    <td>Invite the user to engage with the value proposition promised. Include dismiss as a secondary button as "OK, dismiss". Additional links that takes the user to a new page should be linked from the text and must open in a new tab or window to prevent losing the user’s context.</td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89239536-58427e80-d5ae-11ea-9578-05c74c7701da.png"
+        alt="Example of a teaching bubble with multiple buttons"
+      />
+    </td>
+    <td>
+      Invite the user to engage with the value proposition promised. Include dismiss as a secondary button as "OK,
+      dismiss". Additional links that takes the user to a new page should be linked from the text and must open in a new
+      tab or window to prevent losing the user’s context.
+    </td>
   </tr>
   <tr>
     <th>Emoji</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89239385-dc483680-d5ad-11ea-97e9-9ea6f54fe451.png" alt="Example of a teaching bubble with an emoji" /></td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89239385-dc483680-d5ad-11ea-97e9-9ea6f54fe451.png"
+        alt="Example of a teaching bubble with an emoji"
+      />
+    </td>
     <td>Use emojis to inject personality into the message.</td>
   </tr>
   <tr>
     <th>Pictograms</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89239387-dce0cd00-d5ad-11ea-898b-b574bb837836.png" alt="Example of a teaching bubble with pictograms" />
-    <img src="https://user-images.githubusercontent.com/6744014/89239389-dd796380-d5ad-11ea-84f4-c0819100fc2a.png" alt="Example of a teaching bubble with a pictogram"/></td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89239387-dce0cd00-d5ad-11ea-898b-b574bb837836.png"
+        alt="Example of a teaching bubble with pictograms"
+      />
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89239389-dd796380-d5ad-11ea-84f4-c0819100fc2a.png"
+        alt="Example of a teaching bubble with a pictogram"
+      />
+    </td>
     <td>Use pictograms to represent the feature.</td>
   </tr>
   <tr>
     <th>Illustrations and gifs</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/90083962-d39be280-dcc8-11ea-9d38-4bc24f759ba9.gif" alt="Example of a teaching bubble with a GIF" /></td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/90083962-d39be280-dcc8-11ea-9d38-4bc24f759ba9.gif"
+        alt="Example of a teaching bubble with a GIF"
+      />
+    </td>
     <td>Visually communicate or demonstrate a complex feature with illustrations and gifs to supplement a message.</td>
   </tr>
 </table>
 
 ## Inline feature discovery
 
-Inline feature discovery is a way to highlight features without obscuring other parts of the page while a user may be performing an existing task. 
+Inline feature discovery is a way to highlight features without obscuring other parts of the page while a user may be performing an existing task.
 
 ### Page banner
 
@@ -221,18 +269,30 @@ Use inline banners in a page with multiple steps or actions.
   <tr>
     <th>Inline feature banner</th>
     <td>
-      <img src="https://user-images.githubusercontent.com/6744014/88744364-f5f40480-d0fb-11ea-97c4-5ab87b548a2c.png" alt="Example of an inline feature banner" />
+      <img
+        src="https://user-images.githubusercontent.com/6744014/88744364-f5f40480-d0fb-11ea-97c4-5ab87b548a2c.png"
+        alt="Example of an inline feature banner"
+      />
       <p>A short introduction to the Wiki feature while configuring repository settings.</p>
     </td>
-    <td>Organization, repository, or user settings, where a feature is managed and customized, inline alert banners can highlight relevant features that may help better accomplish a user’s task.</td>
+    <td>
+      Organization, repository, or user settings, where a feature is managed and customized, inline alert banners can
+      highlight relevant features that may help better accomplish a user’s task.
+    </td>
   </tr>
   <tr>
     <th>Hidden revealed</th>
     <td>
-      <img src="https://user-images.githubusercontent.com/6744014/89241458-d35a6380-d5b3-11ea-9307-52c8ae80f2d3.png" alt="Example of an inline banner revealing an easter egg" />
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89241458-d35a6380-d5b3-11ea-9307-52c8ae80f2d3.png"
+        alt="Example of an inline banner revealing an easter egg"
+      />
       <p>Discovering the Profile Readme when creating a new repository.</p>
     </td>
-    <td>Sometimes features can be hidden for users to discover. Show a <a href="">Primer alert</a> at pivotal moments to signal the user they're on the right track and provide more information.</td>
+    <td>
+      Sometimes features can be hidden for users to discover. Show a <a href="">Primer alert</a> at pivotal moments to
+      signal the user they're on the right track and provide more information.
+    </td>
   </tr>
 </table>
 
@@ -269,15 +329,17 @@ Use empty states as an integrated way to onboard users to new features. Read mor
 
 **In-product marketing empty state**
 
-For special occasions, a first time experience may be more unique than the typical blank state. Take a more branded approach to engage and guide the user through complex experiences. Be aware of how the experience will change once the first-time UI is no longer there. 
+For special occasions, a first time experience may be more unique than the typical blank state. Take a more branded approach to engage and guide the user through complex experiences. Be aware of how the experience will change once the first-time UI is no longer there.
 
 <Flex alignItems="center" flexDirection="column" my={3}>
   <BorderBox width={9 / 12} border="1px solid" borderColor="gray.3" mb="2" overflow="hidden">
-    <img src="https://user-images.githubusercontent.com/6744014/88744262-b3cac300-d0fb-11ea-9752-c43722a30399.png" alt="Screenshot of the empty state for GitHub actions" />
+    <img
+      src="https://user-images.githubusercontent.com/6744014/88744262-b3cac300-d0fb-11ea-9752-c43722a30399.png"
+      alt="Screenshot of the empty state for GitHub actions"
+    />
   </BorderBox>
   <p>GitHub Actions branded first-time user experience</p>
 </Flex>
-
 
 ## Designated feature discovery areas
 
@@ -289,12 +351,16 @@ The top of the right sidebar in a user’s dashboard (logged-in home) is a desig
 
 When using a dashboard feature bulletin:
 
-- Limit messages to around 160 characters. 
+- Limit messages to around 160 characters.
 - If there is a click-through, include a descriptive button; avoid hidden links.
 - Use color, with discretion, to spotlight and bring brand feature personality to the announcement.
 
 <Flex alignItems="center" flexDirection="column" my={3}>
-  <img mb={2} src="https://user-images.githubusercontent.com/6744014/89245516-d22e3400-d5bd-11ea-8124-110a698562d2.png" alt="Example of a bulletin that leads to a marketing page" />
+  <img
+    mb={2}
+    src="https://user-images.githubusercontent.com/6744014/89245516-d22e3400-d5bd-11ea-8124-110a698562d2.png"
+    alt="Example of a bulletin that leads to a marketing page"
+  />
   <p>An announcement about GitHub Teams in the feature preview bulletin leads to an off-platform marketing page.</p>
 </Flex>
 
@@ -310,7 +376,7 @@ Feature previews allow teams to test features in production with users who opt i
 
 Flairs are a softer way to accentuate new features without derailing the user from their primary task.
 
-Consider using flairs for features that appear in a user’s current view but may navigate away from their current page to fully engage with the feature. They may also be applicable for smaller features that appear inline that are self-explanatory and do not need a teaching bubble. 
+Consider using flairs for features that appear in a user’s current view but may navigate away from their current page to fully engage with the feature. They may also be applicable for smaller features that appear inline that are self-explanatory and do not need a teaching bubble.
 
 Include relevant links to capture feedback, marketing pages or changelog entries whenever possible.
 
@@ -324,12 +390,22 @@ See Primer documentation on [colored labels](https://primer.style/css/components
   </tr>
   <tr>
     <th>New</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89243986-364ef900-d5ba-11ea-84b7-821dc8b3d535.png" alt="Example of the NEW flair that highlights a new feature" /></td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89243986-364ef900-d5ba-11ea-84b7-821dc8b3d535.png"
+        alt="Example of the NEW flair that highlights a new feature"
+      />
+    </td>
     <td>Generally, a feature may be considered “new” for 2 months.</td>
   </tr>
-    <tr>
+  <tr>
     <th>Beta</th>
-    <td><img src="https://user-images.githubusercontent.com/6744014/89243980-34853580-d5ba-11ea-9570-87de12a3b11c.png" alt="Example of the BETA flair that highlights a beta feature" /></td>
+    <td>
+      <img
+        src="https://user-images.githubusercontent.com/6744014/89243980-34853580-d5ba-11ea-9570-87de12a3b11c.png"
+        alt="Example of the BETA flair that highlights a beta feature"
+      />
+    </td>
     <td>Beta flairs accompany features listed in the feature previews dialog.</td>
   </tr>
 </table>

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -2,9 +2,13 @@
 title: Feature onboarding
 ---
 
-import {Box, Flex, BorderBox, Text} from '@primer/react'
+import { Box, BorderBox, Text } from '@primer/react'
 
-Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
+Onboarding
+
+import { Flex } from '@primer/react/deprecated';
+
+ is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
 
 Check out the feature onboarding Figma [sticker sheet](https://www.figma.com/file/FJtZyBeBfwDkByHPfDSN6k/Feature-onboarding?node-id=857%3A6).
 

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -2,13 +2,13 @@
 title: Feature onboarding
 ---
 
-import { Box, BorderBox, Text } from '@primer/react'
+import {Box, BorderBox, Text} from '@primer/react'
 
 Onboarding
 
-import { Flex } from '@primer/react/deprecated';
+import {Flex} from '@primer/react'
 
- is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
+is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
 
 Check out the feature onboarding Figma [sticker sheet](https://www.figma.com/file/FJtZyBeBfwDkByHPfDSN6k/Feature-onboarding?node-id=857%3A6).
 

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -2,9 +2,13 @@
 title: UI patterns
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
+import { Grid, Box, Link, Text, Label } from '@primer/react'
 
-<Grid gridGap={4}>
+<Grid gridGap
+
+import { Flex } from '@primer/react/deprecated';
+
+={4}>
   {/* <div>
         <Link href="/design/ui-patterns/button-usage">
             <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -2,61 +2,94 @@
 title: UI patterns
 ---
 
-import {Grid, Flex, Box, Link, Text, Label} from '@primer/components'
+import {Grid, Flex, Box, Link, Text, Label} from '@primer/react'
 
 <Grid gridGap={4}>
-    {/* <div>
+  {/* <div>
         <Link href="/design/ui-patterns/button-usage">
             <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />
         </Link>
     </div> */}
-    <div>
-        <Link href="/design/ui-patterns/button-usage" fontWeight="bold">Button usage</Link>
-        <Box as="p">Buttons are a fundamental building block of the GitHub UI. These guidelines summarize how to use buttons across the product.</Box>
-    </div>
-    {/* <div>
+  <div>
+    <Link href="/design/ui-patterns/button-usage" fontWeight="bold">
+      Button usage
+    </Link>
+    <Box as="p">
+      Buttons are a fundamental building block of the GitHub UI. These guidelines summarize how to use buttons across
+      the product.
+    </Box>
+  </div>
+  {/* <div>
         <Link href="/design/ui-patterns/empty-states">
             <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png" />
         </Link>
     </div> */}
-    <div>
-        <Link href="/design/ui-patterns/empty-states" fontWeight="bold">Empty states</Link>
-        <Box as="p">Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the blankslate component and designing empty states.</Box>
-    </div>
-    {/* <div>
+  <div>
+    <Link href="/design/ui-patterns/empty-states" fontWeight="bold">
+      Empty states
+    </Link>
+    <Box as="p">
+      Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature
+      of the feature. These guidelines demonstrate best practices for using the blankslate component and designing empty
+      states.
+    </Box>
+  </div>
+  {/* <div>
         <Link href="/design/ui-patterns/feature-onboarding">
             <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />
         </Link>
     </div> */}
-    <div>
-        <Link href="/design/ui-patterns/feature-onboarding" fontWeight="bold">Feature onboarding</Link>
-        <Box as="p">Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.</Box>
-    </div>
-    {/* <div>
+  <div>
+    <Link href="/design/ui-patterns/feature-onboarding" fontWeight="bold">
+      Feature onboarding
+    </Link>
+    <Box as="p">
+      Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for
+      designing onboarding for the product and does not include what to do for marketing pages, email announcements,
+      social media, etc.
+    </Box>
+  </div>
+  {/* <div>
         <Link href="/design/ui-patterns/messaging">
             <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />
         </Link>
     </div> */}
-    <div>
-        <Link href="/design/ui-patterns/messaging" fontWeight="bold">Messaging</Link>
-        <Box as="p">Messaging components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more. Primer includes three different messaging components: toasts, flash alerts, popovers.</Box>
-    </div>
-    {/* <div>
+  <div>
+    <Link href="/design/ui-patterns/messaging" fontWeight="bold">
+      Messaging
+    </Link>
+    <Box as="p">
+      Messaging components are used to provide important and relevant information to the user, including feedback,
+      contextual information, product updates, and more. Primer includes three different messaging components: toasts,
+      flash alerts, popovers.
+    </Box>
+  </div>
+  {/* <div>
         <Link href="/design/ui-patterns/progressive-disclosure">
             <img role="presentation" src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png" />
         </Link>
     </div> */}
-    <div>
-        <Link href="/design/ui-patterns/progressive-disclosure" fontWeight="bold">Progressive disclosure</Link>
-        <Box as="p">These guidelines summarize how to use progressive disclosure, as well as guiding principles, best practices, and implementation support.</Box>
-    </div>
-    {/* <div>
+  <div>
+    <Link href="/design/ui-patterns/progressive-disclosure" fontWeight="bold">
+      Progressive disclosure
+    </Link>
+    <Box as="p">
+      These guidelines summarize how to use progressive disclosure, as well as guiding principles, best practices, and
+      implementation support.
+    </Box>
+  </div>
+  {/* <div>
         <Link href="/design/ui-patterns/saving">
             <img role="presentation" src="" />
         </Link>
     </div> */}
-    <div>
-        <Link href="/design/ui-patterns/saving" fontWeight="bold">Saving</Link>
-        <Box as="p">Saving and submitting data is critical to task completion. Use these guidelines to ensure your workflows are consistent and accessible.</Box>
-    </div>
+  <div>
+    <Link href="/design/ui-patterns/saving" fontWeight="bold">
+      Saving
+    </Link>
+    <Box as="p">
+      Saving and submitting data is critical to task completion. Use these guidelines to ensure your workflows are
+      consistent and accessible.
+    </Box>
+  </div>
 </Grid>

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -3,8 +3,8 @@ title: UI patterns
 ---
 
 import {Box, Link, Text, Label} from '@primer/react'
-import {Grid} from '@primer/react/deprecated'
-import {Flex} from '@primer/react/deprecated'
+import {Grid} from '@primer/react'
+import {Flex} from '@primer/react'
 
 <Grid gridGap={4}>
   {/* <div>

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -2,13 +2,11 @@
 title: UI patterns
 ---
 
-import { Grid, Box, Link, Text, Label } from '@primer/react'
+import {Box, Link, Text, Label} from '@primer/react'
+import {Grid} from '@primer/react/deprecated'
+import {Flex} from '@primer/react/deprecated'
 
-<Grid gridGap
-
-import { Flex } from '@primer/react/deprecated';
-
-={4}>
+<Grid gridGap={4}>
   {/* <div>
         <Link href="/design/ui-patterns/button-usage">
             <img role="presentation" src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png" />

--- a/content/ui-patterns/messaging.mdx
+++ b/content/ui-patterns/messaging.mdx
@@ -2,7 +2,7 @@
 title: Messaging
 ---
 
-import {Box, Flex} from '@primer/components'
+import {Box, Flex} from '@primer/react'
 
 Messaging components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more.
 

--- a/content/ui-patterns/messaging.mdx
+++ b/content/ui-patterns/messaging.mdx
@@ -2,9 +2,13 @@
 title: Messaging
 ---
 
-import {Box, Flex} from '@primer/react'
+import { Box } from '@primer/react'
 
-Messaging components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more.
+Messaging
+
+import { Flex } from '@primer/react/deprecated';
+
+ components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more.
 
 Primer includes three different messaging components:
 

--- a/content/ui-patterns/messaging.mdx
+++ b/content/ui-patterns/messaging.mdx
@@ -2,13 +2,13 @@
 title: Messaging
 ---
 
-import { Box } from '@primer/react'
+import {Box} from '@primer/react'
 
 Messaging
 
-import { Flex } from '@primer/react/deprecated';
+import {Flex} from '@primer/react'
 
- components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more.
+components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more.
 
 Primer includes three different messaging components:
 

--- a/content/ui-patterns/progressive-disclosure.mdx
+++ b/content/ui-patterns/progressive-disclosure.mdx
@@ -2,7 +2,7 @@
 title: Progressive disclosure
 ---
 
-import {Flex, BorderBox} from '@primer/components'
+import {Flex, BorderBox} from '@primer/react'
 
 These guidelines summarize how GitHub implements progressive disclosure—an interaction design pattern that hides/shows information—as well as guiding principles, best practices, and implementation support.
 
@@ -32,9 +32,9 @@ The following table outlines common progressive disclosure solutions in use at G
 
 | Component                       | Icon                                                                                                              | Usage                                                          | Notes                                                                                                                             |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [Chevron icon](#chevron-icon)   | ![chevron](https://user-images.githubusercontent.com/24916540/52089727-1ae9d480-2564-11e9-8291-1ee9d3225427.png)  | When elements of content are collapsed and can be toggled open | Do not use this icon to trigger dropdown menus or navigation; the caret icon is the more suitable for this.                     |
+| [Chevron icon](#chevron-icon)   | ![chevron](https://user-images.githubusercontent.com/24916540/52089727-1ae9d480-2564-11e9-8291-1ee9d3225427.png)  | When elements of content are collapsed and can be toggled open | Do not use this icon to trigger dropdown menus or navigation; the caret icon is the more suitable for this.                       |
 | [Fold/Unfold icon](#foldunfold) | ![expand](https://user-images.githubusercontent.com/24916540/52089724-1a513e00-2564-11e9-84f8-eba077f6abfc.png)   | Signify that there is content (typically text) to be revealed  | Should generally stand alone, rather than being paired with text                                                                  |
-| [Ellipsis icon](#ellipsis-icon) | ![ellipsis](https://user-images.githubusercontent.com/24916540/52089725-1ae9d480-2564-11e9-8d29-1dc28740924a.png) | For toggling truncated inline text content                     | Do not use this icon to trigger dropdown menus or navigation; the Kebab icon is the more suitable for this.                     |
+| [Ellipsis icon](#ellipsis-icon) | ![ellipsis](https://user-images.githubusercontent.com/24916540/52089725-1ae9d480-2564-11e9-8d29-1dc28740924a.png) | For toggling truncated inline text content                     | Do not use this icon to trigger dropdown menus or navigation; the Kebab icon is the more suitable for this.                       |
 | Text-only toggles               |                                                                                                                   |                                                                | Usage of this solution is discouraged, as generally icons or icon+text pairings provide better accessibility and more information |
 | Kebab                           | ![kebab](https://user-images.githubusercontent.com/24916540/52089726-1ae9d480-2564-11e9-984b-2d304cc0d46e.png)    | N/A                                                            | For toggling inline dropdowns and menus                                                                                           |
 | Caret                           | ![caret](https://user-images.githubusercontent.com/24916540/52089723-1a513e00-2564-11e9-8179-420bba7922e7.png)    | N/A                                                            | Refrain from using this icon as a progressive disclosure solution                                                                 |

--- a/content/ui-patterns/progressive-disclosure.mdx
+++ b/content/ui-patterns/progressive-disclosure.mdx
@@ -2,13 +2,13 @@
 title: Progressive disclosure
 ---
 
-import { BorderBox } from '@primer/react'
+import {BorderBox} from '@primer/react'
 
 These
 
-import { Flex } from '@primer/react/deprecated';
+import {Flex} from '@primer/react'
 
- guidelines summarize how GitHub implements progressive disclosure—an interaction design pattern that hides/shows information—as well as guiding principles, best practices, and implementation support.
+guidelines summarize how GitHub implements progressive disclosure—an interaction design pattern that hides/shows information—as well as guiding principles, best practices, and implementation support.
 
 ## Guiding principles
 

--- a/content/ui-patterns/progressive-disclosure.mdx
+++ b/content/ui-patterns/progressive-disclosure.mdx
@@ -2,9 +2,13 @@
 title: Progressive disclosure
 ---
 
-import {Flex, BorderBox} from '@primer/react'
+import { BorderBox } from '@primer/react'
 
-These guidelines summarize how GitHub implements progressive disclosure—an interaction design pattern that hides/shows information—as well as guiding principles, best practices, and implementation support.
+These
+
+import { Flex } from '@primer/react/deprecated';
+
+ guidelines summarize how GitHub implements progressive disclosure—an interaction design pattern that hides/shows information—as well as guiding principles, best practices, and implementation support.
 
 ## Guiding principles
 

--- a/content/ui-patterns/saving.mdx
+++ b/content/ui-patterns/saving.mdx
@@ -2,10 +2,11 @@
 title: Saving
 ---
 
-import {Box, Text} from '@primer/components'
+import {Box, Text} from '@primer/react'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
-    Save patterns help users store and update their content and configuration throughout GitHub. These changes should be represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
+  Save patterns help users store and update their content and configuration throughout GitHub. These changes should be
+  represented in the UI accurately, quickly, and obviously. Their behavior should inspire confidence and trust.
 </Box>
 
 ## Explicit saving
@@ -18,11 +19,17 @@ If there is an error saving the data, the user's data should be preserved in the
 
 <DoDontContainer>
   <Do>
-    <img alt="A form broken into two sections where one section has a dropdown that automatically saves" src="https://user-images.githubusercontent.com/2313998/159594852-aa1223c7-201e-42ea-9109-649371709d22.png" />
+    <img
+      alt="A form broken into two sections where one section has a dropdown that automatically saves"
+      src="https://user-images.githubusercontent.com/2313998/159594852-aa1223c7-201e-42ea-9109-649371709d22.png"
+    />
     <Caption>Separate auto-saving controls from an explicitly saved form</Caption>
   </Do>
   <Dont>
-    <img alt="A form with a single section and it contains a dropdown that automatically saves" src="https://user-images.githubusercontent.com/2313998/159594854-8edb9736-bdd1-436c-a327-8525b6ddac0c.png" />
+    <img
+      alt="A form with a single section and it contains a dropdown that automatically saves"
+      src="https://user-images.githubusercontent.com/2313998/159594854-8edb9736-bdd1-436c-a327-8525b6ddac0c.png"
+    />
     <Caption>Don't mix auto-saving controls and explicitly saved controls in the same form</Caption>
   </Dont>
 </DoDontContainer>
@@ -59,7 +66,6 @@ There are a few issues to bear in mind with autosaving declarative controls.
 - Radio button groups: Screenreader users can't read the options without selecting them, which could accidentally apply a selection the user didn't want.
 - Browser-native `<select>` dropdowns: Similarly to radio button groups, options could be selected when a user focuses the select and uses the arrow keys to read through each option.
 
-
 ### Calls to action
 
 When data is not automatically saved after the user makes changes, buttons are used to submit or cancel the changes.
@@ -69,6 +75,7 @@ When data is not automatically saved after the user makes changes, buttons are u
 All configuration flows should have calls to action that include an obvious active verb such as "Create", "Save", "Delete", or "Update" (for example, "Create" a new repository, "Add" an SSH key to your profile, "Save" security preferences, "Update" a repository's description, "Delete" an old email address).
 
 When defining these calls to actions, make sure to:
+
 1. Keep the text as succinct and clear as possible
 2. Add the item’s name to the button text in cases where it may be unclear to the user what is being changed
 
@@ -91,27 +98,40 @@ When defining these calls to actions, make sure to:
 
 For more guidance on button usage, see the [button interface guidelines](/ui-patterns/button-usage).
 
-<Box mb={3} display="flex" alignItems="flex-start" justifyContent="space-between" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <Box mb={3} display="flex" alignItems="center" flexDirection="column" mx="auto" sx={{gap: 2}}>
-        <img
-            width="456"
-            src="https://user-images.githubusercontent.com/2313998/152432687-e119f44c-9325-4ae7-b277-e8559a4eb37b.png"
-        />
-        <Text as="p" mt="0" align="center" fontSize={1}>Controls all belong to one form</Text>
-        <img
-            width="456"
-            alt="A small form in a dialog that has 'Cancel' and 'Save' buttons at the bottom right"
-            src="https://user-images.githubusercontent.com/2313998/151623724-d59d5967-5484-4e81-a4c2-1109409956ee.png"
-        />
-        <Text as="p" mt="0" align="center" fontSize={1}>A form with a button to save and a button to cancel</Text>
-    </Box>
-    <Box mb={3} display="flex" alignItems="center" flexDirection="column" mx="auto" sx={{gap: 2}}>
-        <img
-            width="456"
-            src="https://user-images.githubusercontent.com/2313998/152432688-e74f67b2-a777-4c5f-be45-37a43615e6ab.png"
-        />
-        <Text as="p" mt="0" align="center" fontSize={1}>Controls divided into multiple sections</Text>
-    </Box>
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  justifyContent="space-between"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <Box mb={3} display="flex" alignItems="center" flexDirection="column" mx="auto" sx={{gap: 2}}>
+    <img
+      width="456"
+      src="https://user-images.githubusercontent.com/2313998/152432687-e119f44c-9325-4ae7-b277-e8559a4eb37b.png"
+    />
+    <Text as="p" mt="0" align="center" fontSize={1}>
+      Controls all belong to one form
+    </Text>
+    <img
+      width="456"
+      alt="A small form in a dialog that has 'Cancel' and 'Save' buttons at the bottom right"
+      src="https://user-images.githubusercontent.com/2313998/151623724-d59d5967-5484-4e81-a4c2-1109409956ee.png"
+    />
+    <Text as="p" mt="0" align="center" fontSize={1}>
+      A form with a button to save and a button to cancel
+    </Text>
+  </Box>
+  <Box mb={3} display="flex" alignItems="center" flexDirection="column" mx="auto" sx={{gap: 2}}>
+    <img
+      width="456"
+      src="https://user-images.githubusercontent.com/2313998/152432688-e74f67b2-a777-4c5f-be45-37a43615e6ab.png"
+    />
+    <Text as="p" mt="0" align="center" fontSize={1}>
+      Controls divided into multiple sections
+    </Text>
+  </Box>
 </Box>
 
 #### State
@@ -131,7 +151,7 @@ Do not disable or hide a form's save button even if the form is invalid or has n
 
 #### Placement
 
-Place save buttons somewhere intuitive and easily accessible. 
+Place save buttons somewhere intuitive and easily accessible.
 
 - There should only be one save button on a page.
 - Place save buttons somewhere intuitive and easily accessible. If all of the fields save automatically, do not include a save button. This makes it unclear when data is being saved. See the guidelines on [explicit saving](#explicit-saving) and [automatic saving](#automatic-saving) for more information.
@@ -139,11 +159,17 @@ Place save buttons somewhere intuitive and easily accessible.
 
 <DoDontContainer>
   <Do>
-    <img alt="A form with one save button at the bottom" src="https://user-images.githubusercontent.com/2313998/151887934-cfcc5130-53a8-4f40-ba36-97148ead72c0.png" />
+    <img
+      alt="A form with one save button at the bottom"
+      src="https://user-images.githubusercontent.com/2313998/151887934-cfcc5130-53a8-4f40-ba36-97148ead72c0.png"
+    />
     <Caption>Have one save button per form</Caption>
   </Do>
   <Dont>
-    <img alt="A form with two sections. Each section has it's own save button." src="https://user-images.githubusercontent.com/2313998/151887938-1fa6b5d7-c5c1-4010-ab99-e5c37bff8c0a.png" />
+    <img
+      alt="A form with two sections. Each section has it's own save button."
+      src="https://user-images.githubusercontent.com/2313998/151887938-1fa6b5d7-c5c1-4010-ab99-e5c37bff8c0a.png"
+    />
     <Caption>Don't have one save button per section of a form</Caption>
   </Dont>
 </DoDontContainer>
@@ -152,39 +178,64 @@ Place save buttons somewhere intuitive and easily accessible.
 
 If there is a button to submit and a button to cancel, the cancel button should go to the **right** of the submit button.
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <img
-        width="456"
-        alt="A form with the controls and save button left aligned"
-        src="https://user-images.githubusercontent.com/2313998/155623608-440c8f2c-dbb1-4b3c-a76e-7f01af63b3a8.png"
-    />
-    <Box as="p" mt="0">Default to placing the submit button at the bottom left of the form. Labels and inputs are left-aligned and run from top-to-bottom, so users would naturally move their eyes down and to the left.</Box>
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <img
+    width="456"
+    alt="A form with the controls and save button left aligned"
+    src="https://user-images.githubusercontent.com/2313998/155623608-440c8f2c-dbb1-4b3c-a76e-7f01af63b3a8.png"
+  />
+  <Box as="p" mt="0">
+    Default to placing the submit button at the bottom left of the form. Labels and inputs are left-aligned and run from
+    top-to-bottom, so users would naturally move their eyes down and to the left.
+  </Box>
 </Box>
 
 ##### Bottom-right (dialogs and comments)
 
 If there is a button to submit and a button to cancel, the button to cancel should go to the **left** of the submit button.
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <img
-        width="456"
-        alt="A small form in a dialog that has 'Cancel' and 'Save' buttons at the bottom right"
-        src="https://user-images.githubusercontent.com/2313998/151623724-d59d5967-5484-4e81-a4c2-1109409956ee.png"
-    />
-    <Box as="p" mt="0">If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog buttons feel familiar because it's a common pattern across various platforms such as Windows, macOS, and Android.</Box>
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <img
+    width="456"
+    alt="A small form in a dialog that has 'Cancel' and 'Save' buttons at the bottom right"
+    src="https://user-images.githubusercontent.com/2313998/151623724-d59d5967-5484-4e81-a4c2-1109409956ee.png"
+  />
+  <Box as="p" mt="0">
+    If the save button is used in a dialog, place the button at the bottom right of the dialog. Right-aligned dialog
+    buttons feel familiar because it's a common pattern across various platforms such as Windows, macOS, and Android.
+  </Box>
 </Box>
 
-<Box mb={3} display="flex" alignItems="flex-start" flexDirection={["column", "column", "column", "column", "row"]} sx={{gap: 3}}>
-    <img
-        width="456"
-        alt="A multi-line text input with 'Close with Comment' and 'Comment' buttons right-aligned below the input"
-        src="https://user-images.githubusercontent.com/2313998/158623777-a4bb25ec-e1a0-4feb-bd56-e46a69c7f768.png"
-    />
-    <Box as="p" mt="0">
-        If the button is used to send a message such as a comment on an issue, right-align the button below the text area. This is where GitHub has traditionally placed the <strong>Submit</strong> button for issues and pull requests, and it's common practice in other apps to place a <strong>Send</strong> button to the right.
-    </Box>
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <img
+    width="456"
+    alt="A multi-line text input with 'Close with Comment' and 'Comment' buttons right-aligned below the input"
+    src="https://user-images.githubusercontent.com/2313998/158623777-a4bb25ec-e1a0-4feb-bd56-e46a69c7f768.png"
+  />
+  <Box as="p" mt="0">
+    If the button is used to send a message such as a comment on an issue, right-align the button below the text area.
+    This is where GitHub has traditionally placed the <strong>Submit</strong> button for issues and pull requests, and
+    it's common practice in other apps to place a <strong>Send</strong> button to the right.
+  </Box>
 </Box>
-
 
 <!--
 TODO:
@@ -200,9 +251,9 @@ To simplify the interface, some content may be edited inline without taking the 
 An input used for inline editing should have a save button placed very close to visually connect the input with the button.
 
 <img
-    width="960"
-    alt="Two images of a pull request header. The first image shows the title as read-only text. The second image shows a text input to edit the pull request title with 'Cancel' and 'Save' buttons below the input."
-    src="https://user-images.githubusercontent.com/2313998/158624334-fcd4e268-d144-4420-98ed-819c51631e7e.png"
+  width="960"
+  alt="Two images of a pull request header. The first image shows the title as read-only text. The second image shows a text input to edit the pull request title with 'Cancel' and 'Save' buttons below the input."
+  src="https://user-images.githubusercontent.com/2313998/158624334-fcd4e268-d144-4420-98ed-819c51631e7e.png"
 />
 
 ##### Other
@@ -214,25 +265,37 @@ If you believe your submit button will not be intuitive or easily accessible usi
 Automatic saving applies changes as they are made. Automatic saving should be used when the user expects instant feedback from the change they made.
 
 <Box mb={3} display="flex" alignItems="center" flexDirection="column" mt={6} mx="auto" sx={{gap: 2, maxWidth: '450px'}}>
-    <Box display="inline-block" overflow="hidden" borderWidth="1px" borderColor="border.default" borderStyle="solid" borderRadius="12px">
-        <img
-            width="456"
-            src="https://user-images.githubusercontent.com/2313998/152013139-02eb5213-bb19-4c8d-8b19-01f1d73602d1.gif"
-            alt="Opening the 'Watch' dropdown menu and changing. It saves automatically."
-        />
-    </Box>
-    <Text as="p" mt="0" align="center" fontSize={1}>If a form field is saved automatically, it should be obvious whether or not it saved without using text or visual indicators. A visual indicator for whether or not a form field has been saved successfully could be mistaken as a validation status.</Text>
+  <Box
+    display="inline-block"
+    overflow="hidden"
+    borderWidth="1px"
+    borderColor="border.default"
+    borderStyle="solid"
+    borderRadius="12px"
+  >
+    <img
+      width="456"
+      src="https://user-images.githubusercontent.com/2313998/152013139-02eb5213-bb19-4c8d-8b19-01f1d73602d1.gif"
+      alt="Opening the 'Watch' dropdown menu and changing. It saves automatically."
+    />
+  </Box>
+  <Text as="p" mt="0" align="center" fontSize={1}>
+    If a form field is saved automatically, it should be obvious whether or not it saved without using text or visual
+    indicators. A visual indicator for whether or not a form field has been saved successfully could be mistaken as a
+    validation status.
+  </Text>
 </Box>
 
 ### Imperative controls
 
 To reduce UI and give instant feedback, you should use automatic saving (and not explicit saving) for imperative controls. These are:
+
 - [Toggle switches](/components/toggle-switch). The toggle switch behaves like a light switch: the light just switches on and off without you having to confirm each time you flip the switch.
 - Single-select dropdowns that are not native `<select>` dropdowns or part of an explicitly saved form. Single-select dropdowns behave like a radio dial: the station starts playing as soon as you select it.
 
 ### Dropdown menu accessibility
 
-Semantic menus should only have a list of options to select from and should not have a save button in their dropdown. As soon as additional features (search inputs, filters, tabs, etc) are added, the component should be treated like a dialog with a button to submit and a button to cancel. 
+Semantic menus should only have a list of options to select from and should not have a save button in their dropdown. As soon as additional features (search inputs, filters, tabs, etc) are added, the component should be treated like a dialog with a button to submit and a button to cancel.
 
 ## Feedback
 
@@ -241,7 +304,10 @@ If the change is not obvious within the user's viewport, provide feedback to let
 - If the change occurred without a redirect or page refresh, you can use the [toast component](https://primer.style/design/ui-patterns/messaging#toasts).
 - If the change occurred and the page refreshes or redirects, you can use a [flash banner component](https://primer.style/design/ui-patterns/messaging#flash-alerts).
 
-<Note variant="warning">If your design is being implemented in github.com, avoid using a toast for now. The toast components used on github.com have accessibility issues that need to be fixed.</Note>
+<Note variant="warning">
+  If your design is being implemented in github.com, avoid using a toast for now. The toast components used on
+  github.com have accessibility issues that need to be fixed.
+</Note>
 
 ## Error forgiveness
 
@@ -249,19 +315,34 @@ Before submitting a form with potentially destructive consequences (for example,
 
 For risky changes, provide a way to undo those changes after saving.
 
-<Box display="flex" alignItems="center" flexDirection="column"mx="auto" sx={{gap: 1}}>
-    <Box display="inline-block" overflow="hidden" borderWidth="1px" borderColor="border.default" borderStyle="solid" borderRadius="12px">
-        <img width="960" src="https://user-images.githubusercontent.com/2313998/152434199-a067b037-baf8-4093-8796-b0bb58344223.png" />
-    </Box>
-    <Text as="p" mt="0" align="center" fontSize={1}>After merging a pull request, a button appears to revert the changes</Text>
+<Box display="flex" alignItems="center" flexDirection="column" mx="auto" sx={{gap: 1}}>
+  <Box
+    display="inline-block"
+    overflow="hidden"
+    borderWidth="1px"
+    borderColor="border.default"
+    borderStyle="solid"
+    borderRadius="12px"
+  >
+    <img
+      width="960"
+      src="https://user-images.githubusercontent.com/2313998/152434199-a067b037-baf8-4093-8796-b0bb58344223.png"
+    />
+  </Box>
+  <Text as="p" mt="0" align="center" fontSize={1}>
+    After merging a pull request, a button appears to revert the changes
+  </Text>
 </Box>
 
 ## Redirecting
 
 When creating new content like issues, discussions, or even larger entities such as repositories or organizations, you may redirect the user to the entity they just created at the end of the flow.
 
-In some cases, such as forking or using a template, you may need to hold the user at a waiting page while the entity is generated. In these cases, make the user feel confident that something is happening and that their configuration details will not be lost. 
+In some cases, such as forking or using a template, you may need to hold the user at a waiting page while the entity is generated. In these cases, make the user feel confident that something is happening and that their configuration details will not be lost.
 
 <Box overflow="hidden" borderWidth="1px" borderColor="border.default" borderStyle="solid" borderRadius="12px">
-    <img src="https://user-images.githubusercontent.com/2313998/151446009-58bfb92f-00e1-4a15-a2a3-f1afb6fb4031.gif" alt="Screen recording of a user forking a repository" />
+  <img
+    src="https://user-images.githubusercontent.com/2313998/151446009-58bfb92f-00e1-4a15-a2a3-f1afb6fb4031.gif"
+    alt="Screen recording of a user forking a repository"
+  />
 </Box>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-github": "1.6.0",
     "gatsby": "^2.32.13",
     "gatsby-plugin-alias-imports": "^1.0.5",
+    "primer-react-migrate": "^0.5.0",
     "react": "16.9.x",
     "react-dom": "16.9.x",
     "yarn": "^1.22.18"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@primer/gatsby-theme-doctocat": "^4.0.0 ",
     "@primer/octicons-react": "^11.0.0",
+    "@primer/react": "^35.2.2",
     "eslint": "5.8.0",
     "eslint-plugin-github": "1.6.0",
     "gatsby": "^2.32.13",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "^3.1.1",
+    "@primer/gatsby-theme-doctocat": "^4.0.0 ",
     "@primer/octicons-react": "^11.0.0",
     "eslint": "5.8.0",
     "eslint-plugin-github": "1.6.0",

--- a/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -1,4 +1,4 @@
-import {Box, Heading, ThemeProvider} from '@primer/components'
+import {Box, Heading, ThemeProvider} from '@primer/react'
 import React from 'react'
 import {Container} from '@primer/gatsby-theme-doctocat'
 import heroIllustration from '../../../hero-illustration.svg'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,7 +1014,7 @@
     core-js-pure "^3.16.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
   integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
@@ -1025,6 +1025,13 @@
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
   integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.7.6":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1604,56 +1611,38 @@
     style-value-types "^3.1.7"
     tslib "^1.10.0"
 
+"@primer/behaviors@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.1.1.tgz#51e2f02ebfe297c4c05f503cdc52ae8b4ce5794c"
+  integrity sha512-wvF1PYjyxKNTr6+5w4uR5Gkz53t1fsRDgKjWxDKk7wmlh0cwiILBo4dDFjjVhWRF1mBSjaIxxJGB4WGaP7ct2Q==
+
 "@primer/component-metadata@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@primer/component-metadata/-/component-metadata-0.4.0.tgz#44b7d7b1285bea41c2a88621fd17f2c777a4c5e9"
   integrity sha512-yppmDSSDrN2CHwjq3h+RWhfpjehFQAx21JcEipYyNTp0f/kC+iazFVNCKZE6DOavAxv003ti7QIrp+QkPT9tpg==
 
-"@primer/components@^30.0.0":
-  version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/components/-/components-30.3.0.tgz#e62d10bd891699f8455b297f4577ed9c58de4334"
-  integrity sha512-5W2WQtTzBsGE12+SIcc49RlosgkoamFDMkwNh5kKuQq1Ni9fXjxfWQaykh8CaWydcywMfnZbPcESKnuu+KfLZQ==
-  dependencies:
-    "@primer/octicons-react" "^13.0.0"
-    "@primer/primitives" "4.8.1"
-    "@radix-ui/react-polymorphic" "0.0.14"
-    "@react-aria/ssr" "3.1.0"
-    "@styled-system/css" "5.1.5"
-    "@styled-system/props" "5.1.5"
-    "@styled-system/theme-get" "5.1.2"
-    "@types/history" "4.7.8"
-    "@types/styled-components" "5.1.11"
-    "@types/styled-system" "5.1.12"
-    "@types/styled-system__css" "5.0.16"
-    "@types/styled-system__theme-get" "5.0.1"
-    classnames "2.3.1"
-    color2k "1.2.4"
-    deepmerge "4.2.2"
-    focus-visible "5.2.0"
-    styled-system "5.1.5"
-
-"@primer/gatsby-theme-doctocat@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-3.1.1.tgz#66dfaaff71a5ac21f7d6c1b06fbecec8edb67034"
-  integrity sha512-TQxb9RcDQEVp9aEY69ZplrTVoiNys6xTP7fHWJ+brOStJDc4g5RjPirBy3l3zEal8BPZk7A5NdwHBp9/hu2Uyw==
+"@primer/gatsby-theme-doctocat@^4.0.0 ":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.0.0.tgz#29c916ce62f14f7e70c0e8c9195ff38d89467ffa"
+  integrity sha512-V6+cANzIKbPh4KHl+WtGBnRzIRt9WWfI5o1iTOwfmoPz7NOpU63kHmvmhofdbS64Nnv/1urc+eI3NIBfO4XbVQ==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
     "@mdx-js/mdx" "^1.0.21"
     "@mdx-js/react" "^1.0.21"
     "@primer/component-metadata" "^0.4.0"
-    "@primer/components" "^30.0.0"
-    "@primer/octicons-react" "^16.0.0"
+    "@primer/octicons-react" "^16.3.1"
+    "@primer/react" "^35.2.2"
     "@styled-system/theme-get" "^5.0.12"
-    "@testing-library/jest-dom" "^4.1.0"
+    "@testing-library/jest-dom" "^5.16.2"
     "@testing-library/react" "^9.1.3"
     axios "^0.21.2"
     babel-jest "^24.9.0"
     copy-to-clipboard "^3.2.0"
-    date-fns "^2.0.1"
+    date-fns "^2.28.0"
     details-element-polyfill "^2.4.0"
     downshift "^3.2.10"
-    find-up "^4.1.0"
+    find-up "^6.3.0"
     framer-motion "^1.4.2"
     fuse.js "^3.4.5"
     gatsby-plugin-catch-links "^2.1.2"
@@ -1675,12 +1664,12 @@
     pluralize "^8.0.0"
     preval.macro "^3.0.0"
     prism-react-renderer "^1.2.0"
-    prismjs "^1.25.0"
+    prismjs "^1.27.0"
     react-addons-text-content "^0.0.4"
     react-element-to-jsx-string "^14.0.3"
     react-focus-on "^3.3.0"
-    react-frame-component "^4.1.1"
-    react-helmet "^5.2.1"
+    react-frame-component "^5.2.1"
+    react-helmet "^6.1.0"
     react-live "^2.1.2"
     react-measure "^2.3.0"
     read-pkg-up "^6.0.0"
@@ -1689,25 +1678,49 @@
     styled-system "^5.0.18"
     worker-loader "^3.0.2"
 
+"@primer/octicons-react@16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-16.1.1.tgz#6a9eaffbbf46cb44d344a37a5ff2384973b82d3f"
+  integrity sha512-xCxQ5z23ol7yDuJs85Lc4ARzyoay+b3zOhAKkEMU7chk0xi2hT2OnRP23QUudNNDPTGozX268RGYLexUa6P4xw==
+
 "@primer/octicons-react@^11.0.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-11.3.0.tgz#794641d95ff5749a9438a2e0c201956b2a377b60"
   integrity sha512-4sVhkrBKuj3h+PFw69yOyO/l3nQB/mm95V+Kz7LRSlIrbZr6hZarZD5Ft4ewdONPROkIHQM/6KSK90+OAimxsQ==
 
-"@primer/octicons-react@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-13.0.0.tgz#a7f2288fd9cf9cabc1e75553a0dd9f00d74b68c1"
-  integrity sha512-j5XppNRCvgaMZLPsVvvmp6GSh7P5pq6PUbsfLNBWi2Kz3KYDeoGDWbPr5MjoxFOGUn6Hjnt6qjHPRxahd11vLQ==
+"@primer/octicons-react@^16.3.1":
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-16.3.1.tgz#86982fe1001eee138d5ee46accbcdf62d51d11c5"
+  integrity sha512-uzTs8/CvLiW1/47cgMRkIK9bKWpnw+UonCbgczXErwSSLqMDHfiiTpobW1trvRuoiMgLwsPo0l7kBBdKBnmq3g==
 
-"@primer/octicons-react@^16.0.0":
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-16.2.0.tgz#702f59169dd763dc03e613b0e881aa715da37a5c"
-  integrity sha512-943t5kkVRt+/hxVnKS27xweUp4lXFxwJaTrsit1C1xBB4kqdjzmYGpU84zwKsNyyV2Ch7may3umKjbI/mFBPPQ==
+"@primer/primitives@7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-7.6.0.tgz#942efe38b6e09bf6d0351c045436e628e32c3ddb"
+  integrity sha512-cu28QLjectVf2rT4P7m6zS9v4g4yHtErRuPfsgEWEJhbXVIII6vDBm6elJzYixGpTNxpVtSUNezxUXv16l1ejQ==
 
-"@primer/primitives@4.8.1":
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-4.8.1.tgz#05f76e47f67018514fd54b35ca615b9d27ef2a46"
-  integrity sha512-mgr6+EKpn4DixuhLt3drk7QmNQO8M7RYONWovg1nkV7p56jklhDLfZmp1luLUee37eQGAxx3ToStL6gqINFjnQ==
+"@primer/react@^35.2.2":
+  version "35.2.2"
+  resolved "https://registry.yarnpkg.com/@primer/react/-/react-35.2.2.tgz#b64c406b4e17a01cb0c850e9b6dea06ad4690393"
+  integrity sha512-JToTi4YwOJ5mlvSBF66Csz35fLeMl6PeGYcXqwE34giGXRrOLRID+eHVPZPWUEDo/Sg389cVYR44ueM03/C56A==
+  dependencies:
+    "@primer/behaviors" "1.1.1"
+    "@primer/octicons-react" "16.1.1"
+    "@primer/primitives" "7.6.0"
+    "@radix-ui/react-polymorphic" "0.0.14"
+    "@react-aria/ssr" "3.1.0"
+    "@styled-system/css" "5.1.5"
+    "@styled-system/props" "5.1.5"
+    "@styled-system/theme-get" "5.1.2"
+    "@types/styled-components" "5.1.11"
+    "@types/styled-system" "5.1.12"
+    "@types/styled-system__css" "5.0.16"
+    "@types/styled-system__theme-get" "5.0.1"
+    classnames "2.3.1"
+    color2k "1.2.4"
+    deepmerge "4.2.2"
+    focus-visible "5.2.0"
+    history "5.0.0"
+    styled-system "5.1.5"
 
 "@radix-ui/react-polymorphic@0.0.14":
   version "0.0.14"
@@ -1917,19 +1930,19 @@
     pretty-format "^25.1.0"
     wait-for-expect "^3.0.2"
 
-"@testing-library/jest-dom@^4.1.0":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
-  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+"@testing-library/jest-dom@^5.16.2":
+  version "5.16.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz#938302d7b8b483963a3ae821f1c0808f872245cd"
+  integrity sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==
   dependencies:
-    "@babel/runtime" "^7.5.1"
-    chalk "^2.4.1"
-    css "^2.2.3"
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css "^3.0.0"
     css.escape "^1.5.1"
-    jest-diff "^24.0.0"
-    jest-matcher-utils "^24.0.0"
-    lodash "^4.17.11"
-    pretty-format "^24.0.0"
+    dom-accessibility-api "^0.5.6"
+    lodash "^4.17.15"
     redent "^3.0.0"
 
 "@testing-library/react@^9.1.3":
@@ -2066,11 +2079,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/history@4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2112,6 +2120,14 @@
   integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.1.tgz#2c8b6dc6ff85c33bcd07d0b62cb3d19ddfdb3ab9"
+  integrity sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
 
 "@types/json-patch@0.0.30":
   version "0.0.30"
@@ -2282,6 +2298,13 @@
   integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
   dependencies:
     pretty-format "^24.3.0"
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.14.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz#ee6c7ffe9f8595882ee7bda8af33ae7b8789ef17"
+  integrity sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/testing-library__react@^9.1.2":
   version "9.1.3"
@@ -2755,6 +2778,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -2844,6 +2872,11 @@ aria-query@^4.0.2, aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4753,15 +4786,14 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^2.2.3:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
   dependencies:
-    inherits "^2.0.3"
+    inherits "^2.0.4"
     source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4909,10 +4941,15 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
-date-fns@^2.0.1, date-fns@^2.14.0:
+date-fns@^2.14.0:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
   integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.9:
   version "2.6.9"
@@ -5191,6 +5228,11 @@ diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
+
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -6572,6 +6614,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.3.0.tgz#2abab3d3280b2dc7ac10199ef324c4e002c8c790"
+  integrity sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==
+  dependencies:
+    locate-path "^7.1.0"
+    path-exists "^5.0.0"
+
 flat-cache@^1.2.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
@@ -7912,6 +7962,13 @@ highlight.js@^10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
+history@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
+  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9052,7 +9109,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.0.0, jest-diff@^24.9.0:
+jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -9071,6 +9128,16 @@ jest-diff@^25.5.0:
     diff-sequences "^25.2.6"
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-docblock@^24.3.0:
   version "24.9.0"
@@ -9123,6 +9190,11 @@ jest-get-type@^25.2.6:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
+
 jest-haste-map@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
@@ -9172,7 +9244,7 @@ jest-leak-detector@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -9181,6 +9253,16 @@ jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -9704,6 +9786,13 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+locate-path@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.1.0.tgz#241d62af60739f6097c055efe10329c88b798425"
+  integrity sha512-HNx5uOnYeK4SxEoid5qnhRfprlJeGMzFRKPLCf/15N3/B4AiofNwC/yq7VBKdVk9dx7m+PiYCJOGg55JYTAqoQ==
+  dependencies:
+    p-locate "^6.0.0"
 
 lock@^1.0.0:
   version "1.1.0"
@@ -11177,6 +11266,13 @@ p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.3.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -11197,6 +11293,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
 
 p-map@^2.0.0:
   version "2.1.0"
@@ -11476,6 +11579,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -12080,7 +12188,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -12099,6 +12207,15 @@ pretty-format@^25.1.0, pretty-format@^25.5.0:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
+
+pretty-format@^27.0.0, pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 pretty-format@^27.0.2:
   version "27.0.6"
@@ -12122,10 +12239,10 @@ prism-react-renderer@^1.2.0, prism-react-renderer@^1.2.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
   integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==
 
-prismjs@^1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
-  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
+prismjs@^1.27.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.28.0.tgz#0d8f561fa0f7cf6ebca901747828b149147044b6"
+  integrity sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -12460,10 +12577,10 @@ react-error-overlay@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
   integrity sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw==
 
-react-fast-compare@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
 react-focus-lock@^2.5.0:
   version "2.5.2"
@@ -12489,20 +12606,20 @@ react-focus-on@^3.3.0:
     use-callback-ref "^1.2.5"
     use-sidecar "^1.0.5"
 
-react-frame-component@^4.1.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.1.3.tgz#64c09dd29574720879c5f43ee36c17d8ae74d4ec"
-  integrity sha512-4PurhctiqnmC1F5prPZ+LdsalH7pZ3SFA5xoc0HBe8mSHctdLLt4Cr2WXfXOoajHBYq/yiipp9zOgx+vy8GiEA==
+react-frame-component@^5.2.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.3.tgz#2d5d1e29b23d5b915c839b44980d03bb9cafc453"
+  integrity sha512-r+h0o3r/uqOLNT724z4CRVkxQouKJvoi3OPfjqWACD30Y87rtEmeJrNZf1WYPGknn1Y8200HAjx7hY/dPUGgmA==
 
-react-helmet@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
-  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
   dependencies:
     object-assign "^4.1.1"
-    prop-types "^15.5.4"
-    react-fast-compare "^2.0.2"
-    react-side-effect "^1.1.0"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-hot-loader@^4.12.21:
   version "4.13.0"
@@ -12586,12 +12703,10 @@ react-remove-scroll@^2.4.1:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-side-effect@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
-  integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
-  dependencies:
-    shallowequal "^1.0.1"
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-simple-code-editor@^0.11.0:
   version "0.11.0"
@@ -13549,7 +13664,7 @@ shallow-compare@^1.2.2:
   resolved "https://registry.yarnpkg.com/shallow-compare/-/shallow-compare-1.2.2.tgz#fa4794627bf455a47c4f56881d8a6132d581ffdb"
   integrity sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg==
 
-shallowequal@^1.0.1, shallowequal@^1.1.0:
+shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -13825,7 +13940,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -13835,6 +13950,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
@@ -16046,6 +16169,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 yoga-layout-prebuilt@^1.9.6:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,18 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@mdx-js/mdx@^1.0.21":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
@@ -1958,6 +1970,16 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
   integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
+"@ts-morph/common@~0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.12.3.tgz#a96e250217cd30e480ab22ec6a0ebbe65fd784ff"
+  integrity sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==
+  dependencies:
+    fast-glob "^3.2.7"
+    minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
 
 "@turist/fetch@^7.1.7":
   version "7.1.7"
@@ -3416,7 +3438,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@^4.0.0, bl@^4.0.3:
+bl@^4.0.0, bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -3931,7 +3953,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -4116,6 +4138,11 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
+  integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -4169,6 +4196,11 @@ clone-response@1.0.2, clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4182,6 +4214,13 @@ coa@^2.0.2:
     "@types/q" "^1.5.1"
     chalk "^2.4.1"
     q "^1.1.2"
+
+code-block-writer@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.0.tgz#5956fb186617f6740e2c3257757fea79315dd7d4"
+  integrity sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==
+  dependencies:
+    tslib "2.3.1"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -4972,6 +5011,13 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -5045,6 +5091,13 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -6408,6 +6461,17 @@ fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.7:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -8718,6 +8782,11 @@ is-installed-globally@^0.4.0:
     global-dirs "^3.0.0"
     is-path-inside "^3.0.2"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-invalid-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-invalid-path/-/is-invalid-path-0.1.0.tgz#307a855b3cf1a938b44ea70d2c61106053714f34"
@@ -8906,6 +8975,11 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-upper-case@^1.1.0:
   version "1.1.2"
@@ -9928,6 +10002,14 @@ lodash@4.17.21, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 loglevel@^1.6.8:
   version "1.7.1"
@@ -11186,6 +11268,21 @@ optionator@^0.8.1, optionator@^0.8.2, optionator@^0.8.3:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
 original@>=0.0.5, original@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
@@ -11550,6 +11647,11 @@ path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-case@^2.1.0:
   version "2.1.1"
@@ -12233,6 +12335,17 @@ preval.macro@^3.0.0:
   integrity sha512-vGSGpDb4V+fGrh5em63YsyzlgQhWCZling7WbkPzgAhT7/88O1lk6dS51+2cfnjzoj00X2Q4Um+WX5Eshk/ulg==
   dependencies:
     babel-plugin-preval "^3.0.0"
+
+primer-react-migrate@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/primer-react-migrate/-/primer-react-migrate-0.5.0.tgz#e6af34bbd839e2fbfbe728edf22fe3bbff94d297"
+  integrity sha512-1F8Dwrzd6/elCqsF8Y6twnExbNSnugqMUUhsY7QSSNqjo/anmEUqasxrMOZi47vL+GFSqITYfqVVNVzYQbqDOw==
+  dependencies:
+    chalk "^4.1.2"
+    ora "^5.4.1"
+    simple-git "^3.2.6"
+    ts-morph "^13.0.3"
+    yargs-parser "^21.0.0"
 
 prism-react-renderer@^1.2.0, prism-react-renderer@^1.2.1:
   version "1.2.1"
@@ -13761,6 +13874,15 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-git@^3.2.6:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.7.1.tgz#cb85c59da4da3d69792d206dd28cfbd803941fac"
+  integrity sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.3"
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -14879,6 +15001,14 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
 
+ts-morph@^13.0.3:
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-13.0.3.tgz#c0c51d1273ae2edb46d76f65161eb9d763444c1d"
+  integrity sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==
+  dependencies:
+    "@ts-morph/common" "~0.12.3"
+    code-block-writer "^11.0.0"
+
 ts-node@^9:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
@@ -14905,15 +15035,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@2.3.1, tslib@^2, tslib@^2.0.3, tslib@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2, tslib@^2.0.3, tslib@~2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@~2.0.1:
   version "2.0.3"
@@ -15663,6 +15793,13 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
+
 web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
@@ -16103,6 +16240,11 @@ yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.0.0:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
 yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"


### PR DESCRIPTION
The latest Doctocat (with the shiny new sidebar) uses PRC v35, and the migration to get there with `mdx` seems more complex than `jsx`. This PR will need some help.

- The migrate script didn't work very well for `mdx`. After I manually fixed the file imports, it still couldn't resolve `/deprecated` in PRC
- Linking to this PR where @owenniblock found some broad accessibility issues. Maybe we can address them here https://github.com/primer/design/pull/265