### PR TITLE
Comment box

### DIFF
--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -95,7 +95,7 @@ A label is shown above the comment box to establish the context and inform users
 
 The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. The default placeholder text is "Type here...".
 
-Note: A placeholder text is not required, but still recommended. It helps to improve usablity and make sure users know where to type.
+Note: A placeholder text is not required, but can help suggest CommentBox features specific to a component implementation, such as slash commands.
 
 <DoDontContainer>
   <Do>

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -167,7 +167,7 @@ A [flash alert](https://primer.style/design/ui-patterns/messaging#flash-alerts) 
   width="960"
 />
 
-## Responsiveness
+## Responsive behavior
 
 The comment box's toolbar uses an [action bar](https://primer.style/design/components/action-bar) under the hood that is responsive by default. Toolbar items that don't fit in the available space are moved to an [overflow menu](https://primer.style/design/components/action-bar#overflow-menu).
 

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -64,7 +64,7 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
 
 ## Anatomy
 
-<img width="960" alt="A diagram of a comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/191696249-e3fc3240-5b7f-49e5-9973-6698e705ecd6.png" />
+<img width="960" alt="A diagram of a comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/193514076-427273cc-4e81-4793-a401-9fc47b3c8dfb.png" />
 
 ## Content
 
@@ -75,7 +75,7 @@ A label is shown above the comment box to establish the context and inform users
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/191459919-0301444a-18cc-474e-8db7-1480976e4128.png"
+      src="https://user-images.githubusercontent.com/378023/193514339-81bc5e18-3aab-4e15-919f-933fb5e74ef0.png"
       role="presentation"
       width="456"
     />
@@ -83,7 +83,7 @@ A label is shown above the comment box to establish the context and inform users
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/191459943-1bc24fb4-224e-4598-94b6-f15b80401946.png"
+      src="https://user-images.githubusercontent.com/378023/193514422-54ab3bb8-238f-4852-a813-206b81449575.png"
       role="presentation"
       width="456"
     />
@@ -98,7 +98,7 @@ In most cases a placeholder text is not needed and a label alone will suffice.
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/191459984-243b1223-5029-4915-afc9-53b89e6e8ce3.png"
+      src="https://user-images.githubusercontent.com/378023/193514545-d7e7d798-7699-4aca-8e90-eb63f70494c3.png"
       role="presentation"
       width="456"
     />
@@ -106,7 +106,7 @@ In most cases a placeholder text is not needed and a label alone will suffice.
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/191460009-bc05c1ad-f47c-45cb-8e5d-aa9ac22ac215.png"
+      src="https://user-images.githubusercontent.com/378023/193514612-a0bdb034-4047-4491-affa-e3e5fc10d455.png"
       role="presentation"
       width="456"
     />
@@ -119,7 +119,7 @@ In most cases a placeholder text is not needed and a label alone will suffice.
 A tab nav is used to toggle between write and preview mode. In **write mode** the entered text is rendered as typed (plain text).
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191464893-2e6c1d21-b084-4396-a996-895f8d405bd7.png"
+  src="https://user-images.githubusercontent.com/378023/193514697-e96fdb90-15d1-4557-8216-1772698a0888.png"
   alt=""
   width="960"
 />
@@ -142,7 +142,7 @@ The toolbar provides the comment box with shortcuts to...
 - attach images and files
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191506569-91762edb-3d62-4448-919d-34c3ab04ee2d.png"
+  src="https://user-images.githubusercontent.com/378023/193514788-20ceac63-2229-41bf-ad5e-7e4cafb19bf9.png"
   alt=""
   width="960"
 />
@@ -152,7 +152,7 @@ The toolbar provides the comment box with shortcuts to...
 The input is used to write the comment. While typing it will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191506579-c95ce6c1-0efe-4fcc-b47c-f7a29eb545a0.png"
+  src="https://user-images.githubusercontent.com/378023/193514864-e0528816-7560-4fdd-b816-e076f74a9981.png"
   alt=""
   width="960"
 />
@@ -180,7 +180,7 @@ A [flash alert](https://primer.style/design/ui-patterns/messaging#flash-alerts) 
 The comment box's toolbar uses an [action bar](https://primer.style/design/components/action-bar) under the hood that is responsive by default. Toolbar items that don't fit in the available space are moved to an [overflow menu](https://primer.style/design/components/action-bar#overflow-menu).
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191652073-193a7314-89ba-49ca-8c2c-d914b7d14fc7.png"
+  src="https://user-images.githubusercontent.com/378023/193515630-0e2582b4-1141-4547-a513-6d0d7a0d9563.png"
   alt=""
   width="960"
 />
@@ -188,7 +188,7 @@ The comment box's toolbar uses an [action bar](https://primer.style/design/compo
 When the available space becomes narrow, the tab nav takes up full width and the toolbar moves to its own row underneath.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191652075-ed8d6b89-f33f-4807-a61e-78e8ad3a9ce2.png"
+  src="https://user-images.githubusercontent.com/378023/193515012-09e66b7f-39e2-406a-9560-71e1bd88ec12.png"
   alt=""
   width="960"
 />
@@ -198,7 +198,7 @@ When the available space becomes narrow, the tab nav takes up full width and the
 A typical use of the comment box is at the bottom of a timeline or inline when replying to existing comments. Most often there is a cancel and a submit button on bottom right of the comment box. Pro tips can also be shown to eductate users and help feature discovery.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191895494-bf5eff6b-044b-49f6-bf35-7f2344c0b774.png"
+  src="https://user-images.githubusercontent.com/378023/193515104-3b102575-0eeb-4a69-9203-decf5ffa024b.png"
   alt=""
   width="960"
 />
@@ -212,7 +212,7 @@ A typical use of the comment box is at the bottom of a timeline or inline when r
 | `Tab` | Moves focus between the different parts of the comment box. The order is as follows: 1. tab nav 2. toolbar 3. input. |
 
 <img
-  src="https://user-images.githubusercontent.com/378023/191671398-79f3cd98-bf0f-45ad-896c-a4c010a7cedb.png"
+  src="https://user-images.githubusercontent.com/378023/193515190-f18d784f-43c2-4d9e-87c7-7c9ba4a08069.png"
   alt=""
   width="960"
 />

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -79,7 +79,7 @@ A label is shown above the comment box to establish the context and inform users
       role="presentation"
       width="456"
     />
-    <Caption>The label can be changed depending on the context.</Caption>
+    <Caption>Use a different label depending on the context.</Caption>
   </Do>
   <Dont>
     <img
@@ -87,22 +87,22 @@ A label is shown above the comment box to establish the context and inform users
       role="presentation"
       width="456"
     />
-    <Caption>Don't use the label to notify users of any kind of state or event, like when an error occurred.</Caption>
+    <Caption>Don't hide the label. Also don't change the label to notify users of any kind of state or event, like when an error occurred.</Caption>
   </Dont>
 </DoDontContainer>
 
-### Placeholder (optional)
+### Placeholder text
 
-In most cases a placeholder text is not needed and a label alone will suffice.
+The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. The default placeholder text is "Type here..."
 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/193514545-d7e7d798-7699-4aca-8e90-eb63f70494c3.png"
+      src="https://user-images.githubusercontent.com/378023/195568002-a794f61a-e103-4350-97e7-7cb7fccb3a1e.png"
       role="presentation"
       width="456"
     />
-    <Caption>Only add a placholder text to give users additional hints.</Caption>
+    <Caption>Use a different placeholder text depending on the context.</Caption>
   </Do>
   <Dont>
     <img

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -1,0 +1,199 @@
+---
+title: Comment box
+status: Experimental
+---
+
+import {Box, Label, LabelGroup, Text} from '@primer/react'
+
+<Box sx={{fontSize: 3}} class="lead" as="p">
+  A comment box allows users to write and preview comments, format Markdown, autocomplete user names or references and attach files.
+</Box>
+
+<!-- TODO: uncomment when available
+<LabelGroup>
+  <Label
+    as="a"
+    href="https://primer.style/react/CommentBox"
+    size="large"
+    variant="secondary"
+    sx={{textDecoration: 'none'}}
+  >
+    <img
+      width="16"
+      height="16"
+      alt=""
+      src="https://user-images.githubusercontent.com/293280/123878374-ce9d4d00-d8f3-11eb-8adf-1a160292ff53.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    React
+  </Label>
+  <Label
+    as="a"
+    href=""
+    size="large"
+    variant="secondary"
+    sx={{textDecoration: 'none'}}
+  >
+    <img
+      width="16"
+      height="16"
+      alt=""
+      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    Figma
+  </Label>
+  <Label
+    as="a"
+    href="https://primer.style/view-components/components/alpha/CommentBox"
+    size="large"
+    variant="secondary"
+    sx={{textDecoration: 'none'}}
+  >
+    <img
+      width="16"
+      height="16"
+      alt=""
+      src="https://user-images.githubusercontent.com/18661030/171468311-184bfd70-128e-4bfc-b482-96d0de49d42a.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    Rails
+  </Label>
+</LabelGroup>
+-->
+
+## Anatomy
+
+<img width="960" alt="A diagram of an comment box with a label, a TabNav, an input and an ActionBar." src="https://user-images.githubusercontent.com/378023/191439493-2122cae7-c03a-4c8b-b583-1919ccb34d94.png" />
+
+## Content
+
+### Label
+
+A label is shown above the comment box to inform users what kind of text input is following. The default label is "Add a comment".
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/378023/191459919-0301444a-18cc-474e-8db7-1480976e4128.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>The label can be changed depending on the context.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/378023/191459943-1bc24fb4-224e-4598-94b6-f15b80401946.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't use the label to notify users of any kind of state or event, like when an error occurred.</Caption>
+  </Dont>
+</DoDontContainer>
+
+### Placeholder
+
+In most cases a placeholder text is not needed and the label will suffice.
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/378023/191459984-243b1223-5029-4915-afc9-53b89e6e8ce3.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Only add a placholder text to give users an additional hint.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/378023/191460009-bc05c1ad-f47c-45cb-8e5d-aa9ac22ac215.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't use a placholder text as a replacement for a label.</Caption>
+  </Dont>
+</DoDontContainer>
+
+### Tab nav
+
+The tab nav can be used to toggle between write and preview mode.
+
+#### Write mode
+
+When typing in write mode, the text is rendered as plain text.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191464893-2e6c1d21-b084-4396-a996-895f8d405bd7.png"
+  alt=""
+  width="960"
+/>
+
+#### Preview mode
+
+When toggling to the preview mode, the toolbar disappears and the text is rendered as HTML. Markdown formatting is supported as well.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191464912-fb6dcdb1-f3d7-4d0c-bfdd-e44fab9e6b57.png"
+  alt=""
+  width="960"
+/>
+
+### Toolbar
+
+The toolbar provides the comment box with shortcuts to...
+
+- format Markdown
+- @-mention users or reference issues and pull requests
+- insert saved replies
+- attach images and files
+- and more
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191506569-91762edb-3d62-4448-919d-34c3ab04ee2d.png"
+  alt=""
+  width="960"
+/>
+
+### Input
+
+After typing multiple lines, the input will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191506579-c95ce6c1-0efe-4fcc-b47c-f7a29eb545a0.png"
+  alt=""
+  width="960"
+/>
+
+## Responsiveness
+
+The comment box's toolbar uses an [action bar](https://primer.style/design/components/action-bar) under the hood that is responsive by default. Toolbar items that don't fit in the available space are moved to an [overflow menu](https://primer.style/design/components/action-bar#overflow-menu).
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191652073-193a7314-89ba-49ca-8c2c-d914b7d14fc7.png"
+  alt=""
+  width="960"
+/>
+
+When the available space becomes quite narrow, the tab nav takes up full width and the toolbar moves to its own row.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191652075-ed8d6b89-f33f-4807-a61e-78e8ad3a9ce2.png"
+  alt=""
+  width="960"
+/>
+
+## Accessibility
+
+### Keyboard navigation
+
+| Key | description |
+| -- | -- |
+| `Tab` | Moves focus between the different part of the comment box: 1. tab nav 2. toolbar 3. input. |
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191671398-79f3cd98-bf0f-45ad-896c-a4c010a7cedb.png"
+  alt=""
+  width="960"
+/>
+
+Note that tab nav and [action bar](https://primer.style/design/components/action-bar) have their own keyboard navigation.

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -157,6 +157,16 @@ The input will automatically resize to fit the content until a certain max heigh
   width="960"
 />
 
+## Messages
+
+A [flash alert](https://primer.style/design/ui-patterns/messaging#flash-alerts) is used to inform users about an event related to the comment box. Events include but are not limited to error or warning messages, uploading state or successful actions. The flash alert is shown undertneath the comment box.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191891077-fd523ae4-7bb0-495d-be15-afca2b194ac4.png"
+  alt=""
+  width="960"
+/>
+
 ## Responsiveness
 
 The comment box's toolbar uses an [action bar](https://primer.style/design/components/action-bar) under the hood that is responsive by default. Toolbar items that don't fit in the available space are moved to an [overflow menu](https://primer.style/design/components/action-bar#overflow-menu).
@@ -171,6 +181,16 @@ When the available space becomes narrow, the tab nav takes up full width and the
 
 <img
   src="https://user-images.githubusercontent.com/378023/191652075-ed8d6b89-f33f-4807-a61e-78e8ad3a9ce2.png"
+  alt=""
+  width="960"
+/>
+
+## Example usage
+
+A typical use of the comment box is at the bottom of a timeline or inline when replying to existing comments. Most often there is a cancel and a submit button on bottom right of the comment box. Pro tips can also be shown to eductate users and help feature discovery.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/191895494-bf5eff6b-044b-49f6-bf35-7f2344c0b774.png"
   alt=""
   width="960"
 />

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -157,20 +157,13 @@ The input is used to write the comment. While typing it will automatically resiz
   width="960"
 />
 
-It has the following heights:
-
-- **Min height**: 3 lines of text
-- **Default height**: 5 lines of text
-- **Max height**: `75vh`. This is 3/4 of the viewport height. Leaving 1/4 to scroll the page.
-
-Additionally the input can be configured to have a custom initial height:
+The default and minimum height is `100px`. For cases where users typically add a lot of content, like issues or pull request descriptions, the input can be configured to have an increased initial height:
 
 Option | value
 --- | ---
-`small` | 3 lines
-`medium` | 5 lines (default)
-`large` | 15 lines
-`xlarge` | 30 lines
+`small` (default) | `100px`
+`medium` | `300px` 
+`large` | `500px`
 
 ## Messages
 

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -64,7 +64,7 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
 
 ## Anatomy
 
-<img width="960" alt="A diagram of a comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/193514076-427273cc-4e81-4793-a401-9fc47b3c8dfb.png" />
+<img width="960" alt="A diagram of a comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/197092931-b5207868-036b-4858-9fad-1195b2fd7604.png" />
 
 ## Content
 
@@ -93,9 +93,7 @@ A label is shown above the comment box to establish the context and inform users
 
 ### Placeholder text (recommended)
 
-The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. The default placeholder text is "Type here...".
-
-Note: A placeholder text is not required, but can help suggest CommentBox features specific to a component implementation, such as slash commands.
+The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. A placeholder text is not required, but can help suggest CommentBox features specific to a component implementation, such as slash commands. Having a placeholder text also helps with improving usablity and making sure users know where to start typing. The default placeholder text is "Comment".
 
 <DoDontContainer>
   <Do>
@@ -152,7 +150,7 @@ The toolbar provides the comment box with shortcuts to...
 Additional toolbar items can be added based on context. They appear at the beginning of the toolbar separated with a divider.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/195733570-175c1c4d-1573-4ff5-a24a-dedcc0de9d62.png"
+  src="https://user-images.githubusercontent.com/378023/197093096-ea3a9f65-4dde-4636-a154-06b03add8788.png"
   alt=""
   width="960"
 />
@@ -190,7 +188,7 @@ A [flash alert](https://primer.style/design/ui-patterns/messaging#flash-alerts) 
 The comment box's toolbar uses an [action bar](https://primer.style/design/components/action-bar) under the hood that is responsive by default. Toolbar items that don't fit in the available space are moved to an [overflow menu](https://primer.style/design/components/action-bar#overflow-menu).
 
 <img
-  src="https://user-images.githubusercontent.com/378023/193515630-0e2582b4-1141-4547-a513-6d0d7a0d9563.png"
+  src="https://user-images.githubusercontent.com/378023/197094055-a68f5cb1-a0df-4e39-8803-32338d7829cc.png"
   alt=""
   width="960"
 />
@@ -198,17 +196,17 @@ The comment box's toolbar uses an [action bar](https://primer.style/design/compo
 When the available space becomes narrow, the tab nav takes up full width and the toolbar moves to its own row underneath.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/193515012-09e66b7f-39e2-406a-9560-71e1bd88ec12.png"
+  src="https://user-images.githubusercontent.com/378023/197094061-d073e3fe-9f82-4592-a04c-3d9bb9cb7e5e.png"
   alt=""
   width="960"
 />
 
 ## Example usage
 
-A typical use of the comment box is at the bottom of a timeline or inline when replying to existing comments. Most often there is a cancel and a submit button on bottom right of the comment box. Pro tips can also be shown to eductate users and help feature discovery.
+A typical use of the comment box is at the bottom of a timeline or inline when replying to existing comments. Most often there is a cancel and a submit button at the bottom right of the comment box. Pro tips can also be shown to eductate users and help feature discovery.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/193515104-3b102575-0eeb-4a69-9203-decf5ffa024b.png"
+  src="https://user-images.githubusercontent.com/378023/197094065-ae2cdb9f-94a7-4703-a5b7-a9f4d5b224cf.png"
   alt=""
   width="960"
 />

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -9,8 +9,24 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
   A comment box allows users to write and preview comments.
 </Box>
 
-<!-- TODO: uncomment when available
 <LabelGroup>
+  <Label
+    as="a"
+    href="https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=17091%3A66640"
+    size="large"
+    variant="secondary"
+    sx={{textDecoration: 'none'}}
+  >
+    <img
+      width="16"
+      height="16"
+      alt=""
+      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
+      style="vertical-align: middle; margin-right: 4px;"
+    />
+    Figma
+  </Label>
+  <!-- TODO: uncomment when available
   <Label
     as="a"
     href="https://primer.style/react/CommentBox"
@@ -27,22 +43,7 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
     />
     React
   </Label>
-  <Label
-    as="a"
-    href=""
-    size="large"
-    variant="secondary"
-    sx={{textDecoration: 'none'}}
-  >
-    <img
-      width="16"
-      height="16"
-      alt=""
-      src="https://user-images.githubusercontent.com/293280/123878720-80d51480-d8f4-11eb-9b10-d02a1cb606f8.png"
-      style="vertical-align: middle; margin-right: 4px;"
-    />
-    Figma
-  </Label>
+
   <Label
     as="a"
     href="https://primer.style/view-components/components/alpha/CommentBox"
@@ -59,8 +60,9 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
     />
     Rails
   </Label>
+  -->
 </LabelGroup>
--->
+
 
 ## Anatomy
 

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -26,7 +26,9 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
     />
     Figma
   </Label>
-  <!-- TODO: uncomment when available
+</LabelGroup>
+
+<!-- TODO: Add to LabelGroup when available
   <Label
     as="a"
     href="https://primer.style/react/CommentBox"
@@ -60,9 +62,7 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
     />
     Rails
   </Label>
-  -->
-</LabelGroup>
-
+-->
 
 ## Anatomy
 

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -6,7 +6,7 @@ status: Experimental
 import {Box, Label, LabelGroup, Text} from '@primer/react'
 
 <Box sx={{fontSize: 3}} class="lead" as="p">
-  A comment box allows users to write and preview comments, format Markdown, autocomplete user names or references and attach files.
+  A comment box allows users to write and preview comments.
 </Box>
 
 <!-- TODO: uncomment when available
@@ -64,13 +64,13 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
 
 ## Anatomy
 
-<img width="960" alt="A diagram of an comment box with a label, a TabNav, an input and an ActionBar." src="https://user-images.githubusercontent.com/378023/191439493-2122cae7-c03a-4c8b-b583-1919ccb34d94.png" />
+<img width="960" alt="A diagram of an comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/191696249-e3fc3240-5b7f-49e5-9973-6698e705ecd6.png" />
 
 ## Content
 
 ### Label
 
-A label is shown above the comment box to inform users what kind of text input is following. The default label is "Add a comment".
+A label is shown above the comment box to establish the context and inform users about the purpose of the text input that follows. The default label is "Add a comment".
 
 <DoDontContainer>
   <Do>
@@ -91,9 +91,9 @@ A label is shown above the comment box to inform users what kind of text input i
   </Dont>
 </DoDontContainer>
 
-### Placeholder
+### Placeholder (optional)
 
-In most cases a placeholder text is not needed and the label will suffice.
+In most cases a placeholder text is not needed and a label alone will suffice.
 
 <DoDontContainer>
   <Do>
@@ -102,7 +102,7 @@ In most cases a placeholder text is not needed and the label will suffice.
       role="presentation"
       width="456"
     />
-    <Caption>Only add a placholder text to give users an additional hint.</Caption>
+    <Caption>Only add a placholder text to give users additional hints.</Caption>
   </Do>
   <Dont>
     <img
@@ -116,11 +116,7 @@ In most cases a placeholder text is not needed and the label will suffice.
 
 ### Tab nav
 
-The tab nav can be used to toggle between write and preview mode.
-
-#### Write mode
-
-When typing in write mode, the text is rendered as plain text.
+A tab nav is used to toggle between write and preview mode. In **write mode** the entered text is rendered as typed (plain text).
 
 <img
   src="https://user-images.githubusercontent.com/378023/191464893-2e6c1d21-b084-4396-a996-895f8d405bd7.png"
@@ -128,9 +124,7 @@ When typing in write mode, the text is rendered as plain text.
   width="960"
 />
 
-#### Preview mode
-
-When toggling to the preview mode, the toolbar disappears and the text is rendered as HTML. Markdown formatting is supported as well.
+When switching to **preview mode** the toolbar disappears and the text is rendered as HTML. Markdown formatting, autolinking and other features are supported as well.
 
 <img
   src="https://user-images.githubusercontent.com/378023/191464912-fb6dcdb1-f3d7-4d0c-bfdd-e44fab9e6b57.png"
@@ -146,7 +140,6 @@ The toolbar provides the comment box with shortcuts to...
 - @-mention users or reference issues and pull requests
 - insert saved replies
 - attach images and files
-- and more
 
 <img
   src="https://user-images.githubusercontent.com/378023/191506569-91762edb-3d62-4448-919d-34c3ab04ee2d.png"
@@ -156,7 +149,7 @@ The toolbar provides the comment box with shortcuts to...
 
 ### Input
 
-After typing multiple lines, the input will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.
+The input will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.
 
 <img
   src="https://user-images.githubusercontent.com/378023/191506579-c95ce6c1-0efe-4fcc-b47c-f7a29eb545a0.png"
@@ -174,7 +167,7 @@ The comment box's toolbar uses an [action bar](https://primer.style/design/compo
   width="960"
 />
 
-When the available space becomes quite narrow, the tab nav takes up full width and the toolbar moves to its own row.
+When the available space becomes narrow, the tab nav takes up full width and the toolbar moves to its own row underneath.
 
 <img
   src="https://user-images.githubusercontent.com/378023/191652075-ed8d6b89-f33f-4807-a61e-78e8ad3a9ce2.png"
@@ -188,7 +181,7 @@ When the available space becomes quite narrow, the tab nav takes up full width a
 
 | Key | description |
 | -- | -- |
-| `Tab` | Moves focus between the different part of the comment box: 1. tab nav 2. toolbar 3. input. |
+| `Tab` | Moves focus between the different parts of the comment box. The order is as follows: 1. tab nav 2. toolbar 3. input. |
 
 <img
   src="https://user-images.githubusercontent.com/378023/191671398-79f3cd98-bf0f-45ad-896c-a4c010a7cedb.png"
@@ -196,4 +189,4 @@ When the available space becomes quite narrow, the tab nav takes up full width a
   width="960"
 />
 
-Note that tab nav and [action bar](https://primer.style/design/components/action-bar) have their own keyboard navigation.
+Note that tab nav and toolbar ([action bar](https://primer.style/design/components/action-bar#keyboard-navigation)) have their own keyboard navigation.

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -149,13 +149,28 @@ The toolbar provides the comment box with shortcuts to...
 
 ### Input
 
-The input will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.
+The input is used to write the comment. While typing it will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.
 
 <img
   src="https://user-images.githubusercontent.com/378023/191506579-c95ce6c1-0efe-4fcc-b47c-f7a29eb545a0.png"
   alt=""
   width="960"
 />
+
+It has the following heights:
+
+- **Min height**: 3 lines of text
+- **Default height**: 5 lines of text
+- **Max height**: `75vh`. This is 3/4 of the viewport height. Leaving 1/4 to scroll the page.
+
+Additionally the input can be configured to have a custom initial height:
+
+Option | value
+--- | ---
+`small` | 3 lines
+`medium` | 5 lines (default)
+`large` | 15 lines
+`xlarge` | 30 lines
 
 ## Messages
 

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -68,7 +68,7 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
 
 ## Content
 
-### Label
+### Label (required)
 
 A label is shown above the comment box to establish the context and inform users about the purpose of the text input that follows. The default label is "Add a comment".
 
@@ -87,13 +87,15 @@ A label is shown above the comment box to establish the context and inform users
       role="presentation"
       width="456"
     />
-    <Caption>Don't hide the label. Also don't change the label to notify users of any kind of state or event, like when an error occurred.</Caption>
+    <Caption>Don't hide the label. Also don't use the label to notify users of any kind of state or event, like when an error occurred.</Caption>
   </Dont>
 </DoDontContainer>
 
-### Placeholder text
+### Placeholder text (recommended)
 
-The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. The default placeholder text is "Type here..."
+The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. The default placeholder text is "Type here...".
+
+Note: A placeholder text is not required, but still recommended. It helps to improve usablity and make sure users know where to type.
 
 <DoDontContainer>
   <Do>

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -149,6 +149,14 @@ The toolbar provides the comment box with shortcuts to...
   width="960"
 />
 
+Additional toolbar items can be added based on context. They appear at the beginning of the toolbar separated with a divider.
+
+<img
+  src="https://user-images.githubusercontent.com/378023/195733570-175c1c4d-1573-4ff5-a24a-dedcc0de9d62.png"
+  alt=""
+  width="960"
+/>
+
 ### Input
 
 The input is used to write the comment. While typing it will automatically resize to fit the content until a certain max height is reached. The input can also be manually resized by dragging the handle in the bottom right corner.

--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -64,7 +64,7 @@ import {Box, Label, LabelGroup, Text} from '@primer/react'
 
 ## Anatomy
 
-<img width="960" alt="A diagram of an comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/191696249-e3fc3240-5b7f-49e5-9973-6698e705ecd6.png" />
+<img width="960" alt="A diagram of a comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/191696249-e3fc3240-5b7f-49e5-9973-6698e705ecd6.png" />
 
 ## Content
 

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -56,6 +56,22 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
+    <Link href="/design/components/comment-box" sx={{fontWeight: 'bold'}}>
+      <img
+        role="presentation"
+        src="https://user-images.githubusercontent.com/378023/191678010-124e429a-4eed-4f68-980a-a0bbf0c4f907.png"
+      />
+    </Link>
+  </div>
+  <div>
+    <Link href="/design/components/comment-box" sx={{fontWeight: 'bold'}}>
+      Comment box
+    </Link>
+    <Text as="p">
+      A comment box allows users to write and preview comments.
+    </Text>
+  </div>
+  <div>
     <Link href="/design/components/dialog" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -60,6 +60,8 @@
       url: /components/action-list
     - title: Autocomplete
       url: /components/autocomplete
+    - title: Comment box
+      url: /components/comment-box
     - title: Dialog
       url: /components/dialog
     - title: Segmented control


### PR DESCRIPTION
This adds the `CommentBox` component.

👀  [Preview](https://primer-707dc87d93-26441320.drafts.github.io/components/comment-box)

<img width="960" alt="A diagram of a comment box with a label, a tab nav, a toolbar and an input with a placeholder text." src="https://user-images.githubusercontent.com/378023/197092931-b5207868-036b-4858-9fad-1195b2fd7604.png" />

---

- [Figma source](https://www.figma.com/file/BMg5gToJrKBvJCkwM09iv0/Q3---Comment-form-explorations?node-id=207%3A2321) (for the images)
- Part of https://github.com/github/primer/issues/737
- [API](https://github.com/github/primer/pull/1289)
