### PR TITLE
Restore contributor stats to docs footer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build
         run: yarn build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive build output
         run: 'tar --dereference --directory public/ -cvf artifact.tar .'

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build
         run: yarn build:preview
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive build output
         run: 'tar --dereference --directory public/ -cvf artifact.tar .'


### PR DESCRIPTION
Restores the footer. E.g:

![docs footer](https://user-images.githubusercontent.com/13340707/182623547-0e5d700d-c18e-495f-8d99-1e6eb854e0d2.png)
 