### PR TITLE
Use `fg.muted` for ActionBar icons

### DIFF
--- a/content/components/action-bar.mdx
+++ b/content/components/action-bar.mdx
@@ -68,7 +68,7 @@ Use an action bar to render multiple icon buttons in a row. Buttons can be split
 
 ## Anatomy
 
-<img width="960" alt="A diagram of an action bar with a few buttons, a divider and at the end a button that opens an overflow menu." src="https://user-images.githubusercontent.com/378023/188037013-e0c071ee-19f5-4a1c-9deb-3bc695d71cec.png" />
+<img width="960" alt="A diagram of an action bar with a few buttons, a divider and at the end a button that opens an overflow menu." src="https://user-images.githubusercontent.com/378023/193506131-be8bead4-d1ab-4c79-8ac1-054e75bac9be.png" />
 
 ## Content
 
@@ -79,7 +79,7 @@ An action bar should only contain icon buttons with the `invisible` variant (no 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/187869924-a28f1932-f2ac-41a2-8191-8ae7ac7b4c96.png"
+      src="https://user-images.githubusercontent.com/378023/193506398-6d6da18a-b70d-4cd4-b6e4-fd472a24934f.png"
       role="presentation"
       width="456"
     />
@@ -87,7 +87,7 @@ An action bar should only contain icon buttons with the `invisible` variant (no 
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/187869945-9ad1403b-5803-4f74-8059-ca2383b17c48.png"
+      src="https://user-images.githubusercontent.com/378023/193506488-44543352-f513-469e-8783-5d1cc7f44eaf.png"
       role="presentation"
       width="456"
     />
@@ -102,7 +102,7 @@ Dividers can be added to visually group related buttons.
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/187867904-7790eed2-35bd-4434-9fbe-89778a69d13f.png"
+      src="https://user-images.githubusercontent.com/378023/193506858-6542a6ba-4bac-400d-bba9-8601fbc032ed.png"
       role="presentation"
       width="456"
     />
@@ -110,7 +110,7 @@ Dividers can be added to visually group related buttons.
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/187869152-6f6fb191-bdf3-4e77-9ad5-53685190f5a3.png"
+      src="https://user-images.githubusercontent.com/378023/193506894-dc0a65a0-0f81-444a-aa8c-f3b0f74aecb5.png"
       role="presentation"
       width="456"
     />
@@ -123,7 +123,7 @@ Dividers can be added to visually group related buttons.
 When the buttons don't fit in the available space, an overflow button ("kebab" icon) is added at the end of the action bar signaling that there are more actions available. Clicking on the overflow button opens a menu with the remaining actions that didn't fit.
 
 <img
-  src="https://user-images.githubusercontent.com/378023/188367082-eb264f25-75e4-4ab3-8eb8-a32e4e3b3997.png"
+  src="https://user-images.githubusercontent.com/378023/193507064-4efe3f63-7b30-4656-8304-3dea3e3f1e03.png"
   alt=""
   width="960"
 />
@@ -157,7 +157,7 @@ Buttons in action bars are solely used for triggering actions. Consider using a 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/187873600-b77626d4-a832-4297-90bc-b0cb1060b9c1.png"
+      src="https://user-images.githubusercontent.com/378023/193506579-a665b941-5b4e-4e44-9439-cfb4e7e93ef3.png"
       role="presentation"
       width="456"
     />
@@ -165,7 +165,7 @@ Buttons in action bars are solely used for triggering actions. Consider using a 
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/187875081-42478d03-e650-414c-81c2-6d04e8e3a398.png"
+      src="https://user-images.githubusercontent.com/378023/193506649-07cb8b8b-3658-477a-b7a2-f00ad9825f26.png"
       role="presentation"
       width="456"
     />
@@ -180,7 +180,7 @@ When hovering over a button, a tooltip will appear that describes the action.
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/188030590-f1bceb3a-184a-438d-9885-db7c9ecc8c36.png"
+      src="https://user-images.githubusercontent.com/378023/193506950-1702cff8-c751-4bc2-a37a-a837d1e69320.png"
       role="presentation"
       width="456"
     />
@@ -188,7 +188,7 @@ When hovering over a button, a tooltip will appear that describes the action.
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/188030603-4bb5c238-edf4-41ed-9113-0d59649f0d5b.png"
+      src="https://user-images.githubusercontent.com/378023/193506979-07aa35d2-48f5-4b09-aa3e-c575be0e578e.png"
       role="presentation"
       width="456"
     />
@@ -203,7 +203,7 @@ When hovering over a button, a tooltip will appear that describes the action.
 Action bars can have 3 different sizes:
 
 <img
-  src="https://user-images.githubusercontent.com/378023/188034827-840e6fda-11ad-45ae-80ac-8eeae20ab618.png"
+  src="https://user-images.githubusercontent.com/378023/193507132-f3ad4632-e257-4301-bd48-0669f4347ddc.png"
   role="presentation"
   width="960"
 />
@@ -218,7 +218,7 @@ Action bars can be used inline next to other content or also full width taking u
 
 <Box as="p">
   <img
-    src="https://user-images.githubusercontent.com/378023/188048756-73d282d7-05f9-4a97-b02a-78afbb10870b.png"
+    src="https://user-images.githubusercontent.com/378023/193507204-7d2e1e10-8906-49b4-9c80-10d69fce3e92.png"
     role="presentation"
     width="960"
   />
@@ -231,7 +231,7 @@ Make sure to add extra spacing around the action bar.
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/378023/188822044-706ce900-db2c-40cf-999a-2765ba943929.png"
+      src="https://user-images.githubusercontent.com/378023/193507240-00801a0a-053b-45e3-9896-9d47150f8a99.png"
       role="presentation"
       width="456"
     />
@@ -239,7 +239,7 @@ Make sure to add extra spacing around the action bar.
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/378023/188040662-8df33335-3f24-479f-ad88-f75e2c153475.png"
+      src="https://user-images.githubusercontent.com/378023/193507276-25dbece0-ea90-4050-8333-2a7891dee8ef.png"
       role="presentation"
       width="456"
     />
@@ -280,7 +280,7 @@ An action bar has an ARIA role of [`toolbar`](https://developer.mozilla.org/en-U
     Ensure action bar buttons have a large enough touch target size (44px by 44px). The buttons should respond to hovers, clicks, and taps anywhere in the touch target area, even if it isn't directly on the control. To avoid overlapping of touch targets, additional space between each button is needed (for example a 12px gap for medium sized buttons).
   </Text>
   <img
-    src="https://user-images.githubusercontent.com/378023/189246049-03ffe20d-54b1-46b7-b059-d32dff0b4f14.png"
+    src="https://user-images.githubusercontent.com/378023/193507314-1f1cc55d-ca4e-4832-a6de-785546e079ca.png"
     role="presentation"
     width="456"
   />


### PR DESCRIPTION
This updates the `ActionBar` images. The only change is replacing `fg/default` with `fg/muted`:

Before | After
--- | ---
<img width="456" alt="before" src="https://user-images.githubusercontent.com/378023/187869924-a28f1932-f2ac-41a2-8191-8ae7ac7b4c96.png"> | <img width="456" alt="after" src="https://user-images.githubusercontent.com/378023/193506398-6d6da18a-b70d-4cd4-b6e4-fd472a24934f.png">

This is a follow-up to https://github.com/primer/design/pull/287 and based on  https://github.com/primer/design/pull/298#issuecomment-1256511049

> @vdepizzol I think icon buttons have a more subtler color other than `fg.default`?