### PR TITLE
Add Rails alpha link to Dialog design doc

### DIFF
--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -40,7 +40,7 @@ import {Caption} from '@primer/gatsby-theme-doctocat'
         width="16"
         height="16"
         alt=""
-        isrc="https://user-images.githubusercontent.com/18661030/171468311-184bfd70-128e-4bfc-b482-96d0de49d42a.png"
+        src="https://user-images.githubusercontent.com/18661030/171468311-184bfd70-128e-4bfc-b482-96d0de49d42a.png"
         style="vertical-align: middle; margin-right: 4px;"
       />
       Rails

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -29,6 +29,22 @@ import {Caption} from '@primer/gatsby-theme-doctocat'
       />
       React
     </Label>
+    <Label
+      as="a"
+      ihref="https://primer.style/view-components/components/alpha/dialog"
+      size="large"
+      variant="secondary"
+      sx={{textDecoration: 'none'}}
+    >
+      <img
+        width="16"
+        height="16"
+        alt=""
+        isrc="https://user-images.githubusercontent.com/18661030/171468311-184bfd70-128e-4bfc-b482-96d0de49d42a.png"
+        style="vertical-align: middle; margin-right: 4px;"
+      />
+      Rails
+    </Label>
     {/* <Label
       as="a"
       href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0"

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -31,7 +31,7 @@ import {Caption} from '@primer/gatsby-theme-doctocat'
     </Label>
     <Label
       as="a"
-      ihref="https://primer.style/view-components/components/alpha/dialog"
+      href="https://primer.style/view-components/components/alpha/dialog"
       size="large"
       variant="secondary"
       sx={{textDecoration: 'none'}}


### PR DESCRIPTION
Based on [this internal Slack discussion](https://github.slack.com/archives/CPA865D9S/p1663167201987339?thread_ts=1651226211.045639&cid=CPA865D9S) about the Dialog component.

Note the Rails component is in alpha but this Dialog page already has the alpha label beside the heading so that feels okay?

If there’s a misunderstanding about status here, feel free to close.