### PR TITLE
Use indented do/don't instead of images in Foundations/content page

### DIFF
--- a/content/foundations/content.mdx
+++ b/content/foundations/content.mdx
@@ -97,101 +97,62 @@ Avoid using emojis, but when you do:
 Be friendly and helpful, and avoid jargon. Do not blame the user.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Be friendly and helpful. Example: Enter a name, Your name must be between 2 and 20 characters"
-      src="https://user-images.githubusercontent.com/10384315/125705639-f7b1633b-0292-4244-b89e-77bfc319fd5c.png"
-    />
+  <Do indented>
+    <em>Enter a name</em><br />
+    <em>Your name must be between 2 and 20 characters</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Blame the user and use jargon. Example: You forgot to add your name, Error 1234567890"
-      src="https://user-images.githubusercontent.com/10384315/125705637-46f0f425-ce56-4cf1-a270-0cba9be2a0e6.png"
-    />
+  <Dont indented>
+    <em>Error 1234567890</em><br />
+    <em>You forgot to add your name</em>
   </Dont>
 </DoDontContainer>
 
 Be specific.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Be specific. Example: Enter a credit card number"
-      src="https://user-images.githubusercontent.com/10384315/125707971-28e57b6a-c236-4aa1-afc2-dccda4dd1902.png"
-    />
+  <Do indented>
+    <em>Enter a credit card number</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Be vague. Example: Field required"
-      src="https://user-images.githubusercontent.com/10384315/125707969-a1ddcf5a-58e9-410b-81cf-a6433ace8420.png"
-    />
+  <Dont indented>
+    <em>Field required</em>
   </Dont>
 </DoDontContainer>
 
 In most cases, apologizing won't fix the problem. As a rule, do not apologize too much in any situation in the UI.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: State what has happened. Example: All checks failed"
-      src="https://user-images.githubusercontent.com/10384315/125705636-24363aa4-a064-4242-86fa-e315ca72f8ed.png"
-    />
+  <Do indented>
+    <em>All checks failed</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Do not apologize excessively in the UI. Example: Sorry, all checks failed"
-      src="https://user-images.githubusercontent.com/10384315/125705635-c1910a2e-6810-4b56-b29f-f918a4543bef.png"
-    />
+  <Dont indented>
+    <em>Sorry, all checks failed</em>
   </Dont>
 </DoDontContainer>
 
 Do not try to be funny or humorous.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Clearly state the outcome. Example: Some checks failed"
-      src="https://user-images.githubusercontent.com/10384315/125705634-aa90dfb2-afb8-4023-97f6-98682a0ac1c3.png"
-    />
+  <Do indented>
+    <em>Some checks failed</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Try to be humorous or funny. Example: Oops, some checks failed"
-      src="https://user-images.githubusercontent.com/10384315/125705633-d4b75c6d-7299-4192-b15c-88e9f9b36eac.png"
-    />
+  <Dont indented>
+    <em>Oops, some checks failed</em>
   </Dont>
 </DoDontContainer>
+
 
 ### Feedback
 
 Feedback should be clear and reassuring, using the same terms used by the UI elements that triggered it. Don't try to be funny, and avoid jargon.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Write feedback to be clear and reassuring. Example: Issue transfer in progress"
-      src="https://user-images.githubusercontent.com/10384315/125705630-b26ef02a-6110-4b58-8bce-d4a45bfc7c05.png"
-    />
-    <Caption>
-      Feedback message when transferring an issue, using the same term ("transfer") as the trigger button
-    </Caption>
+  <Do indented>
+    <em>Issue transfer in progress</em><br /><br />
+    Feedback message when transferring an issue, using the same term ("transfer") as the trigger button
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Use language in feedback that is different from its trigger. Example: Moving the issue"
-      src="https://user-images.githubusercontent.com/10384315/125705629-78c436df-76ab-4dab-9ca8-966835c4de10.png"
-    />
-    <Caption>Feedback message that uses a different term ("moving") than the trigger button</Caption>
+  <Dont indented>
+    <em>Moving the issue</em><br /><br />
+    Feedback message that uses a different term ("moving") than the trigger button
   </Dont>
 </DoDontContainer>
 
