### PR TITLE
update generic link text guidance

### DIFF
--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -16,7 +16,7 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ## How to test links
 - Check a link's function. If clicking a link activates a feature on the page, it should be a `<button>`, and vice versa. 
-- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. 
+- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. Learn more at [Link text](#link-text).
 - [Check a link's contrast](https://webaim.org/resources/contrastchecker/). Because links are text-based, they need to pass 4.5:1 against the background color that they are on.
 - In body text, like a Markdown file, check to make sure that all links have underline styling. 
 
@@ -67,10 +67,38 @@ People who have low or colorblind vision may have trouble identifying links that
 - Only adding an underline to a link when it has focus or is hovered over
 - Underlining every link on the page. For example, a navigation list is a list of links but navigational links don't have to be underlined because the intent is understood and an underline is not needed to identify the interactive nature of the control.
 
+## Link text
+
+Link text should be descriptive enough to convey the destination without the context of the surrounding text. Screen reader users often tab through links on a page to quickly find content without needing to listen to the full page.
+When link text is too generic like "Read more", the destination of the link is not conveyed. 
+
+It may be acceptable in some scenarios to provide a more descriptive link text for screen reader users by setting the `aria-label`. However, this technique will result in divergence between the label and the text and is not an ideal, future-proof solution.
+Whenever possible, prefer a single descriptive link text that is available for both sighted users and screen reader users.
+
+If you must resort to the ARIA technique to provide a descriptive link text, you must follow these principles:
+
+1. The visible text is included in full as part of the accessible name to avoid a violation of [SC 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
+2. The sentence that the link is a part of is well-formed and grammatical when read with both the visible text and the accessible name.
+
+### Bad: Accessible name results in badly formed sentence 👎 
+
+### Bad: Accessible name does not include visible link text 👎 
+
+### Good: Accessible name includes visible link text 👍 
+
+The link below includes visible link text and is well-formed:
+
+```HTML
+<a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>
+```
+
+As demonstrated, this technique can easily go wrong and is not a future proof solution so only use it if necessary.
+
 ## Additional resources
 - [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text) (requires a subscription to access the content)
 - [Accessibility Insights plugin](https://accessibilityinsights.io/en/): With the Accessibility Insights plugin installed, open the plugin, visit the **Assessment** option and select **7. Links**
 - [WebAIM: Links and Hypertext - Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
+- [erblint-github Avoid generic link text](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/avoid-generic-link-text-counter.md)
 
 ### Related WCAG guidelines and success criteria
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -111,7 +111,7 @@ As demonstrated in the examples, this technique adds more complexity to the code
 - [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text) (requires a subscription to access the content)
 - [Accessibility Insights plugin](https://accessibilityinsights.io/en/): With the Accessibility Insights plugin installed, open the plugin, visit the **Assessment** option and select **7. Links**
 - [WebAIM: Links and Hypertext - Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
-- [erblint-github Avoid generic link text](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/avoid-generic-link-text-counter.md)
+- [erblint-github: Avoid generic link text](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/avoid-generic-link-text-counter.md)
 
 ### Related WCAG guidelines and success criteria
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -84,26 +84,17 @@ If you must resort to the ARIA technique to provide a descriptive link text, fol
 
 The content below will be announced as, "Learn more about keyboard shortcuts allow you to access common commands more quickly" by screen readers which is incomprehensible.
 
-```HTML
-<a href="..." aria-label="Learn more about keyboard shortcuts">Keyboard shortcuts</a> allow you to access common commands more quickly.
-```
-
-### Bad: Accessible name does not include information conveyed in visible text 👎 
-
-The link text below has an accessible name that fails to convey information that is available in visible text.
-
-```HTML
-<a href="..." aria-label="Visit profile">@monalisa's profile</a>
-```
-
-### Good: Accessible name includes visible link text 👍 
-
-The link below has an accessible name that fully includes the visible link text and is comprehensible.
-(This example uses the ARIA technique for demo purposes and is technically valid, but the link text here can just be "Learn more about GitHub pricing plans".)
-
-```HTML
-There are various plans available. <a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>
-```
+<DoDontContainer>
+    <Do>
+      <Caption>Accessible name fully includes the visible link text, "Learn more" and is well-formed with either label.</Caption>
+      <Code className="language-html">{`There are various plans available. <a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>`}</Code>
+      <br />
+    </Do>
+    <Dont>
+      <Caption>Accessible name results in poorly-formed sentence, "Learn more about keyboard shortcuts allow you to access common commands more quickly". </Caption>
+      <Code className="language-html">{`<a href="..." aria-label="Learn more about keyboard shortcuts">Keyboard shortcuts</a> allow you to access common commands more quickly.`}</Code>
+    </Dont>
+</DoDontContainer>
 
 As demonstrated in the examples, this technique adds more complexity to the code and can introduce more problems than it solves so only use this technique if absolutely necessary.
 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -69,30 +69,43 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ## Link text
 
-Link text should be descriptive enough to convey the destination without the context of the surrounding text. Screen reader users often tab through links on a page to quickly find content without needing to listen to the full page.
+Link text should be descriptive enough to convey the destination without relying on the surrounding text. Screen reader users often tab through links on a page to quickly find content without needing to listen to the full page.
 When link text is too generic like "Read more", the destination of the link is not conveyed. 
 
 It may be acceptable in some scenarios to provide a more descriptive link text for screen reader users by setting the `aria-label`. However, this technique will result in divergence between the label and the text and is not an ideal, future-proof solution.
 Whenever possible, prefer a single descriptive link text that is available for both sighted users and screen reader users.
 
-If you must resort to the ARIA technique to provide a descriptive link text, you must follow these principles:
+If you must resort to the ARIA technique to provide a descriptive link text, follow these principles:
 
 1. The visible text is included in full as part of the accessible name to avoid a violation of [SC 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
 2. The sentence that the link is a part of is well-formed and grammatical when read with both the visible text and the accessible name.
 
-### Bad: Accessible name results in badly formed sentence 👎 
+### Bad: Accessible name results in poorly-formed sentence 👎 
 
-### Bad: Accessible name does not include visible link text 👎 
+The content below will be announced as, "Learn more about keyboard shortcuts allow you to access common commands more quickly" by screen readers which is incomprehensible.
+
+```HTML
+<a href="..." aria-label="Learn more about keyboard shortcuts">Keyboard shortcuts</a> allow you to access common commands more quickly.
+```
+
+### Bad: Accessible name does not include information conveyed in visible text 👎 
+
+The link text below has an accessible name that fails to convey information that is available in visible text.
+
+```HTML
+<a href="..." aria-label="Visit profile">@monalisa's profile</a>
+```
 
 ### Good: Accessible name includes visible link text 👍 
 
-The link below includes visible link text and is well-formed:
+The link below has an accessible name that fully includes the visible link text and is comprehensible.
+(This example uses the ARIA technique for demo purposes and is technically valid, but the link text here can just be "Learn more about GitHub pricing plans".)
 
 ```HTML
-<a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>
+There are various plans available. <a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>
 ```
 
-As demonstrated, this technique can easily go wrong and is not a future proof solution so only use it if necessary.
+As demonstrated in the examples, this technique adds more complexity to the code and can introduce more problems so only use this technique if absolutely necessary.
 
 ## Additional resources
 - [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text) (requires a subscription to access the content)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -105,7 +105,7 @@ The link below has an accessible name that fully includes the visible link text 
 There are various plans available. <a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>
 ```
 
-As demonstrated in the examples, this technique adds more complexity to the code and can introduce more problems so only use this technique if absolutely necessary.
+As demonstrated in the examples, this technique adds more complexity to the code and can introduce more problems than it solves so only use this technique if absolutely necessary.
 
 ## Additional resources
 - [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text) (requires a subscription to access the content)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -16,7 +16,7 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ## How to test links
 - Check a link's function. If clicking a link activates a feature on the page, it should be a `<button>`, and vice versa. 
-- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. Learn more about [link text](#link-text).
+- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. [Learn how to write good link text](#writing-link-text).
 - [Check a link's contrast](https://webaim.org/resources/contrastchecker/). Because links are text-based, they need to pass 4.5:1 against the background color that they are on.
 - In body text, like a Markdown file, check to make sure that all links have underline styling. 
 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -16,7 +16,7 @@ People who have low or colorblind vision may have trouble identifying links that
 
 ## How to test links
 - Check a link's function. If clicking a link activates a feature on the page, it should be a `<button>`, and vice versa. 
-- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. Learn more at [Link text](#link-text).
+- Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. Learn more about [link text](#link-text).
 - [Check a link's contrast](https://webaim.org/resources/contrastchecker/). Because links are text-based, they need to pass 4.5:1 against the background color that they are on.
 - In body text, like a Markdown file, check to make sure that all links have underline styling. 
 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -67,7 +67,7 @@ People who have low or colorblind vision may have trouble identifying links that
 - Only adding an underline to a link when it has focus or is hovered over
 - Underlining every link on the page. For example, a navigation list is a list of links but navigational links don't have to be underlined because the intent is understood and an underline is not needed to identify the interactive nature of the control.
 
-## Link text
+## Writing link text
 
 Link text should be descriptive enough to convey the destination without relying on the surrounding text. Screen reader users often tab through links on a page to quickly find content without needing to listen to the full page.
 When link text is too generic like "Read more", the destination of the link is not conveyed. 

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -80,10 +80,6 @@ If you must resort to the ARIA technique to provide a descriptive link text, fol
 1. The visible text is included in full as part of the accessible name to avoid a violation of [SC 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
 2. The sentence that the link is a part of is well-formed and grammatical when read with both the visible text and the accessible name.
 
-### Bad: Accessible name results in poorly-formed sentence 👎 
-
-The content below will be announced as, "Learn more about keyboard shortcuts allow you to access common commands more quickly" by screen readers which is incomprehensible.
-
 <DoDontContainer>
     <Do>
       <Caption>Accessible name fully includes the visible link text, "Learn more" and is well-formed with either label.</Caption>


### PR DESCRIPTION
Closes: https://github.com/github/accessibility/issues/1343 (staff-only link)

This PR updates the link guidance with more guidance around generic link text and techniques. 

Updating this to make sure we document the discussions we've been having on Slack and this [recommended guidance in a recent GitHub issue](https://github.com/github/accessibility/issues/1291#issuecomment-1159088348) (staff-only link).
