### PR TITLE
Dialog interface guidelines

### DIFF
--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -1,0 +1,197 @@
+---
+title: Dialog
+status: Alpha
+---
+
+import {Box, Heading, Label, LabelGroup, Link, Caption} from '@primer/components'
+
+<Box sx={{fontSize: 3}} class="lead" as="p">
+  A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and more.
+</Box>
+
+<LabelGroup display="block" mb={4}>
+  <Label
+    as="a"
+    href="https://primer.style/react/Dialog"
+    variant="xl"
+    color="text.success"
+    outline
+    style="text-decoration: none; line-height: 20px;"
+  >
+    <img
+      width="20"
+      height="20"
+      alt=" "
+      src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    React
+  </Label>
+  <Label as="a" href="#" variant="xl" outline style="text-decoration: none; line-height: 20px;">
+    <img
+      width="20"
+      height="20"
+      alt=" "
+      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    Figma
+  </Label>
+</LabelGroup>
+
+## Overview
+
+Dialogs can streamline the interface by allowing extra content to be disclosed as needed. Dialogs create a new modality to the user, and can facilitate the completion of individual tasks.
+
+## Anatomy
+
+<img alt="" src="https://user-images.githubusercontent.com/293280/174921246-606b8de1-dabd-4865-ae98-1e7677f1bb38.png" width="960" />
+<Caption>Anatomy of a Dialog.</Caption>
+
+### Dialog regions
+
+- **Header**: Provides context for the Dialog with a `title`.
+- **Subheader**: Optional area for additional header content such as an `input` field.
+- **Actions**: Optional area for an additional action button.
+- **Close Button**: Required button that dismisses the Dialog.
+- **Body** : The main contents of the Dialog.
+- **Footer**: Optional area for confirmation or cancel action buttons.
+
+### Header region
+
+The **header** region provides context for the Dialog. By default, the region supports a title, description, and a close button. Titles and descriptions may wrap to multiple lines if necessary.
+
+The title is required for all Dialogs, but may be visually hidden for custom scenarios such as a command palette. The close button is required and may **not** be visually hidden.
+
+The header region provides a slot for custom content in place of the default title/description, though title is still required and may be visually hidden. The title has a default size and a large option for confirmation dialogs.
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849372-a9d33d3b-96f3-497e-bad6-70df4d91072a.png" alt="" />
+    <Caption>Header with the default title variant.</Caption>
+  </div>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849374-6a71d8a0-da61-4745-a059-4560d053089b.png" alt="" />
+    <Caption>Header with large title variant.</Caption>
+  </div>
+</Box>
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849370-bcc9161c-901e-4e03-ba40-0626dd0523c4.png" alt="" />
+    <Caption>Header with custom variant.</Caption>
+  </div>
+</Box>
+
+### Subheader region
+
+The subheader region is an optional space for interactive controls. Use it to display a search field, a filter menu, or a local navigation component.
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849377-ef70f4e7-2978-415c-9da1-a2ba2f33bdc3.png" alt="" />
+    <Caption>Header displaying a subheader with a search field.</Caption>
+  </div>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849376-ef25a1ba-b5b7-4ae0-8d9a-78095932886a.png" alt="" />
+    <Caption>Header displaying a subheader with a local navigation.</Caption>
+  </div>
+</Box>
+
+### Footer region
+
+The footer region may be used to show confirmation actions, navigation links, or specialized actions.
+
+If the content area has overflow scrolling, a divider will be shown between the footer and content area. Otherwise, showing a divider is optional.
+
+<img src="https://user-images.githubusercontent.com/293280/175850630-9f3df284-c69b-4d16-9e57-ea04a0202d04.png" width="960" alt="" />
+<Caption>
+  Use buttons in a footer to let the user complete a task.
+</Caption>
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175850639-a77d537e-2807-47d2-b456-a298d5f44918.png" alt="" />
+    <Caption>Footer with small buttons.</Caption>
+  </div>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175850637-3b193552-b35f-4b07-b2d6-4ca546c8131a.png" alt="" />
+    <Caption>Footer with auxiliary create button.</Caption>
+  </div>
+</Box>
+
+### Dimensions
+
+Dialogs should never extend beyond the viewport sizes, and may resize to fit smaller devices. The body contents should fit narrow viewports with a minimum width of `320px`. If the contents extend vertically beyond the specified height, the **body** region will scroll.
+
+The `height` and `width` may be set to `auto` which will set a minimum width of `192px` and respond to the contents of the Dialog. Additionally, an explicit `height` and `width` may be set with a specific set of options.
+
+<!-- img -->
+<Caption>Recommended height and width combinations for Dialog</Caption>
+
+### Scroll behavior
+
+The **body** region scrolls vertically to accommodate lists and contents too long to fit in the available space, or when the Dialog appears in a small screen.
+
+### Spacing
+
+The edges of Dialog are free of text and heavy visuals to visually distinguish the Dialog as an elevated surface, alongside its shadow. Content within the body and header should remain within the 16px safe area. However, inner components that have transparent or discrete backgrounds may bleed into the padding for visual alignment.
+
+<img alt="" src="https://user-images.githubusercontent.com/293280/174925634-603a27cf-2281-4a3a-9078-d1b8138e0d09.png" width="960" />
+<Caption>
+  1. A search field in the Subheader region appears closer to the edges. While the search icon remains within the safe area.<br />
+  2. Close button placed `8px` away from the edges. Note that the "×" glyph remains within the safe area.<br />
+  3. Action list items in the Body region.<br />
+  4. Footer buttons always appear inside the safe area. <br />
+</Caption>
+
+### Backdrop
+
+Dialog displays with a **backdrop**, which dims the rest of the page. The backdrop is visible when the Dialog is centered on the page, or attached to a sides as a sheet.
+
+By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
+
+## Usage
+
+### Keep content simple
+
+Dialogs are meant to be interacted with in a single context. Avoid creating a whole page inside a Dialog. Prefer single-column layouts that convey a clear goal from the moment the Dialog is opened.
+
+However, Dialogs are powerful tools when creating space for single-context interfaces. When designing a new feature to support a main interface, start by considering if the new feature can be created under a single context.
+
+If the answer is yes, designing the feature inside a Dialog provides an easy way to add responsive support, and avoid deeper navigations. If the answer is no, or if a side navigation is required for the feature, consider designing a new page.
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/293280/174922550-782a544b-12aa-4b2a-9ca7-700f8bc4f166.png"
+      alt=""
+    />
+    <Caption>Prefer a single column layout.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/293280/174922547-c658b89e-d304-48f0-b884-76bd0d440c9c.png"
+      alt=""
+    />
+    <Caption>Avoid side navigation within a Dialog.</Caption>
+  </Dont>
+</DoDontContainer>
+
+### Trigger elements and keyboard focus
+
+Dialogs are initially hidden, and can be opened by an element with `role="button"`, called a **trigger**. The role `button` allows the **trigger** to be a relativelly complex element, such as an action list item.
+
+Dialogs should be fully functional using the keyboard and assistive technology. Pressing `Esc` should dismiss a Dialog, also returning focus to the **trigger** that opened it.
+
+### Dialogs should work well on any device
+
+Dialogs must adjust their designs to fit in smaller viewports. Make sure the overlay contents work with all supported sizes and input methods.
+
+## Placement
+
+<!-- Where to use the component and how it interacts with the rest of the UI. Include images and dos and donts of how the component should be used within the UI. -->
+
+## Accessibility
+
+<!-- Accessibility considerations when using the component. Include keyboard navigation, descriptions, common mistakes to avoid. -->

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -143,7 +143,7 @@ The body region is the main content of the Dialog. It can contain any content th
     <img
       width="650"
       alt=""
-      src="https://user-images.githubusercontent.com/18661030/185478320-2a4a3053-dca3-4048-b7c4-d5a39a83acd6.png"
+      src="https://user-images.githubusercontent.com/18661030/186003712-36441f05-1407-4b03-a50a-3773275e4d61.png"
     />
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -251,7 +251,7 @@ Before using an extra large Dialog, consider whether or not the content would be
   alt=""
   src="https://user-images.githubusercontent.com/18661030/187482817-9d82fe3e-c24d-4eca-9b4b-c74fa32450d4.png"
 />
-<Caption>Extra large Dialogs have a min width of 960px, and a max height of 600px.</Caption>
+<Caption>Extra large Dialogs have a width of 960px, and a max height of 600px.</Caption>
 
 ## Usage
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -46,7 +46,7 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 
 ## Anatomy
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185224138-0365fdee-c4b8-41bb-9eb8-65c05d1c52c1.png" />
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185477953-4b18ef02-675f-4f30-9c83-e421a875ae92.png" />
 <Caption>Anatomy of a Dialog.</Caption>
 
 ### Dialog regions
@@ -79,12 +79,11 @@ The header region provides a slot for custom content in place of the default tit
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849370-bcc9161c-901e-4e03-ba40-0626dd0523c4.png" alt="" />
+    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185478040-be5a3552-9ed1-40ef-a713-3d6ac8f6b697.png" />
     <Caption>Header with custom variant and a secondary action button.</Caption>
   </div>
   <div>
