### PR TITLE
Add dedicated The Zen of GitHub

### DIFF
--- a/content/foundations/introduction.mdx
+++ b/content/foundations/introduction.mdx
@@ -45,24 +45,3 @@ GitHub is a platform used for productivity. We aim to encourage flow, focus, and
 By providing a cohesive, inclusive, and responsive design, Primer’s goal is to remove as much friction as possible between the human and the software.
 
 Primer patterns and components aim towards accessible solutions that don’t dilute efficient UI interactions. It focuses on responsive design that doesn’t reduce desktop experiences into mobile-first solutions. Ultimately, it recognizes the need to encourage flow by providing calm and logical experiences throughout.
-
-## The zen of GitHub
-
-The [GitHub API](https://api.github.com/zen) consolidates the process and style in which GitHub makes design decisions in 14 aphorisms.
-
-More details about the zen of GitHub can be found in [@kneath](https://github.com/kneath)’s [post](https://warpspire.com/posts/taste).
-
-- Responsive is better than fast
-- It’s not fully shipped until it’s fast
-- Anything added dilutes everything else
-- Practicality beats purity
-- Approachable is better than simple
-- Mind your words, they are important
-- Speak like a human
-- Half measures are as bad as nothing at all
-- Encourage flow
-- Non-blocking is better than blocking
-- Favor focus over features
-- Avoid administrative distraction
-- Design for failure
-- Keep it logically awesome

--- a/content/foundations/the-zen-of-github.mdx
+++ b/content/foundations/the-zen-of-github.mdx
@@ -1,0 +1,27 @@
+---
+title: The Zen of GitHub
+---
+
+> “Whether you call it taste, culture, or zen, there are underlying assumptions that members of an organization rely on to resolve ambiguity in pursuit of the organization’s mission.”  
+> – [Ben Balter](https://ben.balter.com/2015/08/12/the-zen-of-github/)
+
+The [GitHub API](https://api.github.com/zen) consolidates the Zen of GitHub in its own codespace, in 14 aphorisms:
+
+- Responsive is better than fast
+- It’s not fully shipped until it’s fast
+- Anything added dilutes everything else
+- Practicality beats purity
+- Approachable is better than simple
+- Mind your words, they are important
+- Speak like a human
+- Half measures are as bad as nothing at all
+- Encourage flow
+- Non-blocking is better than blocking
+- Favor focus over features
+- Avoid administrative distraction
+- Design for failure
+- Keep it logically awesome
+
+We recommend you to read about the story behind the Zen of Github in these posts:
+- [Taste and The Zen of GitHub](https://warpspire.com/posts/taste), by [@kneath](https://github.com/kneath)
+- [The Zen of GitHub](https://ben.balter.com/2015/08/12/the-zen-of-github/), by [@benbalter](https://github.com/benbalter)

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -3,14 +3,16 @@
   children:
     - title: Introduction
       url: /foundations/introduction
+    - title: The Zen of GitHub
+      url: /foundations/the-zen-of-github
+    - title: Content
+      url: /foundations/content
     - title: Color
       url: /foundations/color
     - title: Layout
       url: /foundations/layout
     - title: Typography
       url: /foundations/typography
-    - title: Content
-      url: /foundations/content
 - title: Accessibility
   url: /accessibility
   children:


### PR DESCRIPTION
This PR moves the **Zen of GitHub** section from the Introduction page to a dedicated navigation item.

It also links two great articles from @kneath and @benbalter about it.