### PR TITLE
Form guidelines - correct broken anchors

### DIFF
--- a/content/ui-patterns/forms.mdx
+++ b/content/ui-patterns/forms.mdx
@@ -29,8 +29,6 @@ Placeholder text is never an acceptable substitute for a label because:
 
 When a field is required to have a value, it should be visibly marked as required. An individual checkbox or radio button cannot be marked as required.
 
-For more information, see the [required fields](#required-fields) section.
-
 ### Input (required)
 
 The input is what the user interacts with to set the value of the form control. You may pre-fill inputs with smart default values, but be careful about making too many assumptions about what a user wants or needs.
@@ -102,7 +100,7 @@ Information from the caption should not be repeated in the error message. Show t
   </Dont>
 </DoDontContainer>
 
-For more information about form validation, see the [validation guidelines](#invalid-input).
+For more information about form validation, see the [validation guidelines](#validation).
 
 ## Input methods
 


### PR DESCRIPTION
- Removes sentence that refers to a "required inputs" section that no longer exists
- Corrects anchor to the `#validation` section