-    {/* new img here */}
-    <img src="https://user-images.githubusercontent.com/293280/175849370-bcc9161c-901e-4e03-ba40-0626dd0523c4.png" alt="" />
+    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185478144-87887a98-e541-4a23-bd1c-6cb174a453a7.png"/>
     <Caption>Command palette with a visually hidden title.</Caption>
   </div>
 </Box>
@@ -110,11 +109,11 @@ The body region is the main content of the Dialog. It can contain any content th
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849377-ef70f4e7-2978-415c-9da1-a2ba2f33bdc3.png" alt="" />
+    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185478284-e093c72f-fc49-4dbf-b848-d1468dab14b0.png"/>
     <Caption>Body content will scroll vertically if the content exceeds the overall Dialog height.</Caption>
   </div>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849376-ef25a1ba-b5b7-4ae0-8d9a-78095932886a.png" alt="" />
+    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185478320-2a4a3053-dca3-4048-b7c4-d5a39a83acd6.png">
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>
 </Box>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -222,7 +222,7 @@ Small viewports force Dialogs to remain small. All Dialogs need to work on viewp
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/187482408-97bcb753-62a9-4b7c-b02b-b94ba369203e.png"
+  src="https://user-images.githubusercontent.com/18661030/187552557-452e7253-9fdc-4f58-8ad7-9cd016d7786e.png"
 />
 <Caption>Small Dialogs have a width of 320px, and a max height of 256px.</Caption>
 
@@ -233,7 +233,7 @@ Medium is the default size for Dialog and should be used for most tasks such as 
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/187482576-557672f9-6695-435d-b93e-2b7b8fda2a98.png"
+  src="https://user-images.githubusercontent.com/18661030/187552600-06dcbd81-90b5-45aa-81ce-89f8d9763508.png"
 />
 <Caption>Medium Dialogs have a width of 480px, and a max height of 320px. Medium portrait oriented Dialogs have a width of 480px, and a max height of 600px.</Caption>
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -244,7 +244,7 @@ Large dialogs are suitable for content that requires more horizontal space for t
 
 ### Extra large
 
-Before using an extra large dialog, consider whether or not the content would be more appropriate for a new page.
+Before using an extra large Dialog, consider whether or not the content would be more appropriate for a new page.
 
 <img
   width="1292"

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -140,7 +140,7 @@ If the content area has overflow scrolling, a divider will be shown between the 
 
 ### Backdrop
 
-Dialog displays with a **backdrop**, which dims the rest of the page. The backdrop is visible when the Dialog is centered on the page, or attached to a sides as a sheet.
+Dialog displays with a **backdrop**, which dims the rest of the page. The backdrop is visible when the Dialog is centered on the page, or attached to a side as a sheet.
 
 By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -190,7 +190,7 @@ If the answer is yes, designing the feature inside a Dialog provides an easy way
 
 Dialogs are initially hidden, and can be opened by an element with `role="button"`, called a **trigger**. The role `button` allows the **trigger** to be a relatively complex element, such as an action list item.
 
-Dialogs should be fully functional using the keyboard and assistive technology. Pressing `Esc` should dismiss a Dialog, also returning focus to the **trigger** that opened it.
+Dialogs must be fully functional using the keyboard and assistive technology. Pressing `Esc` must dismiss a Dialog, also returning focus to the **trigger** that opened it.
 
 <CustomVideoPlayer
     width="100%"

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -213,12 +213,10 @@ Dialog offers a range of sizes from `small` to `xlarge` with a default of `mediu
 
 ### Small
 
-Small Dialogs are reserved for quick interactions, such as a `ConfirmationDialog`.
-
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/187478234-01d19983-2494-459e-8ac0-7c59cbf8ae94.png"
+  src="https://user-images.githubusercontent.com/18661030/187482408-97bcb753-62a9-4b7c-b02b-b94ba369203e.png"
 />
 <Caption>Small Dialogs have a min width of 320px, and a max height of 256px.</Caption>
 
@@ -226,24 +224,12 @@ Small Dialogs are reserved for quick interactions, such as a `ConfirmationDialog
 
 Medium is the default size for Dialog and should be used for most tasks such as completing a form or selecting an option from a list. The medium portrait size is suitable for longer lists of items that require more vertical space for the body.
 
-<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
-  <div>
-    <img
-      width="650"
-      alt=""
-      src="https://user-images.githubusercontent.com/18661030/187478218-84255754-0e38-4613-a4c4-613b17fd918e.png"
-    />
-    <Caption>Medium Dialogs have a min width of 480px, and a max height of 320px.</Caption>
-  </div>
-  <div>
-    <img
-      width="650"
-      alt=""
-      src="https://user-images.githubusercontent.com/18661030/187478222-d640b755-a624-43e2-b17b-320f1e7a8b9a.png"
-    />
-    <Caption>Medium portrait oriented Dialogs have a min width of 480px, and a max height of 600px.</Caption>
-  </div>
-</Box>
+<img
+  width="1292"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/187482576-557672f9-6695-435d-b93e-2b7b8fda2a98.png"
+/>
+<Caption>Medium Dialogs have a min width of 480px, and a max height of 320px. Medium portrait oriented Dialogs have a min width of 480px, and a max height of 600px.</Caption>
 
 ### Large
 
@@ -252,7 +238,7 @@ Large dialogs are suitable for content that requires more horizontal space for t
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/187478224-45bc523b-cefa-4d94-a83f-0c9d2f854c08.png"
+  src="https://user-images.githubusercontent.com/18661030/187482693-04eb3780-89e1-4705-a55b-5fa8ba0f9865.png"
 />
 <Caption>Large Dialogs have a min width of 640px, and a max height of 432px.</Caption>
 
@@ -260,12 +246,10 @@ Large dialogs are suitable for content that requires more horizontal space for t
 
 Before using an extra large dialog, consider whether or not the content would be more appropriate for a new page.
 
-<!-- large img here -->
-
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/187478227-edf33f8e-946c-42fe-9334-072c2b970be1.png"
+  src="https://user-images.githubusercontent.com/18661030/187482817-9d82fe3e-c24d-4eca-9b4b-c74fa32450d4.png"
 />
 <Caption>Extra large Dialogs have a min width of 960px, and a max height of 600px.</Caption>
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -409,9 +409,9 @@ Dialogs must be fully functional using the keyboard and assistive technology. Pr
   loop
   src="https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4"
 />
-<Caption>Clicking the backdrop or hitting the `esc` key should dismiss the Dialog.</Caption>
+<Caption>Clicking the backdrop or hitting the `Esc` key should dismiss the Dialog.</Caption>
 
-When a Dialog is opened, the first interactive element (typically the close button) is focused. For a scenario like a command palette with an `<input>` next to the close button, the `<input>` will recieve focus first. Hitting `tab` will cycle through all interactive elements within the Dialog. To escape the focus trap, hitting the `esc` key or clicking on the backdrop will close the Dialog. While the Dialog is open, page scrolling is disabled and becomes `inert`.
+When a Dialog is opened, the first interactive element (typically the close button) is focused. For a scenario like a command palette with an `<input>` next to the close button, the `<input>` will recieve focus first. Hitting `Tab` will cycle through all interactive elements within the Dialog. To escape the focus trap, hitting the `Esc` key or clicking on the backdrop will close the Dialog. While the Dialog is open, page scrolling is disabled and becomes `inert`.
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5} marginBottom={5}>
   <div>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -62,9 +62,9 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 
 The **header** region provides context for the Dialog. By default, the region supports a title, description, and a close button. Titles and descriptions may wrap to multiple lines if necessary.
 
-The title is required for all Dialogs, but may be visually hidden for custom scenarios such as a command palette. The close button is required and may **not** be visually hidden.
+The title is required for all Dialogs, but may be visually hidden for custom scenarios such as a command palette. The close button is required and may **not** be visually hidden. The title has a default size along with a larger option for confirmation dialogs.
 
-The header region provides a slot for custom content in place of the default title/description, though title is still required and may be visually hidden. The title has a default size and a large option for confirmation dialogs.
+The header region provides a slot for custom content in place of the default title/description, though a title is still required and may be visually hidden. Secondary action icon buttons may be placed next to the close button.
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
@@ -80,7 +80,12 @@ The header region provides a slot for custom content in place of the default tit
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
     <img src="https://user-images.githubusercontent.com/293280/175849370-bcc9161c-901e-4e03-ba40-0626dd0523c4.png" alt="" />
-    <Caption>Header with custom variant.</Caption>
+    <Caption>Header with custom variant and a secondary action button.</Caption>
+  </div>
+  <div>
+    {/* new img here */}
+    <img src="https://user-images.githubusercontent.com/293280/175849370-bcc9161c-901e-4e03-ba40-0626dd0523c4.png" alt="" />
+    <Caption>Command palette with a visually hidden title.</Caption>
   </div>
 </Box>
 
@@ -96,6 +101,21 @@ The subheader region is an optional space for interactive controls. Use it to di
   <div>
     <img src="https://user-images.githubusercontent.com/293280/175849376-ef25a1ba-b5b7-4ae0-8d9a-78095932886a.png" alt="" />
     <Caption>Header displaying a subheader with a local navigation.</Caption>
