### PR TITLE
Adding WebAIM contrast checker to tools section

### DIFF
--- a/content/accessibility/tools.mdx
+++ b/content/accessibility/tools.mdx
@@ -4,6 +4,9 @@ title: Accessibility tools
 
 A selection of tools to help product designers design accessibly. 
 
+### On testing color contrast
+When testing contrast be wary of tools that use color pickers. The picked color may differ depending on your color space settings and other factors. Always prefer direct value input.
+
 ## Figma 
 
 ### [Accessibility sticker sheet](https://www.figma.com/file/o3Vhxw4SmBsUjeaVq3nF4y/Accessibility-Notation?node-id=0%3A1)
@@ -58,3 +61,12 @@ Free application for Windows that is comparable to Sim Daltonism on Mac.
 Color review is fantastic if you're looking for help finding an accessible color in an existing palette. 
 
 ![""](https://user-images.githubusercontent.com/40274682/88444756-90d6a100-cdd3-11ea-876c-1c850ae19223.png)
+
+### [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+
+The WebAIM contrast checker is the golden standard and does a good job explaining what the result means. 
+At GitHub the WebAIM contrast checker is the standard that has to be met.
+
+There is also a [link contrast checker](https://webaim.org/resources/linkcontrastchecker/?fcolor=D9D9D9&bcolor=FFFFFF).
+
+!["webaim contrast color checker website"](https://user-images.githubusercontent.com/813754/188844756-2340bcbd-2630-4a5f-be4a-8796774601cc.png)

--- a/content/accessibility/tools.mdx
+++ b/content/accessibility/tools.mdx
@@ -56,12 +56,6 @@ Free application for Windows that is comparable to Sim Daltonism on Mac.
 
 ## Web tools
 
-### [Color Review](https://color.review/) 
-
-Color review is fantastic if you're looking for help finding an accessible color in an existing palette. 
-
-![""](https://user-images.githubusercontent.com/40274682/88444756-90d6a100-cdd3-11ea-876c-1c850ae19223.png)
-
 ### [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
 
 The WebAIM contrast checker is the golden standard and does a good job explaining what the result means. 
@@ -70,3 +64,9 @@ At GitHub the WebAIM contrast checker is the standard that has to be met.
 There is also a [link contrast checker](https://webaim.org/resources/linkcontrastchecker/?fcolor=D9D9D9&bcolor=FFFFFF).
 
 !["webaim contrast color checker website"](https://user-images.githubusercontent.com/813754/188844756-2340bcbd-2630-4a5f-be4a-8796774601cc.png)
+
+### [Color Review](https://color.review/) 
+
+Color review is fantastic if you're looking for help finding an accessible color in an existing palette. 
+
+![""](https://user-images.githubusercontent.com/40274682/88444756-90d6a100-cdd3-11ea-876c-1c850ae19223.png)


### PR DESCRIPTION
I added the WebAIM contrast checker. I think this is the defacto standard (@ericwbailey ?) and we should define our standards of measurement for color contrast.

I also added a note on tools that use color pickers as I noticed huge divergence when using the "Contrast" menubar app to WebAIM or the figma plugin.