@@ -209,19 +170,15 @@ Do not include colons in form labels.
 All labels and button text should be in sentence case, and not include punctuation.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Leave out punctuation in labels and buttons. Example: Save email preferences, 1 linked pull request, 12 days ago"
-      src="https://user-images.githubusercontent.com/10384315/125705627-5396a0fc-891f-4e22-8add-ead2a1a621f1.png"
-    />
+  <Do indented>
+    <em>Save email preferences</em><br />
+    <em>1 linked pull request</em><br />
+    <em>12 days ago</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Include punctuation in labels and buttons. Example: Save email preferences., 1 Linked pull request, 12 Days ago"
-      src="https://user-images.githubusercontent.com/10384315/125705625-1ecfde99-9d8f-4566-97b3-3959e78b2c45.png"
-    />
+  <Dont indented>
+    <em>Save email preferences.</em><br />
+    <em>1 Linked pull request</em><br />
+    <em>12 Days ago</em>
   </Dont>
 </DoDontContainer>
 
@@ -233,24 +190,16 @@ All labels and button text should be in sentence case, and not include punctuati
 Action labels should start with an imperative verb that clearly indicates what to expect.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Start action labels with an imperative verb. Example: Save preferences"
-      src="https://user-images.githubusercontent.com/10384315/125705622-1b7f24d2-423a-4616-9b43-2c48e01c2ca1.png"
-    />
+  <Do indented>
+    <em>Save preferences</em>
   </Do>
 </DoDontContainer>
 
 Action labels can be shortened to only include an adjective and a noun.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Shorten action labels. Example: New issue"
-      src="https://user-images.githubusercontent.com/10384315/125705620-379acdd5-2e62-4e30-8e2d-ad2211e768b9.png"
-    />
+  <Do indented>
+    <em>New issue</em>
   </Do>
 </DoDontContainer>
 
@@ -260,38 +209,30 @@ Use “sign in” rather than “log in”.
 
 Link text should be meaningful and unique, with as few duplicated references as possible to prevent confusion. Ideally the link itself, or, alternatively, its programmatically determined context, should provide information about where the link will take you, and help users decide whether to follow the link. Examples of programmatically determined context can be aria labels, or text within the same paragraph as the link.
 
-<DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Set context and provide information that relates the link's location. Example: You can find out more about our speakers at the GitHub Universe site"
-      src="https://user-images.githubusercontent.com/10384315/125705618-334a5169-fcbd-460f-a8b6-7b05c6ed6254.png"
-    />
-    <Caption>Set the context within the paragraph.</Caption>
+<DoDontContainer stacked>
+  <Do indented>
+    <em>You can find out more about our speakers at the <a href="https://githubuniverse.com/" target="_blank">GitHub Universe site</a></em>
   </Do>
 </DoDontContainer>
 
-<DoDontContainer>
-  <Do>
+Set the context of the image link from the text within the same container.
+
+<DoDontContainer stacked>
+  <Do indented>
     <Code className="language-html">
       {`<a href="/pricing">
-   <img src="pricing.jpg" alt="">
+   <img src="pricing.png" alt="">
    Pricing information
 </a>`}
     </Code>
-    <Caption>Set the context of the image link from the text within the same container.</Caption>
   </Do>
 </DoDontContainer>
 
 Never say “here” or “click here”.
 
-<DoDontContainer>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Never say 'here' or 'click here' in links. Example: Click here to find out more about our speakers at GitHub Universe."
-      src="https://user-images.githubusercontent.com/10384315/125705617-56dc3569-b388-43af-b80a-db43e406450d.png"
-    />
+<DoDontContainer stacked>
+  <Dont indented>
+    <em>Click here to find out more about our speakers at GitHub Universe.</em>
   </Dont>
 </DoDontContainer>
 
@@ -305,19 +246,11 @@ TODO: Commas, truncation, rounding up or down. Do units have a space, KB, MB, et
 Headings, labels and buttons should not include punctuation. In most cases, exclamation marks are not appropriate — most things aren't _that_ exciting.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Remove punctuation from headings and labels. Example: No code scanning alerts found"