+  </div>
+</Box>
+
+### Body region
+
+The body region is the main content of the Dialog. It can contain any content that is relevant to the task at hand. The body region is scrollable if the content exceeds the height of the Dialog.
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849377-ef70f4e7-2978-415c-9da1-a2ba2f33bdc3.png" alt="" />
+    <Caption>Body content will scroll vertically if the content exceeds the overall Dialog height.</Caption>
+  </div>
+  <div>
+    <img src="https://user-images.githubusercontent.com/293280/175849376-ef25a1ba-b5b7-4ae0-8d9a-78095932886a.png" alt="" />
+    <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>
 </Box>
 
@@ -129,10 +149,6 @@ The `height` and `width` may be set to `auto` which will set a minimum width of 
 
 <img width="1292" alt="" src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"/>
 <Caption>Recommended height and width combinations for Dialog</Caption>
-
-### Scroll behavior
-
-The **body** region scrolls vertically to accommodate lists and contents too long to fit in the available space, or when the Dialog appears in a small screen.
 
 ### Spacing
 
@@ -183,14 +199,14 @@ Dialogs should be fully functional using the keyboard and assistive technology. 
 
 Dialogs must adjust their designs to fit in smaller viewports. Make sure the overlay contents work with all supported sizes and input methods.
 
-## Regular-screen placement
+## Regular-viewport placement
 
 ### Centered
 
 By default, Dialog appears centered in the viewport, with a visible backdrop that dims the rest of the window for focus. Centered Dialogs are surrounded by a safe area of `16px` between the frame and the viewport for all sizes.
 
 <img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185224429-9f0af3ee-3e11-4f94-a5f6-746ed8a5c300.png"/>
-<Caption>Dialog centered within a desktop screen size.</Caption>
+<Caption>Dialog centered within a desktop screen.</Caption>
 
 ### Side sheets
 
@@ -204,7 +220,7 @@ Side sheets take the entire height of the viewport, and should be used sparingly
 <img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png"/>
 <Caption>Right aligned side sheet for global actions.</Caption>
 
-## Narrow-screen placement
+## Narrow-viewport placement
 
 ### Bottom sheets
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -49,15 +49,6 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 <img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185477953-4b18ef02-675f-4f30-9c83-e421a875ae92.png" />
 <Caption>Anatomy of a Dialog.</Caption>
 
-### Dialog regions
-
-- **Header**: Provides context for the Dialog with a `title`.
-- **Subheader**: Optional area for additional header content such as an `input` field.
-- **Actions**: Optional area for an additional action button.
-- **Close Button**: Required button that dismisses the Dialog.
-- **Body** : The main contents of the Dialog.
-- **Footer**: Optional area for confirmation or cancel action buttons.
-
 ### Header region
 
 The **header** region provides context for the Dialog. By default, the region supports a title, description, and a close button. Titles and descriptions may wrap to multiple lines if necessary.
@@ -113,7 +104,7 @@ The body region is the main content of the Dialog. It can contain any content th
     <Caption>Body content will scroll vertically if the content exceeds the overall Dialog height.</Caption>
   </div>
   <div>
-    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185478320-2a4a3053-dca3-4048-b7c4-d5a39a83acd6.png">
+    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185478320-2a4a3053-dca3-4048-b7c4-d5a39a83acd6.png" />
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>
 </Box>
@@ -140,6 +131,14 @@ If the content area has overflow scrolling, a divider will be shown between the 
   </div>
 </Box>
 
+### Backdrop
+
+Dialog displays with a **backdrop**, which dims the rest of the page. The backdrop is visible when the Dialog is centered on the page, or attached to a sides as a sheet.
+
+By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
+
+<!-- video here -->
+
 ### Dimensions
 
 Dialogs should never extend beyond the viewport sizes, and may resize to fit smaller devices. The body contents should fit narrow viewports with a minimum width of `320px`. If the contents extend vertically beyond the specified height, the **body** region will scroll.
@@ -160,12 +159,6 @@ The edges of Dialog are free of text and heavy visuals to visually distinguish t
   3. Action list items in the Body region.<br />
   4. Footer buttons always appear inside the safe area. <br />
 </Caption>
-
-### Backdrop
-
-Dialog displays with a **backdrop**, which dims the rest of the page. The backdrop is visible when the Dialog is centered on the page, or attached to a sides as a sheet.
-
-By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
 
 ## Usage
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -261,5 +261,5 @@ In landscape mode, a bottom sheet has a maximum width of `480px`, and is centere
 
 Full-screen Dialogs may be used to present content that needs all the available space on narrow viewports. Dialogs that have one or more input fields should always use the full-screen variant.
 
-<img width="960" alt="fullscreen" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"/>
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"/>
 <Caption>Full-screen dialog in portrait mode.</Caption>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -209,7 +209,13 @@ The edges of Dialog are free of text and heavy visuals to visually distinguish t
 
 ## Size
 
-Dialog offers a range of sizes from `small` to `xlarge` with a default of `medium`. Each size provides a `max-height` and will automatically shrink to its body content. Dialogs will never extend beyond the viewport, and the body content must fit a narrow viewport with a minimum width of `320px`.
+Dialog offers a range of sizes from `small` to `xlarge`, with the default size set to `medium`. 
+
+Each size defines a width and a maximum height. By default the dialog height will adjust to the body content. If the maximum height is reached, the body contents will scroll.
+
+A Dialog sizing is constrained by the viewport dimensions. Dialogs will not grow beyond the boundaries of the viewport.
+
+Small viewports force Dialogs to remain small. All Dialogs need to work on viewports of at least `320px` of width, and `256px` of height.
 
 ### Small
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -53,7 +53,7 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 
 ## Anatomy
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185509649-50791e2f-0a4c-44d9-8b2b-e34b3f394315.png">
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185509649-50791e2f-0a4c-44d9-8b2b-e34b3f394315.png" />
 <Caption>Anatomy of a Dialog.</Caption>
 
 ### Header region

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -229,7 +229,7 @@ Medium is the default size for Dialog and should be used for most tasks such as 
   alt=""
   src="https://user-images.githubusercontent.com/18661030/187482576-557672f9-6695-435d-b93e-2b7b8fda2a98.png"
 />
-<Caption>Medium Dialogs have a min width of 480px, and a max height of 320px. Medium portrait oriented Dialogs have a min width of 480px, and a max height of 600px.</Caption>
+<Caption>Medium Dialogs have a width of 480px, and a max height of 320px. Medium portrait oriented Dialogs have a width of 480px, and a max height of 600px.</Caption>
 
 ### Large
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -218,7 +218,7 @@ Dialog offers a range of sizes from `small` to `xlarge` with a default of `mediu
   alt=""
   src="https://user-images.githubusercontent.com/18661030/187482408-97bcb753-62a9-4b7c-b02b-b94ba369203e.png"
 />
-<Caption>Small Dialogs have a min width of 320px, and a max height of 256px.</Caption>
+<Caption>Small Dialogs have a width of 320px, and a max height of 256px.</Caption>
 
 ### Medium (default)
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -240,7 +240,7 @@ Large dialogs are suitable for content that requires more horizontal space for t
   alt=""
   src="https://user-images.githubusercontent.com/18661030/187482693-04eb3780-89e1-4705-a55b-5fa8ba0f9865.png"
 />
-<Caption>Large Dialogs have a min width of 640px, and a max height of 432px.</Caption>
+<Caption>Large Dialogs have a width of 640px, and a max height of 432px.</Caption>
 
 ### Extra large
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -215,12 +215,10 @@ Dialog offers a range of sizes from `small` to `xlarge` with a default of `mediu
 
 Small Dialogs are reserved for quick interactions, such as a `ConfirmationDialog`.
 
-<!-- small img here -->
-
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+  src="https://user-images.githubusercontent.com/18661030/187478234-01d19983-2494-459e-8ac0-7c59cbf8ae94.png"
 />
 <Caption>Small Dialogs have a min width of 320px, and a max height of 256px.</Caption>
 
@@ -230,16 +228,18 @@ Medium is the default size for Dialog and should be used for most tasks such as 
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <CustomVideoPlayer
-      width="100%"
-      src="https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4"
+    <img
+      width="650"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/187478218-84255754-0e38-4613-a4c4-613b17fd918e.png"
     />
     <Caption>Medium Dialogs have a min width of 480px, and a max height of 320px.</Caption>
   </div>
   <div>
-    <CustomVideoPlayer
-      width="100%"
-      src="https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4"
+    <img
+      width="650"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/187478222-d640b755-a624-43e2-b17b-320f1e7a8b9a.png"
     />
     <Caption>Medium portrait oriented Dialogs have a min width of 480px, and a max height of 600px.</Caption>
   </div>
@@ -249,12 +249,10 @@ Medium is the default size for Dialog and should be used for most tasks such as 
 
 Large dialogs are suitable for content that requires more horizontal space for the body compared to size medium, such as a comment box.
 
-<!-- large img here -->
-
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+  src="https://user-images.githubusercontent.com/18661030/187478224-45bc523b-cefa-4d94-a83f-0c9d2f854c08.png"
 />
 <Caption>Large Dialogs have a min width of 640px, and a max height of 432px.</Caption>
 
