### PR TITLE
Updating links to content guide

### DIFF
--- a/content/foundations/content.mdx
+++ b/content/foundations/content.mdx
@@ -6,7 +6,7 @@ import {Box} from '@primer/components'
 import {Text} from '@primer/components'
 import Code from '@primer/gatsby-theme-doctocat/src/components/code'
 
-These guidelines are specific to and focused on GitHub product interfaces. Your first port of call for general content guidelines should be [GitHub’s Content Style Guide](https://brand.github.com/content/), followed by the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
+These guidelines are specific to and focused on GitHub product interfaces. Your first port of call for general content guidelines should be [GitHub’s content guide](https://github.com/github/brand/blob/main/content.md) (link only accessible to GitHub staff), followed by the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
 
 ## UI content principles
 
@@ -36,7 +36,7 @@ You should consider the context of when a user will read something, keeping in m
 - Humor isn’t welcome in all situations, for example: in errors, when waiting, or when something fails.
 - Error messages should be understandable by humans.
 
-Read more about GitHub’s voice and tone in the [Brand Guide](https://brand.github.com/content/voice).
+Read more about GitHub’s [voice and tone in the content guide](https://github.com/github/brand/blob/main/content.md#voice-and-tone) (link only accessible to GitHub staff).
 
 ## Top 10 rules
 If you’re in a hurry, these are the most important content guidelines to keep in mind, in no particular order.
@@ -288,4 +288,4 @@ TODO: Examples of truncation: dates, large numbers, long file names.
 - Do not use semicolons: they are hard to get right and can be replaced by a period most times.
 
 ## How to get help
-If you need clarification and can’t find an answer in the [GitHub’s Content Style Guide](https://brand.github.com/content/) or the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), or would like your UI content to be reviewed, please start a discussion in github/primer and someone in the team will get back to you. If your query is urgent, you can ask directly in the [#primer](https://github.slack.com/archives/CSGAVNZ19) channel. 
+If you need clarification and can’t find an answer in [GitHub’s content guide](https://github.com/github/brand/blob/main/content.md) (link only accessible to GitHub staff) or the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), or would like your UI content to be reviewed, please start a discussion in github/primer and someone in the team will get back to you. If your query is urgent, you can ask directly in the [#primer](https://github.slack.com/archives/CSGAVNZ19) channel. 


### PR DESCRIPTION
Preview link: https://primer-2c9cab579d-26441320.drafts.github.io/foundations/content