-      src="https://user-images.githubusercontent.com/10384315/125705616-d066fdb3-dcb2-4b88-b154-45dc4e8396f1.png"
-    />
+  <Do indented>
+    <em>No code scanning alerts found</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: In most cases don't use exclamation marks. Example: No code scanning alerts found!"
-      src="https://user-images.githubusercontent.com/10384315/125705615-b800023a-d39b-4d6f-aca2-6a5cf488938f.png"
-    />
+  <Dont indented>
+    <em>No code scanning alerts found!</em>
   </Dont>
 </DoDontContainer>
 
@@ -326,36 +259,26 @@ Headings, labels and buttons should not include punctuation. In most cases, excl
 When referring to unclickable page names and sections, write them as they appear in the interface in quotation marks.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Refer to unclickable sections as they are written in the UI and wrapped in quotes. Example: Go to the 'Email notifications settings' section."
-      src="https://user-images.githubusercontent.com/10384315/125705614-5c6c9ead-7cae-4129-b812-7eb0fd1908bd.png"
-    />
+  <Do indented>
+    <em>Go to the “Email notifications settings” section.</em>
   </Do>
 </DoDontContainer>
 
 When referring to button or link text that a user should click on, use bold text without quotation marks. Make sure all UI references match the capitalization in the interface. If you’re writing for a mobile app experience, use “tap”, instead of “click”.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Write button and links in bold. Example: Click Save with Save in bold"
-      src="https://user-images.githubusercontent.com/10384315/125705613-96de4bcf-cf6d-4c12-886e-a8ad8619d84c.png"
-    />
+  <Do indented>
+    <em>Click <strong>Save</strong></em>
   </Do>
 </DoDontContainer>
 
 When referring to a folder, use a code tag.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Write a folder name with the code tag. Example: Open the <code>docs</code> folder"
-      src="https://user-images.githubusercontent.com/10384315/125705612-77cb3dc3-5445-4440-a2c9-bbe761fdd1e3.png"
-    />
+  <Do indented>
+
+_Open the `docs` folder._
+
   </Do>
 </DoDontContainer>
 
@@ -364,31 +287,20 @@ When referring to a folder, use a code tag.
 In most instances, address the user as "you" and items "owned" by the user as "your" or "yours".
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Address the user as you. Example: Update your profile"
-      src="https://user-images.githubusercontent.com/10384315/125705611-3a5d082d-324b-415a-9c77-5aa59adde753.png"
-    />
+  <Do indented>
+    <em>Update your profile</em>
   </Do>
-  <Dont>
-    <img
-      width="420"
-      alt="Don't: Address the user or things they own with 'I' or 'my'. Example: Update my profile"
-      src="https://user-images.githubusercontent.com/10384315/125705610-58bf0f25-b63e-41db-bc35-40328653ab11.png"
-    />
+  <Dont indented>
+    <em>Update my profile</em>
   </Dont>
 </DoDontContainer>
 
 Some exceptions exist and are usually related to legal language, such as when a user needs to agree to terms, or confirm a destructive action.
 
 <DoDontContainer>
-  <Do>
-    <img
-      width="420"
-      alt="Do: Exception to address the user as I with legal terms. Example: I have read the Terms of Service, I understand, convert this issue to a discussion"
-      src="https://user-images.githubusercontent.com/10384315/125705608-aa8660aa-ec67-4fb0-a4cf-b69ef0b442aa.png"
-    />
+  <Do indented>
+    <em>I have read the Terms of Service</em><br />
+    <em>I understand, convert this issue to a discussion</em>
   </Do>
 </DoDontContainer>
 


### PR DESCRIPTION
I've done a quick translation from image-based content references to an indented [Do/Dont doctocat component](https://primer.style/doctocat/components/do-dont#indented).

This should make it easier to maintain this page as we continue to evolve this documentation.

Also, just to emphasize, all of the alternative text from the now removed images are still available in the page content.