@@ -267,7 +265,7 @@ Before using an extra large dialog, consider whether or not the content would be
 <img
   width="1292"
   alt=""
-  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+  src="https://user-images.githubusercontent.com/18661030/187478227-edf33f8e-946c-42fe-9334-072c2b970be1.png"
 />
 <Caption>Extra large Dialogs have a min width of 960px, and a max height of 600px.</Caption>
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -177,7 +177,7 @@ If the content area has overflow scrolling, a divider will be shown between the 
       src="https://user-images.githubusercontent.com/293280/175850637-3b193552-b35f-4b07-b2d6-4ca546c8131a.png"
       alt=""
     />
-    <Caption>Footer with a secondary button aligned to the left.</Caption>
+    <Caption>Footer with an auxiliary action aligned to the left.</Caption>
   </div>
 </Box>
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -46,7 +46,7 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 
 ## Anatomy
 
-<img alt="" src="https://user-images.githubusercontent.com/293280/174921246-606b8de1-dabd-4865-ae98-1e7677f1bb38.png" width="960" />
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185178231-3d650dac-e9a0-4843-ace3-4ec756125fc4.png">
 <Caption>Anatomy of a Dialog.</Caption>
 
 ### Dialog regions
@@ -127,7 +127,7 @@ Dialogs should never extend beyond the viewport sizes, and may resize to fit sma
 
 The `height` and `width` may be set to `auto` which will set a minimum width of `192px` and respond to the contents of the Dialog. Additionally, an explicit `height` and `width` may be set with a specific set of options.
 
-<!-- img -->
+<img width="1292" alt="" src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png">
 <Caption>Recommended height and width combinations for Dialog</Caption>
 
 ### Scroll behavior
@@ -194,5 +194,13 @@ Dialogs must adjust their designs to fit in smaller viewports. Make sure the ove
 <!-- Where to use the component and how it interacts with the rest of the UI. Include images and dos and donts of how the component should be used within the UI. -->
 
 ## Accessibility
+
+<img width="960" alt="fullscreen" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png">
+<img width="960" alt="bottom-sheet" src="https://user-images.githubusercontent.com/18661030/185214084-43e9573a-1a3b-4b82-b121-bd03897f48ac.png">
+<img width="960" alt="overlay-sheet-landscape" src="https://user-images.githubusercontent.com/18661030/185214089-a1bb1a70-914b-4a8f-b395-9c279a88a1fe.png">
+<img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png">
+<img width="960" alt="placement-desktop-1" src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png">
+<img width="960" alt="placement-desktop" src="https://user-images.githubusercontent.com/18661030/185214098-8fee6748-8c3b-49f2-8713-57bf9372ab16.png">
+
 
 <!-- Accessibility considerations when using the component. Include keyboard navigation, descriptions, common mistakes to avoid. -->

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -236,7 +236,7 @@ Side sheets slide from the right or left edges of the viewport. **Left side shee
 Side sheets take the entire height of the viewport, and should be used sparingly. Don't use side sheets to present forms or flows that should be a page instead.
 
 <img width="960" alt="placement-desktop-1" src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png"/>
-<Caption>Left aligned side sheet for global navigation.</Caption>
+<Caption>Left aligned side sheet is reserved for global navigation only.</Caption>
 
 <img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png"/>
 <Caption>Right aligned side sheet for global actions.</Caption>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -185,19 +185,6 @@ Dialog displays with a **backdrop**, which dims the rest of the page. The backdr
 
 By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
 
-### Dimensions
-
-Dialogs should never extend beyond the viewport sizes, and may resize to fit smaller devices. The body contents should fit narrow viewports with a minimum width of `320px`. If the contents extend vertically beyond the specified height, the **body** region will scroll.
-
-The `height` and `width` may be set to `auto` which will set a minimum width of `192px` and respond to the contents of the Dialog. Additionally, an explicit `height` and `width` may be set with a specific set of options.
-
-<img
-  width="1292"
-  alt=""
-  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
-/>
-<Caption>Recommended height and width combinations for Dialog</Caption>
-
 ### Spacing
 
 The edges of Dialog are free of text and heavy visuals to visually distinguish the Dialog as an elevated surface, alongside its shadow. Content within the body and header should remain within the 16px safe area. However, inner components that have transparent or discrete backgrounds may bleed into the padding for visual alignment.
@@ -217,6 +204,70 @@ The edges of Dialog are free of text and heavy visuals to visually distinguish t
   <br />
   4. Footer buttons always appear inside the safe area. <br />
 </Caption>
+
+## Size
+
+Dialog offers a range of sizes from `small` to `xlarge` with a default of `medium`. Each size provides a `max-height` and will automatically shrink to its body content. Dialogs will never extend beyond the viewport, and the body content must fit a narrow viewport with a minimum width of `320px`.
+
+### Small
+
+Small Dialogs are reserved for quick interactions, such as a `ConfirmationDialog`.
+
+<!-- small img here -->
+
+<img
+  width="1292"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+/>
+<Caption>Small Dialogs have a min width of 320px, and a max height of 256px.</Caption>
+
+### Medium (default)
+
+Medium is the default size for Dialog and should be used for most tasks such as completing a form or selecting an option from a list. The medium portrait size is suitable for longer lists of items that require more vertical space for the body.
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <CustomVideoPlayer
+      width="100%"
+      src="https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4"
+    />
+    <Caption>Medium Dialogs have a min width of 480px, and a max height of 320px.</Caption>
+  </div>
+  <div>
+    <CustomVideoPlayer
+      width="100%"
+      src="https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4"
+    />
+    <Caption>Medium portrait oriented Dialogs have a min width of 480px, and a max height of 600px.</Caption>
+  </div>
+</Box>
+
+### Large
+
+Large dialogs are suitable for content that requires more horizontal space for the body compared to size medium, such as a comment box.
+
+<!-- large img here -->
+
+<img
+  width="1292"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+/>
+<Caption>Large Dialogs have a min width of 640px, and a max height of 432px.</Caption>
+
+### Extra large
+
+Before using an extra large dialog, consider whether or not the content would be more appropriate for a new page.
+
+<!-- large img here -->
+
+<img
+  width="1292"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+/>
+<Caption>Extra large Dialogs have a min width of 960px, and a max height of 600px.</Caption>
 
 ## Usage
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -72,6 +72,7 @@ The header region provides a slot for custom content in place of the default tit
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5} marginBottom={5}>
   <div>
     <img
+      width="464"
       src="https://user-images.githubusercontent.com/293280/175849372-a9d33d3b-96f3-497e-bad6-70df4d91072a.png"
       alt=""
     />
@@ -79,6 +80,7 @@ The header region provides a slot for custom content in place of the default tit
   </div>
   <div>
     <img
+      width="464"
       src="https://user-images.githubusercontent.com/293280/175849374-6a71d8a0-da61-4745-a059-4560d053089b.png"
       alt=""
     />
@@ -298,19 +300,6 @@ If the answer is yes, designing the feature inside a Dialog provides an easy way
   </Dont>
 </DoDontContainer>
 
-### Trigger elements and keyboard focus
-
-Dialogs are initially hidden, and can be opened by an element with `role="button"`, called a **trigger**. The role `button` allows the **trigger** to be a relatively complex element, such as an action list item.
-
-Dialogs must be fully functional using the keyboard and assistive technology. Pressing `Esc` must dismiss a Dialog, also returning focus to the **trigger** that opened it.
-
-<CustomVideoPlayer
-  width="100%"
-  loop
-  src="https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4"
-/>
-<Caption>Clicking the backdrop or hitting the `esc` key should dismiss the Dialog.</Caption>
-
 ### Dialogs should work well on any device
 
 Dialogs must adjust their designs to fit in smaller viewports. Make sure the overlay contents work with all supported sizes and input methods.
@@ -376,6 +365,8 @@ A bottom sheet is a variant supported on narrow viewports made to facilitate rea
 
 A bottom sheet always dims the rest of the screen for focus and takes up the full width of the viewport. Tapping on the backdrop dismisses the Dialog.
 
+Use a bottom to indicate that the user is still in the context of the main page, and that the Dialog is a secondary action.
+
 <img
   width="960"
   alt="bottom-sheet"
@@ -394,7 +385,7 @@ In landscape mode, a bottom sheet has a maximum width of `480px`, and is centere
 
 ### Full-screen
 
-Full-screen Dialogs may be used to present content that needs all the available space on narrow viewports. Dialogs that have one or more input fields should always use the full-screen variant.
+Full-screen Dialogs may be used to present content that needs all the available space on narrow viewports, or to act as a new page without navigating away from the main page. Dialogs that have one or more input fields should always use the full-screen variant.
 
 <img
   width="960"
@@ -405,9 +396,22 @@ Full-screen Dialogs may be used to present content that needs all the available 
 
 ## Accessibility
 
-Dialog's title and close button as addressed previously are required to ensure an accessible experience for everyone. Further, keyboard and focus behavior must be considered.
+Dialog's title and close button are required to ensure an accessible experience for everyone. Further, keyboard and focus behavior must be considered.
 
