### PR TITLE
Update descriptive-buttons.mdx

### DIFF
--- a/content/accessibility/descriptive-buttons.mdx
+++ b/content/accessibility/descriptive-buttons.mdx
@@ -51,7 +51,7 @@ When reviewing buttons on a page, ensure the following are true:
   </Do>
   <Dont>
     <Code className="language-html">
-      {`<button type="button">OK</button>`}
+      {`<button aria-label="button" type="button">OK</button>`}
     </Code>
     <Caption>The button has a redundant and unnecessary `aria-label` attribute.</Caption>
  </Dont>


### PR DESCRIPTION
The `Dont` section of *button aria-label* should have an aria-label attached to the element to demonstrate the caption text.