### PR TITLE
Dedicated Foundations/Responsive design page

### DIFF
--- a/content/foundations/introduction.mdx
+++ b/content/foundations/introduction.mdx
@@ -23,7 +23,7 @@ For more information, see [Accessibility at GitHub](/accessibility/accessibility
 
 ## Responsive design
 
-Browsers are found on devices with different shapes and sizes, so we can’t assume a desktop-only experience is enough. Supporting responsive experiences is an essential part of developing for the Web today. In fact, making sure pages work well [on most screen sizes or zoom levels](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) is an accessibility requirement as well.
+Browsers are found on devices with different shapes, sizes, display qualities, and input methods, so we can’t assume a desktop-only experience is enough. Supporting responsive experiences is an essential part of developing for the Web today. In fact, making sure pages work well [on most screen sizes or zoom levels](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) is an accessibility requirement as well.
 
 Primer plays an important role in providing reusable patterns and components that can streamline the creation of responsive-friendly and accessible designs, letting teams focus on bigger problems. GitHub projects should take advantage of these patterns so they can provide people with cohesive experiences throughout the entire platform.
 

--- a/content/foundations/introduction.mdx
+++ b/content/foundations/introduction.mdx
@@ -25,18 +25,11 @@ For more information, see [Accessibility at GitHub](/accessibility/accessibility
 
 Browsers are found on devices with different shapes and sizes, so we can’t assume a desktop-only experience is enough. Supporting responsive experiences is an essential part of developing for the Web today. In fact, making sure pages work well [on most screen sizes or zoom levels](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) is an accessibility requirement as well.
 
-Nielsen Norman Group [defines Responsive Web Design](https://www.nngroup.com/articles/responsive-web-design-definition/) as “a web development approach that creates dynamic changes to the appearance of a website, depending on the screen size and orientation of the device being used to view it”.
-
-“Adaptive design”, on the other hand, has been a term historically used to identify an approach where entirely separated fixed layouts were created to support mobile devices (MDN has good documentation [on how we got here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design#historic_website_layouts)).
-
-“Responsive design” at GitHub is inherently adaptive, in the sense that it should not only adjust layout and spacing when resizing a page, but support patterns and component variants that match the paradigms and affordances of the person’s device:
-
-- Responsive to the form factor: adapt to viewport size, and pointing device support (`fine` for desktop, or `coarse`, for touch), and to the device metaphors and affordances.
-- Responsive to the user preferences: respect browser’s default font size, reduced motion, color scheme, contrast preferences, etc.
-
 Primer plays an important role in providing reusable patterns and components that can streamline the creation of responsive-friendly and accessible designs, letting teams focus on bigger problems. GitHub projects should take advantage of these patterns so they can provide people with cohesive experiences throughout the entire platform.
 
-Primer uses the unified term “Responsive design” to discuss any design decisions related to device form factor and user preferences.
+Primer uses the term “Responsive design” to refer to design decisions that are adapted to device form factors and user preferences.
+
+For more information, see [Responsive design](/foundations/responsive-design).
 
 ## Design for efficiency
 

--- a/content/foundations/responsive-design.mdx
+++ b/content/foundations/responsive-design.mdx
@@ -27,11 +27,11 @@ To guarantee maximum compatibility, pages should adapt to the [browser’s viewp
 
 Providing support at these smaller sizes enable people with low vision to use GitHub with a browser zoom enabled, up to 400% on a 1280px wide screen. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html).
 
-To understand how to break down a page into regions for a responsive adaptation, check out [Responsive foundations](/foundations/layout#responsive-foundations) and [Responsive behavior](/foundations/layout#responsive-behavior) sections in the [Layout](/foundations/layout) page.
+To understand how to break down a page to work on smaller viewports, check out [Responsive foundations](/foundations/layout#responsive-foundations) and [Responsive behavior](/foundations/layout#responsive-behavior) sections in the [Layout](/foundations/layout) page.
 
 <!--
 
-Link to Figma Templates
+Todo: Link to Figma Templates
 
 > When designing a mobile-friendly rendering of a page, we recommend using a viewport width of **375px**, as this is the most common size among small smartphones. However, the page should still be tested and be fully functional at smaller widths for accessibility reasons, all the way to **320px**.
 
@@ -39,43 +39,52 @@ Link to Figma Templates
 
 ### Pointing device
 
+Instead of trying to infer the input mechanism from screen size, use the device characteristics through [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries) to adapt the experience accordingly.
+
+The table below shows possible device scenarios according to `pointer` and `hover` media features:
+
+&nbsp;             | `pointer: coarse`                                | `pointer: fine`
+-------------------|:------------------------------------------------:|:---------------------:
+**`hover: none`**  | Smartphones, touch screens                       | Stylus-based screens
+**`hover: hover`** | Virtual reality headsets, video-game controllers | Mouse, touch pad
+
 #### Pointer types
 - A `coarse` pointer means the primary input mechanism isn’t very accurate. A finger on a touchscreen is a coarse pointer.
+
+  - When designing for coarse/touch, make sure that the target size is large enough to be easily tapped. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
+
+  - **Minimum coarse/touch target**: 44px
+
+
 - A `fine` pointer means the primary input mechanism supports accurate control. A mouse or a stylus is a fine pointer.
 
-- **Minimum fine/mouse target**: 20px
-- **Minimum coarse/touch target**: 44px
+  - **Recommended minimum fine/mouse target**: 20px
 
-When designing for coarse/touch, make sure that the target size is large enough to be easily tapped. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
+<!--
 
-<!-- Image: an active list item with a hover state on a computer with a mouse cursor (`fine`), compared to the same item on a touch device (`coarse`). -->
+Todo: Touch-friendly strategy section.
 
-[ touch-friendly strategy ]
+Examples of touch adaptation with out-of-boudaries touch targets, when applied to Button and IconButton components, following comparison with ActionListItem, which increases its height instead.
+
+Image source:
+https://www.figma.com/file/YlBTqHTbdRwYQt0bfIHvGw/Interface-guidelines?node-id=457%3A89625
+
+-->
+
 
 #### Hover support
 
 Browsers report if the primary input mechanism can hover over elements with the `hover` media feature.
 
-[ hover strategy ]
+Devices that don’t support hovering such as smartphones and tablets may need adapted experiences so that the user can interact with the page without hovering over elements.
 
-#### Matrix of pointing device support
+Features that rely on hover such as tooltips or hovercards may not be available on these devices. Make sure the information presented is still accessible through other means, such as a direct link to a page with the information.
 
-&nbsp; | `pointer: coarse`| `pointer: fine`
----------------|------------------|-----------------
-**`hover: none`**  | Smartphones, touch screens | Stylus-based screens
-**`hover: hover`** | Virtual reality headsets, video-game controllers | Mouse, touch pad
+<!--
 
-Fine / coarse
+Todo: Do we include examples of device metaphors and afforances here as well?
 
-Hover support
-
-ActionList + Button touch target example
-
-Distance between interactive elements
-
-### Device metaphors and affordances
-
-- bottom sheet
+-->
 
 ## Responsive to the user preferences
 

--- a/content/foundations/responsive-design.mdx
+++ b/content/foundations/responsive-design.mdx
@@ -1,6 +1,6 @@
 ---
 title: Responsive design
-description: Supporting responsive experiences is an essential part of developing for the Web today. Every page and feature at GitHub needs to be responsive to the user’s device and their preferences.
+description: Supporting responsive experiences is an essential part of developing for the Web. Every page and feature at GitHub needs to adapt to the user’s device and their preferences.
 ---
 
 ## Definition
@@ -14,39 +14,56 @@ Nielsen Norman Group [defines Responsive Web Design](https://www.nngroup.com/art
 - Responsive to the form factor: adapt to viewport size, pointing device support, and to the device metaphors and affordances.
 - Responsive to the user preferences: respect browser’s default font size, reduced motion, color scheme, contrast preferences, etc.
 
-<!-- (`fine` for desktop, or `coarse`, for touch) -->
+## Responsive to the device’s form factor
 
-### Responsive to the form factor
+Designing for the web means that people can open your page from virtually any type of device. When designing for GitHub, picture our users using desktops, tablets, and smartphones, but also [custom-built tiny cyberdecks](https://www.reddit.com/r/cyberDeck/top/?t=year) and [VR headsets](https://en.wikipedia.org/wiki/Virtual_reality_headset).
 
+### Viewport size
 
-
-Users can access GitHub from a variety of devices, all with different form factors and capabilities. Browsers can be found in smartphones, laptops, and desktop computers, but also in  to tiny  GitHub needs to adapt its 
-
-, and to the context in which they are using it.
-
-A page and its content needs to work without loss of information or functionality
-
-To make sure pages remain accessible in different scenarios, pages need to be designed to support small viewports without loss of information or functionality. This includes small devices, and scenarios where a computer has browser zoom enabled.
-
-#### Viewport size
-
-Pages should adapt to the viewport size, without loss of information or functionality, starting at the following dimensions:
+To guarantee maximum compatibility, pages should adapt to the [browser’s viewport size](https://developer.mozilla.org/en-US/docs/Web/CSS/Viewport_concepts), without loss of information or functionality, starting at the following dimensions:
 
 - **Minimum viewport width**: 320px
 - **Minimum viewport height**: 256px
 
-When designing a mobile-friendly rendering of a page, we recommend using a viewport width of **375px**, as this is the most common size among small smartphones. However, the page should still be tested and be fully functional at smaller widths.
+Providing support at these smaller sizes enable people with low vision to use GitHub with a browser zoom enabled, up to 400% on a 1280px wide screen. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html).
 
-Providing support at these sizes enable people with low vision to use GitHub with a browser zoom enabled, up to 400% on a 1280px wide screen. [Read more about the Reflow accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html).
+To understand how to break down a page into regions for a responsive adaptation, check out [Responsive foundations](/foundations/layout#responsive-foundations) and [Responsive behavior](/foundations/layout#responsive-behavior) sections in the [Layout](/foundations/layout) page.
 
-#### Pointing device
+<!--
 
-Image: an active list item with a hover state on a computer with a mouse cursor (`fine`), compared to the same item on a touch device (`coarse`).
+Link to Figma Templates
+
+> When designing a mobile-friendly rendering of a page, we recommend using a viewport width of **375px**, as this is the most common size among small smartphones. However, the page should still be tested and be fully functional at smaller widths for accessibility reasons, all the way to **320px**.
+
+-->
+
+### Pointing device
+
+#### Pointer types
+- A `coarse` pointer means the primary input mechanism isn’t very accurate. A finger on a touchscreen is a coarse pointer.
+- A `fine` pointer means the primary input mechanism supports accurate control. A mouse or a stylus is a fine pointer.
+
+- **Minimum fine/mouse target**: 20px
+- **Minimum coarse/touch target**: 44px
+
+When designing for coarse/touch, make sure that the target size is large enough to be easily tapped. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
+
+<!-- Image: an active list item with a hover state on a computer with a mouse cursor (`fine`), compared to the same item on a touch device (`coarse`). -->
+
+[ touch-friendly strategy ]
+
+#### Hover support
+
+Browsers report if the primary input mechanism can hover over elements with the `hover` media feature.
+
+[ hover strategy ]
+
+#### Matrix of pointing device support
 
 &nbsp; | `pointer: coarse`| `pointer: fine`
 ---------------|------------------|-----------------
 **`hover: none`**  | Smartphones, touch screens | Stylus-based screens
-**`hover: hover`** | Virtual reality, video-game controllers | Mouse, touch pad
+**`hover: hover`** | Virtual reality headsets, video-game controllers | Mouse, touch pad
 
 Fine / coarse
 
@@ -56,9 +73,13 @@ ActionList + Button touch target example
 
 Distance between interactive elements
 
-### Responsive to the user preferences
+### Device metaphors and affordances
 
-People may set system preferences to change the way they prefer to interact with their devices. By default, GitHub must respect these preferences. Providing a way to override these preferences is recommended.
+- bottom sheet
+
+## Responsive to the user preferences
+
+People may set system preferences to change the way they prefer to interact with their devices. By default, GitHub must respect these preferences. Providing a way to override these options within the **User settings** is also recommended.
 
 On the web, these user preference media features include:
 
@@ -68,11 +89,16 @@ On the web, these user preference media features include:
 - [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
 - [`inverted-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/inverted-colors)
 
-#### Browser default font size
+### Browser default font size
 
-Users may set their operating system or browsers to use larger or smaller fonts.
+Users may set their operating system or browsers to use larger or smaller fonts. GitHub should respect these preferences, as it enables people with low vision to increase the size of the text on the page.
 
-GitHub should respect these preferences by adopting Primer’s `rem`-unit based relative sizing throughout.
+Primer design tokens are designed to support `rem` units, which are relative to the browser’s default font size. Use Primer-provided design tokens to ensure consistency across the system.
+
+To test this, change the size in the browser:
+
+- In Chrome: Go to `chrome://settings`. Under **Appearance**, change the font size.
+- In Firefox: In the menu button, select **Settings**. Under ”Language and Appearance” you can set different size. Default is `16`.
 
 ## See also
 

--- a/content/foundations/responsive-design.mdx
+++ b/content/foundations/responsive-design.mdx
@@ -1,0 +1,81 @@
+---
+title: Responsive design
+description: Supporting responsive experiences is an essential part of developing for the Web today. Every page and feature at GitHub needs to be responsive to the user’s device and their preferences.
+---
+
+## Definition
+
+Nielsen Norman Group [defines Responsive Web Design](https://www.nngroup.com/articles/responsive-web-design-definition/) as “a web development approach that creates dynamic changes to the appearance of a website, depending on the screen size and orientation of the device being used to view it”.
+
+“Adaptive design”, on the other hand, has been a term historically used to identify an approach where entirely separated fixed layouts were created to support mobile devices (MDN has good documentation [on how we got here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design#historic_website_layouts)).
+
+“Responsive design” at GitHub is inherently adaptive, in the sense that it should not only adjust layout and spacing when resizing a page, but support patterns and component variants that match the paradigms and affordances of the person’s device:
+
+- Responsive to the form factor: adapt to viewport size, pointing device support, and to the device metaphors and affordances.
+- Responsive to the user preferences: respect browser’s default font size, reduced motion, color scheme, contrast preferences, etc.
+
+<!-- (`fine` for desktop, or `coarse`, for touch) -->
+
+### Responsive to the form factor
+
+
+
+Users can access GitHub from a variety of devices, all with different form factors and capabilities. Browsers can be found in smartphones, laptops, and desktop computers, but also in  to tiny  GitHub needs to adapt its 
+
+, and to the context in which they are using it.
+
+A page and its content needs to work without loss of information or functionality
+
+To make sure pages remain accessible in different scenarios, pages need to be designed to support small viewports without loss of information or functionality. This includes small devices, and scenarios where a computer has browser zoom enabled.
+
+#### Viewport size
+
+Pages should adapt to the viewport size, without loss of information or functionality, starting at the following dimensions:
+
+- **Minimum viewport width**: 320px
+- **Minimum viewport height**: 256px
+
+When designing a mobile-friendly rendering of a page, we recommend using a viewport width of **375px**, as this is the most common size among small smartphones. However, the page should still be tested and be fully functional at smaller widths.
+
+Providing support at these sizes enable people with low vision to use GitHub with a browser zoom enabled, up to 400% on a 1280px wide screen. [Read more about the Reflow accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html).
+
+#### Pointing device
+
+Image: an active list item with a hover state on a computer with a mouse cursor (`fine`), compared to the same item on a touch device (`coarse`).
+
+&nbsp; | `pointer: coarse`| `pointer: fine`
+---------------|------------------|-----------------
+**`hover: none`**  | Smartphones, touch screens | Stylus-based screens
+**`hover: hover`** | Virtual reality, video-game controllers | Mouse, touch pad
+
+Fine / coarse
+
+Hover support
+
+ActionList + Button touch target example
+
+Distance between interactive elements
+
+### Responsive to the user preferences
+
+People may set system preferences to change the way they prefer to interact with their devices. By default, GitHub must respect these preferences. Providing a way to override these preferences is recommended.
+
+On the web, these user preference media features include:
+
+- [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+- [`prefers-contrast`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast)
+- [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+- [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+- [`inverted-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/inverted-colors)
+
+#### Browser default font size
+
+Users may set their operating system or browsers to use larger or smaller fonts.
+
+GitHub should respect these preferences by adopting Primer’s `rem`-unit based relative sizing throughout.
+
+## See also
+
+- [Viewport ranges](/foundations/layout#viewport-ranges)
+- [Responsive breakpoints](/foundations/layout#breakpoints)
+- [Responsive layout behavior](/foundations/layout#responsive-behavior)

--- a/content/foundations/responsive.mdx
+++ b/content/foundations/responsive.mdx
@@ -1,22 +1,24 @@
 ---
-title: Responsive design
+title: Responsive
 description: Supporting responsive experiences is an essential part of developing for the Web. Every page and feature at GitHub needs to adapt to the user’s device and their preferences.
 ---
 
 ## Definition
 
-Nielsen Norman Group [defines Responsive Web Design](https://www.nngroup.com/articles/responsive-web-design-definition/) as “a web development approach that creates dynamic changes to the appearance of a website, depending on the screen size and orientation of the device being used to view it”.
+[Responsive web design](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design) is the practice of building a website suitable to work on every device and every screen size, no matter how large or small, mobile or desktop. Responsive web design is an accessibility requirement, focused around providing an intuitive and gratifying experience for everyone.
 
-“Adaptive design”, on the other hand, has been a term historically used to identify an approach where entirely separated fixed layouts were created to support mobile devices (MDN has good documentation [on how we got here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design#historic_website_layouts)).
+At GitHub, being Responsive means our experiences are inherently adaptive. Interfaces should not only adjust layout and spacing when resizing a page, but work efficiently to provide an [efficient experience](/foundations/introduction#design-for-efficiency) that is tailored to match the paradigms and affordances of the person’s device:
 
-“Responsive design” at GitHub is inherently adaptive, in the sense that it should not only adjust layout and spacing when resizing a page, but support patterns and component variants that match the paradigms and affordances of the person’s device:
-
-- Responsive to the form factor: adapt to viewport size, pointing device support, and to the device metaphors and affordances.
+- Responsive to the [form factor](https://en.wikipedia.org/wiki/Form_factor_(design)): adapt to viewport size, pointing device support, and to the device metaphors, power, and affordances.
 - Responsive to the user preferences: respect browser’s default font size, reduced motion, color scheme, contrast preferences, etc.
 
 ## Responsive to the device’s form factor
 
 Designing for the web means that people can open your page from virtually any type of device. When designing for GitHub, picture our users using desktops, tablets, and smartphones, but also [custom-built tiny cyberdecks](https://www.reddit.com/r/cyberDeck/top/?t=year) and [VR headsets](https://en.wikipedia.org/wiki/Virtual_reality_headset).
+
+### Device power
+
+To ensure universal access from a global audience, GitHub experiences need to be fast and performant, even on low-powered devices and slow connections.
 
 ### Viewport size
 
@@ -39,24 +41,20 @@ Todo: Link to Figma Templates
 
 ### Pointing device
 
-Instead of trying to infer the input mechanism from screen size, use the device characteristics through [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries) to adapt the experience accordingly.
-
-The table below shows possible device scenarios according to `pointer` and `hover` media features:
+Use the device characteristics through [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries) to adapt the experience accordingly for different device scenarios. The table below shows some possible device scenarios using `pointer` and `hover` media features:
 
 &nbsp;             | `pointer: coarse`                                | `pointer: fine`
 -------------------|:------------------------------------------------:|:---------------------:
 **`hover: none`**  | Smartphones, touch screens                       | Stylus-based screens
 **`hover: hover`** | Virtual reality headsets, video-game controllers | Mouse, touch pad
 
-#### Pointer types
-- A `coarse` pointer means the primary input mechanism isn’t very accurate. A finger on a touchscreen is a coarse pointer.
+#### Minimum target
 
-  - When designing for coarse/touch, make sure that the target size is large enough to be easily tapped. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
+When designing for coarse/touch, make sure that the target size is large enough to be easily tapped. [Read more about this accessibility requirement](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
 
   - **Minimum coarse/touch target**: 44px
 
-
-- A `fine` pointer means the primary input mechanism supports accurate control. A mouse or a stylus is a fine pointer.
+For mouse or stylus, a recommended target is smaller:
 
   - **Recommended minimum fine/mouse target**: 20px
 

--- a/content/foundations/responsive.mdx
+++ b/content/foundations/responsive.mdx
@@ -9,7 +9,7 @@ description: Supporting responsive experiences is an essential part of developin
 
 At GitHub, being Responsive means our experiences are inherently adaptive. Interfaces should not only adjust layout and spacing when resizing a page, but work [efficiently](/foundations/introduction#design-for-efficiency) to provide an experience that is tailored to match the paradigms and affordances of the person’s device:
 
-- Responsive to the [form factor](https://en.wikipedia.org/wiki/Form_factor_(design)): adapt to viewport size, pointing device support, and to the device metaphors, power, and affordances.
+- Responsive to the [form factor](https://en.wikipedia.org/wiki/Form_factor_(design)): adapt to viewport size, pointing device support, and to the device metaphors, power, and [affordances](https://www.interaction-design.org/literature/topics/affordances).
 - Responsive to the user preferences: respect browser’s default font size, reduced motion, color scheme, contrast preferences, etc.
 
 ## Responsive to the device’s form factor

--- a/content/foundations/responsive.mdx
+++ b/content/foundations/responsive.mdx
@@ -18,7 +18,7 @@ Designing for the web means that people can open your page from virtually any ty
 
 ### Device power
 
-To ensure universal access from a global audience, GitHub experiences need to be fast and performant, even on low-powered devices and slow connections.
+GitHub cannot discriminate against devices and connection speeds. Experiences need to be fast and performant, even on low-powered devices and slow connections. [It’s not fully shipped until it’s fast](/foundations/zen).
 
 ### Viewport size
 

--- a/content/foundations/responsive.mdx
+++ b/content/foundations/responsive.mdx
@@ -7,7 +7,7 @@ description: Supporting responsive experiences is an essential part of developin
 
 [Responsive web design](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design) is the practice of building a website suitable to work on every device and every screen size, no matter how large or small, mobile or desktop. Responsive web design is an accessibility requirement, focused around providing an intuitive and gratifying experience for everyone.
 
-At GitHub, being Responsive means our experiences are inherently adaptive. Interfaces should not only adjust layout and spacing when resizing a page, but work efficiently to provide an [efficient experience](/foundations/introduction#design-for-efficiency) that is tailored to match the paradigms and affordances of the person’s device:
+At GitHub, being Responsive means our experiences are inherently adaptive. Interfaces should not only adjust layout and spacing when resizing a page, but work [efficiently](/foundations/introduction#design-for-efficiency) to provide an experience that is tailored to match the paradigms and affordances of the person’s device:
 
 - Responsive to the [form factor](https://en.wikipedia.org/wiki/Form_factor_(design)): adapt to viewport size, pointing device support, and to the device metaphors, power, and affordances.
 - Responsive to the user preferences: respect browser’s default font size, reduced motion, color scheme, contrast preferences, etc.

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -9,6 +9,8 @@
       url: /foundations/content
     - title: Color
       url: /foundations/color
+    - title: Responsive design
+      url: /foundations/responsive-design
     - title: Layout
       url: /foundations/layout
     - title: Typography

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -9,8 +9,8 @@
       url: /foundations/content
     - title: Color
       url: /foundations/color
-    - title: Responsive design
-      url: /foundations/responsive-design
+    - title: Responsive
+      url: /foundations/responsive
     - title: Layout
       url: /foundations/layout
     - title: Typography


### PR DESCRIPTION
This PR adds a dedicated "Responsive design" page to the Foundations section, covering Primer's [definition of responsive design](https://github.com/github/primer/blob/main/adrs/2022-04-15-responsive-design-api-guidelines.md#1-definition-of-responsive-design-at-github) as per our ADR (private link only available for hubbers).

This is a follow-up to https://github.com/primer/design/pull/305, which already considered other related foundation pages such as this one.

I'm treating this as a living doc. I left a few comments regarding areas we might continue to improve, including more specific touch strategies that are [being designed in this Figma file](https://www.figma.com/file/YlBTqHTbdRwYQt0bfIHvGw/Interface-guidelines?node-id=457%3A89625) (internal for hubbers).