-When a Dialog is opened, the first interactive element (the close button) is focused. Hitting `tab` will cycle through all interactive elements within the Dialog. To escape the focus trap, hitting the `esc` key or clicking on the backdrop will close the Dialog. While the Dialog is open, page scrolling is disabled and becomes `inert`.
+### Trigger elements and keyboard focus
+
+Dialogs are initially hidden, and can be opened by an element with `role="button"`, called a **trigger**. The role `button` allows the **trigger** to be a relatively complex element, such as an action list item.
+
+Dialogs must be fully functional using the keyboard and assistive technology. Pressing `Esc` must dismiss a Dialog, also returning focus to the **trigger** that opened it.
+
+<CustomVideoPlayer
+  width="100%"
+  loop
+  src="https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4"
+/>
+<Caption>Clicking the backdrop or hitting the `esc` key should dismiss the Dialog.</Caption>
+
+When a Dialog is opened, the first interactive element (typically the close button) is focused. For a scenario like a command palette with an `<input>` next to the close button, the `<input>` will recieve focus first. Hitting `tab` will cycle through all interactive elements within the Dialog. To escape the focus trap, hitting the `esc` key or clicking on the backdrop will close the Dialog. While the Dialog is open, page scrolling is disabled and becomes `inert`.
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5} marginBottom={5}>
   <div>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -188,7 +188,7 @@ If the answer is yes, designing the feature inside a Dialog provides an easy way
 
 ### Trigger elements and keyboard focus
 
-Dialogs are initially hidden, and can be opened by an element with `role="button"`, called a **trigger**. The role `button` allows the **trigger** to be a relativelly complex element, such as an action list item.
+Dialogs are initially hidden, and can be opened by an element with `role="button"`, called a **trigger**. The role `button` allows the **trigger** to be a relatively complex element, such as an action list item.
 
 Dialogs should be fully functional using the keyboard and assistive technology. Pressing `Esc` should dismiss a Dialog, also returning focus to the **trigger** that opened it.
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -374,7 +374,7 @@ Full-screen Dialogs may be used to present content that needs all the available 
   alt=""
   src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"
 />
-<Caption>Full-screen dialog in portrait mode.</Caption>
+<Caption>Full-screen Dialog in portrait mode.</Caption>
 
 ## Accessibility
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -7,7 +7,8 @@ import {Box, Heading, Label, LabelGroup, Link} from '@primer/react'
 import {Caption} from '@primer/gatsby-theme-doctocat'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
-  A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and more.
+  A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and
+  more.
 </Box>
 
 <Box mb={4}>
@@ -49,11 +50,15 @@ import {Caption} from '@primer/gatsby-theme-doctocat'
 
 ## Overview
 
-Dialogs can streamline the interface by allowing extra content to be disclosed as needed. Dialogs create a new modality to the user, and can facilitate the completion of individual tasks.
+Dialogs can streamline the interface by allowing extra content to be disclosed as needed. Dialogs create a new modality to the user, and can expedite the completion of individual tasks.
 
 ## Anatomy
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185509649-50791e2f-0a4c-44d9-8b2b-e34b3f394315.png" />
+<img
+  width="960"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185509649-50791e2f-0a4c-44d9-8b2b-e34b3f394315.png"
+/>
 <Caption>Anatomy of a Dialog.</Caption>
 
 ### Header region
@@ -66,22 +71,36 @@ The header region provides a slot for custom content in place of the default tit
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849372-a9d33d3b-96f3-497e-bad6-70df4d91072a.png" alt="" />
+    <img
+      src="https://user-images.githubusercontent.com/293280/175849372-a9d33d3b-96f3-497e-bad6-70df4d91072a.png"
+      alt=""
+    />
     <Caption>Header with the default title variant.</Caption>
   </div>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849374-6a71d8a0-da61-4745-a059-4560d053089b.png" alt="" />
+    <img
+      src="https://user-images.githubusercontent.com/293280/175849374-6a71d8a0-da61-4745-a059-4560d053089b.png"
+      alt=""
+    />
     <Caption>Header with large title variant.</Caption>
   </div>
 </Box>
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185478040-be5a3552-9ed1-40ef-a713-3d6ac8f6b697.png" />
+    <img
+      width="464"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/185478040-be5a3552-9ed1-40ef-a713-3d6ac8f6b697.png"
+    />
     <Caption>Header with custom variant and a secondary action button.</Caption>
   </div>
   <div>
-    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185478144-87887a98-e541-4a23-bd1c-6cb174a453a7.png"/>
+    <img
+      width="464"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/185990665-5cf39b59-420a-41bf-8d65-d431134d2738.png"
+    />
     <Caption>Command palette with a visually hidden title.</Caption>
   </div>
 </Box>
@@ -92,11 +111,17 @@ The subheader region is an optional space for interactive controls. Use it to di
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849377-ef70f4e7-2978-415c-9da1-a2ba2f33bdc3.png" alt="" />
+    <img
+      src="https://user-images.githubusercontent.com/293280/175849377-ef70f4e7-2978-415c-9da1-a2ba2f33bdc3.png"
+      alt=""
+    />
     <Caption>Header displaying a subheader with a search field.</Caption>
   </div>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175849376-ef25a1ba-b5b7-4ae0-8d9a-78095932886a.png" alt="" />
+    <img
+      src="https://user-images.githubusercontent.com/293280/175849376-ef25a1ba-b5b7-4ae0-8d9a-78095932886a.png"
+      alt=""
+    />
     <Caption>Header displaying a subheader with a local navigation.</Caption>
   </div>
 </Box>
@@ -107,34 +132,50 @@ The body region is the main content of the Dialog. It can contain any content th
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185506131-1436b06b-a8fb-4de8-b9b2-4715ab0a63d2.png"/>
+    <img
+      width="650"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/185506131-1436b06b-a8fb-4de8-b9b2-4715ab0a63d2.png"
+    />
     <Caption>Body content will scroll vertically if the content exceeds the overall Dialog height.</Caption>
   </div>
   <div>
-    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185478320-2a4a3053-dca3-4048-b7c4-d5a39a83acd6.png" />
+    <img
+      width="650"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/185478320-2a4a3053-dca3-4048-b7c4-d5a39a83acd6.png"
+    />
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>
 </Box>
 
 ### Footer region
 
-The footer region may be used to show confirmation actions, navigation links, or specialized actions.
+The footer region may be used to show confirmation actions, navigation links, or specialized actions. Primary actions should be aligned to the right of the footer, and grouped why additional related actions. Secondary actions may be shown aligned to the left side.
 
 If the content area has overflow scrolling, a divider will be shown between the footer and content area. Otherwise, showing a divider is optional.
 
-<img src="https://user-images.githubusercontent.com/293280/175850630-9f3df284-c69b-4d16-9e57-ea04a0202d04.png" width="960" alt="" />
-<Caption>
-  Use buttons in a footer to let the user complete a task.
-</Caption>
+<img
+  src="https://user-images.githubusercontent.com/293280/175850630-9f3df284-c69b-4d16-9e57-ea04a0202d04.png"
+  width="960"
+  alt=""
+/>
+<Caption>Use buttons in a footer to let the user complete a task.</Caption>
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175850639-a77d537e-2807-47d2-b456-a298d5f44918.png" alt="" />
-    <Caption>Footer with small buttons.</Caption>
+    <img
+      src="https://user-images.githubusercontent.com/293280/175850639-a77d537e-2807-47d2-b456-a298d5f44918.png"
+      alt=""
+    />
+    <Caption>Footer with small buttons aligned to the right.</Caption>
   </div>
   <div>
-    <img src="https://user-images.githubusercontent.com/293280/175850637-3b193552-b35f-4b07-b2d6-4ca546c8131a.png" alt="" />
-    <Caption>Footer with auxiliary create button.</Caption>
+    <img
+      src="https://user-images.githubusercontent.com/293280/175850637-3b193552-b35f-4b07-b2d6-4ca546c8131a.png"
+      alt=""
+    />
+    <Caption>Footer with a secondary button aligned to the left.</Caption>
   </div>
 </Box>
 
@@ -150,18 +191,30 @@ Dialogs should never extend beyond the viewport sizes, and may resize to fit sma
 
 The `height` and `width` may be set to `auto` which will set a minimum width of `192px` and respond to the contents of the Dialog. Additionally, an explicit `height` and `width` may be set with a specific set of options.
 
-<img width="1292" alt="" src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"/>
+<img
+  width="1292"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"
+/>
 <Caption>Recommended height and width combinations for Dialog</Caption>
 
 ### Spacing
 
 The edges of Dialog are free of text and heavy visuals to visually distinguish the Dialog as an elevated surface, alongside its shadow. Content within the body and header should remain within the 16px safe area. However, inner components that have transparent or discrete backgrounds may bleed into the padding for visual alignment.
 
-<img alt="" src="https://user-images.githubusercontent.com/293280/174925634-603a27cf-2281-4a3a-9078-d1b8138e0d09.png" width="960" />
+<img
+  alt=""
+  src="https://user-images.githubusercontent.com/293280/174925634-603a27cf-2281-4a3a-9078-d1b8138e0d09.png"
+  width="960"
+/>
 <Caption>
