### PR TITLE
Fix "Introduction" link at the Foundations page

### DIFF
--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -6,7 +6,7 @@ import {Box, Link, Text} from '@primer/react'
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
   <div>
-    <Link href="/design/foundations/getting-started" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/foundations/introduction" sx={{fontWeight: 'bold'}}>
       Introduction
     </Link>
     <Text as="p">Get started with the principles of Primer, standards, and recommendations for designing Github.</Text>


### PR DESCRIPTION
"getting-started" link was leading to a 404