-  1. A search field in the Subheader region appears closer to the edges. While the search icon remains within the safe area.<br />
-  2. Close button placed `8px` away from the edges. Note that the "×" glyph remains within the safe area.<br />
-  3. Action list items in the Body region.<br />
+  1. A search field in the Subheader region appears closer to the edges. While the search icon remains within the safe
+  area.
+  <br />
+  2. Close button placed `8px` away from the edges. Note that the "×" glyph remains within the safe area.
+  <br />
+  3. Action list items in the Body region.
+  <br />
   4. Footer buttons always appear inside the safe area. <br />
 </Caption>
 
@@ -177,11 +230,19 @@ If the answer is yes, designing the feature inside a Dialog provides an easy way
 
 <DoDontContainer>
   <Do>
-    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185224257-a40112ff-aaf3-4947-acf0-6b4020e023df.png" />
+    <img
+      width="464"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/185224257-a40112ff-aaf3-4947-acf0-6b4020e023df.png"
+    />
     <Caption>Prefer a single column layout.</Caption>
   </Do>
   <Dont>
-    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185224316-0680b89a-8514-4336-9147-64aac722cd9a.png" />
+    <img
+      width="464"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/185224316-0680b89a-8514-4336-9147-64aac722cd9a.png"
+    />
     <Caption>Avoid side navigation within a Dialog.</Caption>
   </Dont>
 </DoDontContainer>
@@ -193,9 +254,9 @@ Dialogs are initially hidden, and can be opened by an element with `role="button
 Dialogs must be fully functional using the keyboard and assistive technology. Pressing `Esc` must dismiss a Dialog, also returning focus to the **trigger** that opened it.
 
 <CustomVideoPlayer
-    width="100%"
-    loop
-    src="https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4"
+  width="100%"
+  loop
+  src="https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4"
 />
 <Caption>Clicking the backdrop or hitting the `esc` key should dismiss the Dialog.</Caption>
 
@@ -206,15 +267,15 @@ Dialogs must adjust their designs to fit in smaller viewports. Make sure the ove
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
     <CustomVideoPlayer
-        width="100%"
-        src="https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4"
+      width="100%"
+      src="https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4"
     />
     <Caption>Center aligned Dialog becomes fullscreen on narrow viewport.</Caption>
   </div>
   <div>
     <CustomVideoPlayer
-        width="100%"
-        src="https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4"
+      width="100%"
+      src="https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4"
     />
     <Caption>Center aligned Dialog becomes a bottom sheet on narrow viewport.</Caption>
   </div>
@@ -226,7 +287,11 @@ Dialogs must adjust their designs to fit in smaller viewports. Make sure the ove
 
 By default, Dialog appears centered in the viewport, with a visible backdrop that dims the rest of the window for focus. Centered Dialogs are surrounded by a safe area of `16px` between the frame and the viewport for all sizes.
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185224429-9f0af3ee-3e11-4f94-a5f6-746ed8a5c300.png"/>
+<img
+  width="960"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185224429-9f0af3ee-3e11-4f94-a5f6-746ed8a5c300.png"
+/>
 <Caption>Dialog centered within a desktop screen.</Caption>
 
 ### Side sheets
@@ -235,11 +300,22 @@ Side sheets slide from the right or left edges of the viewport. **Left side shee
 
 Side sheets take the entire height of the viewport, and should be used sparingly. Don't use side sheets to present create/edit forms, or flows that may contain a lot of information. For that, use a page instead.
 
-<img width="960" alt="placement-desktop-1" src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png"/>
+<img
+  width="960"
+  alt="placement-desktop-1"
+  src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png"
+/>
 <Caption>Left aligned side sheet is reserved for global navigation only.</Caption>
 
-<img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png"/>
-<Caption>Right aligned side sheet can be used for global actions, but may also be considered for quick previews or configuration panels.</Caption>
+<img
+  width="960"
+  alt="placement-desktop-2"
+  src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png"
+/>
+<Caption>
+  Right aligned side sheet can be used for global actions, but may also be considered for quick previews or
+  configuration panels.
+</Caption>
 
 ## Narrow-viewport placement
 
@@ -249,17 +325,29 @@ A bottom sheet is a variant supported on narrow viewports made to facilitate rea
 
 A bottom sheet always dims the rest of the screen for focus and takes up the full width of the viewport. Tapping on the backdrop dismisses the Dialog.
 
-<img width="960" alt="bottom-sheet" src="https://user-images.githubusercontent.com/18661030/185214084-43e9573a-1a3b-4b82-b121-bd03897f48ac.png"/>
+<img
+  width="960"
+  alt="bottom-sheet"
+  src="https://user-images.githubusercontent.com/18661030/185214084-43e9573a-1a3b-4b82-b121-bd03897f48ac.png"
+/>
 <Caption>Bottom sheet in portrait mode.</Caption>
 
 In landscape mode, a bottom sheet has a maximum width of `480px`, and is centered horizontally.
 
-<img width="960" alt="overlay-sheet-landscape" src="https://user-images.githubusercontent.com/18661030/185214089-a1bb1a70-914b-4a8f-b395-9c279a88a1fe.png"/>
+<img
+  width="960"
+  alt="overlay-sheet-landscape"
+  src="https://user-images.githubusercontent.com/18661030/185214089-a1bb1a70-914b-4a8f-b395-9c279a88a1fe.png"
+/>
 <Caption>Bottom sheet in landscape mode.</Caption>
 
 ### Full-screen
 
 Full-screen Dialogs may be used to present content that needs all the available space on narrow viewports. Dialogs that have one or more input fields should always use the full-screen variant.
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"/>
+<img
+  width="960"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"
+/>
 <Caption>Full-screen dialog in portrait mode.</Caption>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -233,7 +233,7 @@ By default, Dialog appears centered in the viewport, with a visible backdrop tha
 
 Side sheets slide from the right or left edges of the viewport. **Left side sheets are reserved for global navigation drawers. Right side sheets are used for global actions, but can also be considered for quick previews in full-width pages, or configuration panels.**
 
-Side sheets take the entire height of the viewport, and should be used sparingly. Don't use side sheets to present forms or flows that should be a page instead.
+Side sheets take the entire height of the viewport, and should be used sparingly. Don't use side sheets to present create/edit forms, or flows that may contain a lot of information. For that, use a page instead.
 
 <img width="960" alt="placement-desktop-1" src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png"/>
 <Caption>Left aligned side sheet is reserved for global navigation only.</Caption>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -145,7 +145,7 @@ The body region is the main content of the Dialog. It can contain any content th
     <img
       width="650"
       alt=""
-      src="https://user-images.githubusercontent.com/18661030/186003712-36441f05-1407-4b03-a50a-3773275e4d61.png"
+      src="https://user-images.githubusercontent.com/18661030/187487429-bef6924c-9f25-4ec9-9416-5800396a7b32.png"
     />
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -100,7 +100,7 @@ The body region is the main content of the Dialog. It can contain any content th
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185478284-e093c72f-fc49-4dbf-b848-d1468dab14b0.png"/>
+    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185506131-1436b06b-a8fb-4de8-b9b2-4715ab0a63d2.png">
     <Caption>Body content will scroll vertically if the content exceeds the overall Dialog height.</Caption>
   </div>
   <div>
@@ -108,6 +108,19 @@ The body region is the main content of the Dialog. It can contain any content th
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>
 </Box>
+
+
+
+
+
+
+https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4
+
+
+https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4
+
+
+
 
 ### Footer region
 
@@ -138,6 +151,7 @@ Dialog displays with a **backdrop**, which dims the rest of the page. The backdr
 By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
 
 <!-- video here -->
+https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4
 
 ### Dimensions
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -239,7 +239,7 @@ Side sheets take the entire height of the viewport, and should be used sparingly
 <Caption>Left aligned side sheet is reserved for global navigation only.</Caption>
 
 <img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png"/>
-<Caption>Right aligned side sheet for global actions.</Caption>
+<Caption>Right aligned side sheet can be used for global actions, but may also be considered for quick previews or configuration panels.</Caption>
 
 ## Narrow-viewport placement
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -10,35 +10,42 @@ import {Caption} from '@primer/gatsby-theme-doctocat'
   A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and more.
 </Box>
 
-<LabelGroup display="block" mb={4}>
-  <Label
-    as="a"
-    href="https://primer.style/react/Dialog"
-    variant="xl"
-    color="text.success"
-    outline
-    style="text-decoration: none; line-height: 20px;"
-  >
-    <img
-      width="20"
-      height="20"
-      alt=" "
-      src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
-      style="vertical-align: middle; margin-right: 4px;"
-    />
-    React
-  </Label>
-  <Label as="a" href="#" variant="xl" outline style="text-decoration: none; line-height: 20px;">
-    <img
-      width="20"
-      height="20"
-      alt=" "
-      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
-      style="vertical-align: middle; margin-right: 4px;"
-    />
-    Figma
-  </Label>
-</LabelGroup>
+<Box mb={4}>
+  <LabelGroup>
+    <Label
+      as="a"
+      href="https://primer.style/react/Dialog"
+      size="large"
+      variant="secondary"
+      sx={{textDecoration: 'none'}}
+    >
+      <img
+        width="16"
+        height="16"
+        alt=" "
+        src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
+        style="vertical-align: middle; margin-right: 4px;"
+      />
+      React
+    </Label>
+    {/* <Label
+      as="a"
+      href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0"
+      size="large"
+      variant="secondary"
+      sx={{textDecoration: 'none'}}
+    >
+      <img
+        width="16"
+        height="16"
+        alt=" "
+        src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
+        style="vertical-align: middle; margin-right: 4px;"
+      />
+      Figma
+    </Label> */}
+  </LabelGroup>
+</Box>
 
 ## Overview
 
@@ -100,7 +107,7 @@ The body region is the main content of the Dialog. It can contain any content th
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
-    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185506131-1436b06b-a8fb-4de8-b9b2-4715ab0a63d2.png">
+    <img width="650" alt="" src="https://user-images.githubusercontent.com/18661030/185506131-1436b06b-a8fb-4de8-b9b2-4715ab0a63d2.png"/>
     <Caption>Body content will scroll vertically if the content exceeds the overall Dialog height.</Caption>
   </div>
   <div>
@@ -108,19 +115,6 @@ The body region is the main content of the Dialog. It can contain any content th
     <Caption>The body may contain additional content such as banners and form controls.</Caption>
   </div>
 </Box>
-
-
-
-
-
-
-https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4
-
-
-https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4
-
-
-
 
 ### Footer region
 
@@ -149,9 +143,6 @@ If the content area has overflow scrolling, a divider will be shown between the 
 Dialog displays with a **backdrop**, which dims the rest of the page. The backdrop is visible when the Dialog is centered on the page, or attached to a sides as a sheet.
 
 By default, clicking on the **backdrop** will dismiss the Dialog. However, if the Dialog contains a form that can have unsaved changes, the **backdrop** won't dismiss the Dialog, regardless of the state of the form.
-
-<!-- video here -->
-https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4
 
 ### Dimensions
 
@@ -201,9 +192,33 @@ Dialogs are initially hidden, and can be opened by an element with `role="button
 
 Dialogs should be fully functional using the keyboard and assistive technology. Pressing `Esc` should dismiss a Dialog, also returning focus to the **trigger** that opened it.
 
+<CustomVideoPlayer
+    width="100%"
+    loop
+    src="https://user-images.githubusercontent.com/18661030/185507547-0843b014-0b90-48f5-9e4f-746caa42b4e6.mp4"
+/>
+<Caption>Clicking the backdrop or hitting the `esc` key should dismiss the Dialog.</Caption>
+
 ### Dialogs should work well on any device
 
 Dialogs must adjust their designs to fit in smaller viewports. Make sure the overlay contents work with all supported sizes and input methods.
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <CustomVideoPlayer
+        width="100%"
+        src="https://user-images.githubusercontent.com/18661030/185507523-74e0acff-6980-439e-84c5-422b16470c9e.mp4"
+    />
+    <Caption>Center aligned Dialog becomes fullscreen on narrow viewport.</Caption>
+  </div>
+  <div>
+    <CustomVideoPlayer
+        width="100%"
+        src="https://user-images.githubusercontent.com/18661030/185507508-298f9378-3f26-4e45-9809-5aef3d8cd3e2.mp4"
+    />
+    <Caption>Center aligned Dialog becomes a bottom sheet on narrow viewport.</Caption>
+  </div>
+</Box>
 
 ## Regular-viewport placement
 
@@ -216,7 +231,7 @@ By default, Dialog appears centered in the viewport, with a visible backdrop tha
 
 ### Side sheets
 
-Side sheets slide from the right or left edges of the viewport. Left side sheets are reserved for global navigation drawers. Right side sheets are used for global actions, but can also be considered for quick previews in full-width pages, or configuration panels.
+Side sheets slide from the right or left edges of the viewport. **Left side sheets are reserved for global navigation drawers. Right side sheets are used for global actions, but can also be considered for quick previews in full-width pages, or configuration panels.**
 
 Side sheets take the entire height of the viewport, and should be used sparingly. Don't use side sheets to present forms or flows that should be a page instead.
 
@@ -248,22 +263,3 @@ Full-screen Dialogs may be used to present content that needs all the available 
 
 <img width="960" alt="fullscreen" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"/>
 <Caption>Full-screen dialog in portrait mode.</Caption>
-
-
-
-## Accessibility
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- Accessibility considerations when using the component. Include keyboard navigation, descriptions, common mistakes to avoid. -->

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -46,7 +46,7 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 
 ## Anatomy
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185178231-3d650dac-e9a0-4843-ace3-4ec756125fc4.png">
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185178231-3d650dac-e9a0-4843-ace3-4ec756125fc4.png"/>
 <Caption>Anatomy of a Dialog.</Caption>
 
 ### Dialog regions
@@ -127,7 +127,7 @@ Dialogs should never extend beyond the viewport sizes, and may resize to fit sma
 
 The `height` and `width` may be set to `auto` which will set a minimum width of `192px` and respond to the contents of the Dialog. Additionally, an explicit `height` and `width` may be set with a specific set of options.
 
-<img width="1292" alt="" src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png">
+<img width="1292" alt="" src="https://user-images.githubusercontent.com/18661030/185178528-e1c176ef-f407-40ab-8729-965e21d64f6d.png"/>
 <Caption>Recommended height and width combinations for Dialog</Caption>
 
 ### Scroll behavior
@@ -189,18 +189,65 @@ Dialogs should be fully functional using the keyboard and assistive technology. 
 
 Dialogs must adjust their designs to fit in smaller viewports. Make sure the overlay contents work with all supported sizes and input methods.
 
-## Placement
+## Regular-screen placement
 
-<!-- Where to use the component and how it interacts with the rest of the UI. Include images and dos and donts of how the component should be used within the UI. -->
+### Centered
+
+By default, Dialog appears centered in the viewport, with a visible backdrop that dims the rest of the window for focus. Centered Dialogs are surrounded by a safe area of `16px` between the frame and the viewport for all sizes.
+
+<!-- new img here -->
+<img width="960" alt="placement-desktop" src="https://user-images.githubusercontent.com/18661030/185214098-8fee6748-8c3b-49f2-8713-57bf9372ab16.png"/>
+
+### Side sheets
+
+Side sheets slide from the right or left edges of the viewport. Left side sheets are reserved for global navigation drawers. Right side sheets are used for global actions, but can also be considered for quick previews in full-width pages, or configuration panels.
+
+Side sheets take the entire height of the viewport, and should be used sparingly. Don't use side sheets to present forms or flows that should be a page instead.
+
+<img width="960" alt="placement-desktop-1" src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png"/>
+<Caption>Left aligned side sheet for global navigation.</Caption>
+
+<img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png"/>
+<Caption>Right aligned side sheet for global actions.</Caption>
+
+## Narrow-screen placement
+
+### Bottom sheets
+
+A bottom sheet is a variant supported on narrow viewports made to facilitate reachability. Dialogs that appear centered in large screens may adapt to appear as a bottom sheet on small screens.
+
+A bottom sheet always dims the rest of the screen for focus and takes up the full width of the viewport. Tapping on the backdrop dismisses the Dialog.
+
+<img width="960" alt="bottom-sheet" src="https://user-images.githubusercontent.com/18661030/185214084-43e9573a-1a3b-4b82-b121-bd03897f48ac.png"/>
+<Caption>Bottom sheet in portrait mode.</Caption>
+
+In landscape mode, a bottom sheet has a maximum width of `480px`, and is centered horizontally.
+
+<img width="960" alt="overlay-sheet-landscape" src="https://user-images.githubusercontent.com/18661030/185214089-a1bb1a70-914b-4a8f-b395-9c279a88a1fe.png"/>
+<Caption>Bottom sheet in landscape mode.</Caption>
+
+### Full-screen
+
+Full-screen Dialogs may be used to present content that needs all the available space on narrow viewports. Dialogs that have one or more input fields should always use the full-screen variant.
+
+<img width="960" alt="fullscreen" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"/>
+<Caption>Full-screen dialog in portrait mode.</Caption>
+
+
 
 ## Accessibility
 
-<img width="960" alt="fullscreen" src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png">
-<img width="960" alt="bottom-sheet" src="https://user-images.githubusercontent.com/18661030/185214084-43e9573a-1a3b-4b82-b121-bd03897f48ac.png">
-<img width="960" alt="overlay-sheet-landscape" src="https://user-images.githubusercontent.com/18661030/185214089-a1bb1a70-914b-4a8f-b395-9c279a88a1fe.png">
-<img width="960" alt="placement-desktop-2" src="https://user-images.githubusercontent.com/18661030/185214094-419d2271-dbb9-4e78-90e6-4433ed9c42fb.png">
-<img width="960" alt="placement-desktop-1" src="https://user-images.githubusercontent.com/18661030/185214096-8ad908b4-2cbd-467d-8e74-bad6948c5a2d.png">
-<img width="960" alt="placement-desktop" src="https://user-images.githubusercontent.com/18661030/185214098-8fee6748-8c3b-49f2-8713-57bf9372ab16.png">
+
+
+
+
+
+
+
+
+
+
+
 
 
 <!-- Accessibility considerations when using the component. Include keyboard navigation, descriptions, common mistakes to avoid. -->

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -153,7 +153,7 @@ The body region is the main content of the Dialog. It can contain any content th
 
 ### Footer region
 
-The footer region may be used to show confirmation actions, navigation links, or specialized actions. Primary actions should be aligned to the right of the footer, and grouped why additional related actions. Secondary actions may be shown aligned to the left side.
+The footer region may be used to show confirmation actions, navigation links, or specialized actions. Primary actions should be aligned to the right of the footer, and grouped by additional related actions. Secondary actions may be shown aligned to the left side.
 
 If the content area has overflow scrolling, a divider will be shown between the footer and content area. Otherwise, showing a divider is optional.
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -69,7 +69,7 @@ The title is required for all Dialogs, but may be visually hidden for custom sce
 
 The header region provides a slot for custom content in place of the default title/description, though a title is still required and may be visually hidden. Secondary action icon buttons may be placed next to the close button.
 
-<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5} marginBottom={5}>
   <div>
     <img
       src="https://user-images.githubusercontent.com/293280/175849372-a9d33d3b-96f3-497e-bad6-70df4d91072a.png"
@@ -351,3 +351,33 @@ Full-screen Dialogs may be used to present content that needs all the available 
   src="https://user-images.githubusercontent.com/18661030/185214079-d30342c1-6061-4a31-ab65-c0cef0f00278.png"
 />
 <Caption>Full-screen dialog in portrait mode.</Caption>
+
+## Accessibility
+
+Dialog's title and close button as addressed previously are required to ensure an accessible experience for everyone. Further, keyboard and focus behavior must be considered.
+
+When a Dialog is opened, the first interactive element (the close button) is focused. Hitting `tab` will cycle through all interactive elements within the Dialog. To escape the focus trap, hitting the `esc` key or clicking on the backdrop will close the Dialog. While the Dialog is open, page scrolling is disabled and becomes `inert`.
+
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5} marginBottom={5}>
+  <div>
+    <img
+      src="https://user-images.githubusercontent.com/18661030/185997280-fb36be9c-bfde-463b-b33c-9f25412683d2.png"
+      alt=""
+    />
+    <Caption>Dialogs can be trigger by buttons with a mouse click or keypress.</Caption>
+  </div>
+  <div>
+    <img
+      src="https://user-images.githubusercontent.com/18661030/185997278-6fc2b938-6453-47d7-99ae-0411354eb06e.png"
+      alt=""
+    />
+    <Caption>The first interactive item inside a Dialog is focused when on open.</Caption>
+  </div>
+</Box>
+
+<img
+  width="960"
+  alt=""
+  src="https://user-images.githubusercontent.com/18661030/185997276-25cd8796-42e2-41f6-b5be-551f6a02349b.png"
+/>
+<Caption>When a Dialog is closed, focus is returned to the trigger button.</Caption>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -3,7 +3,8 @@ title: Dialog
 status: Alpha
 ---
 
-import {Box, Heading, Label, LabelGroup, Link, Caption} from '@primer/components'
+import {Box, Heading, Label, LabelGroup, Link} from '@primer/react'
+import {Caption} from '@primer/gatsby-theme-doctocat'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
   A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and more.

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -364,14 +364,14 @@ When a Dialog is opened, the first interactive element (the close button) is foc
       src="https://user-images.githubusercontent.com/18661030/185997280-fb36be9c-bfde-463b-b33c-9f25412683d2.png"
       alt=""
     />
-    <Caption>Dialogs can be trigger by buttons with a mouse click or keypress.</Caption>
+    <Caption>Dialogs can be triggered by buttons with a mouse click or keypress.</Caption>
   </div>
   <div>
     <img
       src="https://user-images.githubusercontent.com/18661030/185997278-6fc2b938-6453-47d7-99ae-0411354eb06e.png"
       alt=""
     />
-    <Caption>The first interactive item inside a Dialog is focused when on open.</Caption>
+    <Caption>The first interactive item inside a Dialog is focused when opened.</Caption>
   </div>
 </Box>
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -46,7 +46,7 @@ Dialogs can streamline the interface by allowing extra content to be disclosed a
 
 ## Anatomy
 
-<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185178231-3d650dac-e9a0-4843-ace3-4ec756125fc4.png"/>
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185224138-0365fdee-c4b8-41bb-9eb8-65c05d1c52c1.png" />
 <Caption>Anatomy of a Dialog.</Caption>
 
 ### Dialog regions
@@ -164,17 +164,11 @@ If the answer is yes, designing the feature inside a Dialog provides an easy way
 
 <DoDontContainer>
   <Do>
-    <img
-      src="https://user-images.githubusercontent.com/293280/174922550-782a544b-12aa-4b2a-9ca7-700f8bc4f166.png"
-      alt=""
-    />
+    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185224257-a40112ff-aaf3-4947-acf0-6b4020e023df.png" />
     <Caption>Prefer a single column layout.</Caption>
   </Do>
   <Dont>
-    <img
-      src="https://user-images.githubusercontent.com/293280/174922547-c658b89e-d304-48f0-b884-76bd0d440c9c.png"
-      alt=""
-    />
+    <img width="464" alt="" src="https://user-images.githubusercontent.com/18661030/185224316-0680b89a-8514-4336-9147-64aac722cd9a.png" />
     <Caption>Avoid side navigation within a Dialog.</Caption>
   </Dont>
 </DoDontContainer>
@@ -195,8 +189,8 @@ Dialogs must adjust their designs to fit in smaller viewports. Make sure the ove
 
 By default, Dialog appears centered in the viewport, with a visible backdrop that dims the rest of the window for focus. Centered Dialogs are surrounded by a safe area of `16px` between the frame and the viewport for all sizes.
 
-<!-- new img here -->
-<img width="960" alt="placement-desktop" src="https://user-images.githubusercontent.com/18661030/185214098-8fee6748-8c3b-49f2-8713-57bf9372ab16.png"/>
+<img width="960" alt="" src="https://user-images.githubusercontent.com/18661030/185224429-9f0af3ee-3e11-4f94-a5f6-746ed8a5c300.png"/>
+<Caption>Dialog centered within a desktop screen size.</Caption>
 
 ### Side sheets
 

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -40,6 +40,16 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
+    <Link href="/design/components/dialog">
+      <img role="presentation" src="" />
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/components/segmented-control">
+      <img role="presentation" src="" />
+    </Link>
+  </div>
+  <div>
     <Link href="/design/components/toggle-switch">
       <img
         role="presentation"

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -41,12 +41,7 @@ import {Box, Link, Text} from '@primer/react'
   </div>
   <div>
     <Link href="/design/components/dialog">
-      <img role="presentation" src="" />
-    </Link>
-  </div>
-  <div>
-    <Link href="/design/components/segmented-control">
-      <img role="presentation" src="" />
+      <img role="presentation" src="https://user-images.githubusercontent.com/18661030/187484926-34a5f331-9ca0-4baf-a401-d4a547067467.png" />
     </Link>
   </div>
   <div>

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -43,7 +43,7 @@ import {Box, Link, Text} from '@primer/react'
     <Link href="/design/components/dialog" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"
-        src="https://user-images.githubusercontent.com/18661030/187484926-34a5f331-9ca0-4baf-a401-d4a547067467.png"
+        src="https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png"
       />
     </Link>
   </div>

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -40,9 +40,21 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/components/dialog">
-      <img role="presentation" src="https://user-images.githubusercontent.com/18661030/187484926-34a5f331-9ca0-4baf-a401-d4a547067467.png" />
+    <Link href="/design/components/dialog" sx={{fontWeight: 'bold'}}>
+      <img
+        role="presentation"
+        src="https://user-images.githubusercontent.com/18661030/187484926-34a5f331-9ca0-4baf-a401-d4a547067467.png"
+      />
     </Link>
+  </div>
+  <div>
+    <Link href="/design/components/dialog" sx={{fontWeight: 'bold'}}>
+      Dialog
+    </Link>
+    <Text as="p">
+      A Dialog is a floating surface used to display transient content such as confirmation actions, selection options,
+      and more.
+    </Text>
   </div>
   <div>
     <Link href="/design/components/toggle-switch">

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -58,6 +58,8 @@
       url: /components/action-list
     - title: Autocomplete
       url: /components/autocomplete
+    - title: Dialog
+      url: /components/dialog
     - title: Segmented control
       url: /components/segmented-control
     - title: Toggle switch


### PR DESCRIPTION
Interface guidelines for the updated Dialog component coming soon to PVC! ✨ 

See preview deploy: https://primer-f643fd6630-26441320.drafts.github.io/components/dialog

<img width="960" alt="Dialog anatomy visual with internal labels pointing to each region" src="https://user-images.githubusercontent.com/18661030/185509794-0a3b578e-40b2-43db-ab61-8731c9888702.png">

This is a scoped down version of the Overlay interface guidelines #167. We decided that these guidelines are best suited as component specific compared to a general pattern overview. After Dialog, we'll tackle other Overlay related `ActionMenu`, `SelectPanel`, `SelectMenu` and update `Autocomplete` interface guidelines which will cover the specifics of those components.

**Feedback**

- [ ] Check spelling 🙌 
- [ ] Are the corresponding images clear? Is each caption sufficient?
- [ ] Is there anything else you want to see included here?

PVC implementation: https://github.com/primer/view_components/pull/1214
Closes https://github.com/github/primer/issues/656