### PR TITLE
Add new markdown folder for temp component docs

### DIFF
--- a/content/components/components-temp/action-bar.md
+++ b/content/components/components-temp/action-bar.md
@@ -19,37 +19,41 @@ Use an action bar to render multiple icon buttons in a row. Buttons can be split
 #### Buttons
 An action bar should only contain icon buttons with the invisible variant (no border/background).
 
-`DO` Use only invisible icon buttons in an action bar
+`DO`
 ![image](https://user-images.githubusercontent.com/586552/200722583-48b3f80e-6832-480c-a916-ae48401c3990.png)
- 
-`DON'T` Don't use other variants or components in an action bar.
+*Use only invisible icon buttons in an action bar*
+
+`DON'T`
 ![image](https://user-images.githubusercontent.com/378023/193506488-44543352-f513-469e-8783-5d1cc7f44eaf.png)
- 
+ *Don't use other variants or components in an action bar.*
+
 #### Button states
 Buttons in action bars are solely used for triggering actions. Consider using a [segmented control](~https://primer.style/design/components/segmented-control~) when a button should have a selected state.
  
-`DO` Buttons in action bars should have a hover and pressed state, and a focused state when using a keyboard to navigate.
+`DO`
 ![image](https://user-images.githubusercontent.com/586552/200724597-b4431ab8-dcca-4511-b399-4bab9775d4bb.png)
+*Buttons in action bars should have a hover and pressed state, and a focused state when using a keyboard to navigate.*
 
-`DON'T` Don't add a selected state or any other information like a notification dot or a counter.
+`DON'T` 
 ![image](https://user-images.githubusercontent.com/586552/200724641-25cfa774-0fae-4ea1-860c-529322c40e1b.png)
+*Don't add a selected state or any other information like a notification dot or a counter.*
 
 #### Dividers
 Dividers can be added to visually group related buttons.
 
-`DO` Use a divider between buttons.
+`DO`
 ![image](https://user-images.githubusercontent.com/586552/200728895-327e1144-951e-4363-ba60-658b0b524d26.png)
+*Use a divider between buttons.*
 
-`DON'T` Don’t use a divider at the beginning or end of the action bar.
+`DON'T`
 ![image](https://user-images.githubusercontent.com/586552/200728920-a13b1834-4a3e-4578-ae64-25a648ea8c64.png)
-
+*Don’t use a divider at the beginning or end of the action bar.*
 
 #### Overflow menu
 If the buttons don’t fit in the available space, an overflow button (“kebab” icon) can be added at the end of the action bar signaling that there are more actions available. Clicking on the overflow button opens a menu with the remaining actions that didn’t fit.
 
 ![image](https://user-images.githubusercontent.com/378023/193507064-4efe3f63-7b30-4656-8304-3dea3e3f1e03.png)
 
-##### Sorting
 Buttons that don’t fit are added to the top of the menu. This means that the last button in the action bar will also be the last button when inside the menu.
 
 ![image](https://user-images.githubusercontent.com/378023/188835345-0cfd3376-1658-496f-a78b-f5977aa2198c.png)
@@ -61,11 +65,13 @@ Overflow button appears when there is not enough space and resizing the action b
 #### Tooltips
 When hovering over a button, a tooltip will appear that describes the action.
  
-`DO` Describe what action will be taken when clicking on the button.
+`DO`
 ![image](https://user-images.githubusercontent.com/586552/200725003-654abdfd-b2ad-444a-aec2-5685845f6f66.png)
+*Describe what action will be taken when clicking on the button.*
 
-`DON'T` Don't use a tooltip in action bars to convey a current state.
+`DON'T`
 ![image](https://user-images.githubusercontent.com/378023/193506979-07aa35d2-48f5-4b09-aa3e-c575be0e578e.png)
+*Don't use a tooltip in action bars to convey a current state.* 
 
 #### Spacing
 - Make sure to add extra spacing around the action bar.

--- a/content/components/components-temp/action-bar.md
+++ b/content/components/components-temp/action-bar.md
@@ -31,22 +31,29 @@ An action bar should only contain icon buttons with the invisible variant (no bo
 Buttons in action bars are solely used for triggering actions. Consider using a [segmented control](~https://primer.style/design/components/segmented-control~) when a button should have a selected state.
  
 `DO`
+
 ![image](https://user-images.githubusercontent.com/586552/200724597-b4431ab8-dcca-4511-b399-4bab9775d4bb.png)
 *Buttons in action bars should have a hover and pressed state, and a focused state when using a keyboard to navigate.*
 
 `DON'T` 
+
 ![image](https://user-images.githubusercontent.com/586552/200724641-25cfa774-0fae-4ea1-860c-529322c40e1b.png)
+
 *Don't add a selected state or any other information like a notification dot or a counter.*
 
 #### Dividers
 Dividers can be added to visually group related buttons.
 
 `DO`
+
 ![image](https://user-images.githubusercontent.com/586552/200728895-327e1144-951e-4363-ba60-658b0b524d26.png)
+
 *Use a divider between buttons.*
 
 `DON'T`
+
 ![image](https://user-images.githubusercontent.com/586552/200728920-a13b1834-4a3e-4578-ae64-25a648ea8c64.png)
+
 *Don’t use a divider at the beginning or end of the action bar.*
 
 #### Overflow menu
@@ -66,11 +73,15 @@ Overflow button appears when there is not enough space and resizing the action b
 When hovering over a button, a tooltip will appear that describes the action.
  
 `DO`
+
 ![image](https://user-images.githubusercontent.com/586552/200725003-654abdfd-b2ad-444a-aec2-5685845f6f66.png)
+
 *Describe what action will be taken when clicking on the button.*
 
 `DON'T`
+
 ![image](https://user-images.githubusercontent.com/378023/193506979-07aa35d2-48f5-4b09-aa3e-c575be0e578e.png)
+
 *Don't use a tooltip in action bars to convey a current state.* 
 
 #### Spacing

--- a/content/components/components-temp/action-bar.md
+++ b/content/components/components-temp/action-bar.md
@@ -1,0 +1,62 @@
+# ActionBar
+Type: Regular
+[React](#) | [Rails](#) | [Figma](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=17042%3A65285)
+
+## Overview
+
+### Description
+An action bar contains a collection of horizontally aligned icon buttons.
+
+### Usage
+Use an action bar to render multiple icon buttons in a row. Buttons can be split into groups by adding a divider. When there is not enough space, buttons that don’t fit will be added to an overflow menu.
+
+### Anatomy
+
+#### Buttons
+- An action bar should only contain icon buttons with the invisible variant (no border/background).
+- Use only invisible icon buttons in an action bar.
+- Don’t use other variants or components in an action bar.
+
+##### Button states
+	- Buttons in action bars are solely used for triggering actions. Consider using a [segmented control](~https://primer.style/design/components/segmented-control~) when a button should have a selected state.
+	- Buttons in action bars have a hover and pressed state, and a focused state when using a keyboard to navigate.
+	- Don’t add a selected state or any other information like a notification dot or a counter.
+
+#### Dividers
+- Dividers can be added to visually group related buttons.
+- Use a divider between buttons.
+- Don’t use a divider at the beginning or end of the action bar.
+
+#### Overflow menu
+When the buttons don’t fit in the available space, an overflow button (“kebab” icon) is added at the end of the action bar signaling that there are more actions available. Clicking on the overflow button opens a menu with the remaining actions that didn’t fit.
+- Sorting
+	- Buttons that don’t fit are added to the top of the menu. This means that the last button in the action bar will also be the last button when inside the menu.
+	- Demo
+	 - Overflow button appears when there is not enough space and resizing the action bar updates the overflow menu.
+
+#### Tooltips
+- When hovering over a button, a tooltip will appear that describes the action.
+- Describe what action will be taken when clicking on the button.
+- Don’t use a tooltip in action bars to convey a current state.
+
+### Best practices
+#### Spacing
+	- Make sure to add extra spacing around the action bar.
+	- Extra padding of 8px is added when nesting an action bar in a box component.
+	- Avoid having the action bar touch something else. Even though the action bar buttons have no borders in their resting state, when hovering/pressing a button it will show a background color.
+
+### Options
+#### Size
+Action bars can have 3 different sizes:
+	- Small (28px)
+	- Medium (32px) (default)
+	- Large (40px)
+
+### Layout
+Action bars can be used inline next to other content or also full width taking up the entire space.
+
+## Related Components
+- [ActionList](~https://primer.style/design/components/action-list~)
+
+## Accessibility
+

--- a/content/components/components-temp/action-bar.md
+++ b/content/components/components-temp/action-bar.md
@@ -12,51 +12,81 @@ Use an action bar to render multiple icon buttons in a row. Buttons can be split
 
 ### Anatomy
 
-#### Buttons
-- An action bar should only contain icon buttons with the invisible variant (no border/background).
-- Use only invisible icon buttons in an action bar.
-- Don’t use other variants or components in an action bar.
-
-##### Button states
-	- Buttons in action bars are solely used for triggering actions. Consider using a [segmented control](~https://primer.style/design/components/segmented-control~) when a button should have a selected state.
-	- Buttons in action bars have a hover and pressed state, and a focused state when using a keyboard to navigate.
-	- Don’t add a selected state or any other information like a notification dot or a counter.
-
-#### Dividers
-- Dividers can be added to visually group related buttons.
-- Use a divider between buttons.
-- Don’t use a divider at the beginning or end of the action bar.
-
-#### Overflow menu
-When the buttons don’t fit in the available space, an overflow button (“kebab” icon) is added at the end of the action bar signaling that there are more actions available. Clicking on the overflow button opens a menu with the remaining actions that didn’t fit.
-- Sorting
-	- Buttons that don’t fit are added to the top of the menu. This means that the last button in the action bar will also be the last button when inside the menu.
-	- Demo
-	 - Overflow button appears when there is not enough space and resizing the action bar updates the overflow menu.
-
-#### Tooltips
-- When hovering over a button, a tooltip will appear that describes the action.
-- Describe what action will be taken when clicking on the button.
-- Don’t use a tooltip in action bars to convey a current state.
+![image](https://user-images.githubusercontent.com/586552/200724198-39defdb1-d653-469d-b875-f6f90b7d71a0.png)
 
 ### Best practices
+#### Buttons
+An action bar should only contain icon buttons with the invisible variant (no border/background).
+
+`DO` Use only invisible icon buttons in an action bar
+![image](https://user-images.githubusercontent.com/586552/200722583-48b3f80e-6832-480c-a916-ae48401c3990.png)
+ 
+`DON'T` Don't use other variants or components in an action bar.
+![image](https://user-images.githubusercontent.com/378023/193506488-44543352-f513-469e-8783-5d1cc7f44eaf.png)
+ 
+#### Button states
+Buttons in action bars are solely used for triggering actions. Consider using a [segmented control](~https://primer.style/design/components/segmented-control~) when a button should have a selected state.
+ 
+`DO` Buttons in action bars should have a hover and pressed state, and a focused state when using a keyboard to navigate.
+![image](https://user-images.githubusercontent.com/586552/200724597-b4431ab8-dcca-4511-b399-4bab9775d4bb.png)
+
+`DON'T` Don't add a selected state or any other information like a notification dot or a counter.
+![image](https://user-images.githubusercontent.com/586552/200724641-25cfa774-0fae-4ea1-860c-529322c40e1b.png)
+
+#### Dividers
+Dividers can be added to visually group related buttons.
+
+`DO` Use a divider between buttons.
+![image](https://user-images.githubusercontent.com/586552/200728895-327e1144-951e-4363-ba60-658b0b524d26.png)
+
+`DON'T` Don’t use a divider at the beginning or end of the action bar.
+![image](https://user-images.githubusercontent.com/586552/200728920-a13b1834-4a3e-4578-ae64-25a648ea8c64.png)
+
+
+#### Overflow menu
+If the buttons don’t fit in the available space, an overflow button (“kebab” icon) can be added at the end of the action bar signaling that there are more actions available. Clicking on the overflow button opens a menu with the remaining actions that didn’t fit.
+
+![image](https://user-images.githubusercontent.com/378023/193507064-4efe3f63-7b30-4656-8304-3dea3e3f1e03.png)
+
+##### Sorting
+Buttons that don’t fit are added to the top of the menu. This means that the last button in the action bar will also be the last button when inside the menu.
+
+![image](https://user-images.githubusercontent.com/378023/188835345-0cfd3376-1658-496f-a78b-f5977aa2198c.png)
+
+[.MOV DEMO](https://user-images.githubusercontent.com/378023/188359460-bc88bac8-9c69-4aea-8ce0-bc427bedc3a3.mov)
+
+Overflow button appears when there is not enough space and resizing the action bar updates the overflow menu.
+
+#### Tooltips
+When hovering over a button, a tooltip will appear that describes the action.
+ 
+`DO` Describe what action will be taken when clicking on the button.
+![image](https://user-images.githubusercontent.com/586552/200725003-654abdfd-b2ad-444a-aec2-5685845f6f66.png)
+
+`DON'T` Don't use a tooltip in action bars to convey a current state.
+![image](https://user-images.githubusercontent.com/378023/193506979-07aa35d2-48f5-4b09-aa3e-c575be0e578e.png)
+
 #### Spacing
-	- Make sure to add extra spacing around the action bar.
-	- Extra padding of 8px is added when nesting an action bar in a box component.
-	- Avoid having the action bar touch something else. Even though the action bar buttons have no borders in their resting state, when hovering/pressing a button it will show a background color.
+- Make sure to add extra spacing around the action bar.
+- 8px of extra padding is added when nesting an action bar in a box component.
+- Avoid having the action bar touch something else. Even though the action bar buttons have no borders in their resting state, when hovering/pressing a button it will show a background color.
 
 ### Options
 #### Size
+![image](https://user-images.githubusercontent.com/378023/193507132-f3ad4632-e257-4301-bd48-0669f4347ddc.png)
+
 Action bars can have 3 different sizes:
-	- Small (28px)
-	- Medium (32px) (default)
-	- Large (40px)
+- Small (28px)
+- Medium (32px) (default)
+- Large (40px)
 
-### Layout
+#### Layout
 Action bars can be used inline next to other content or also full width taking up the entire space.
+![image](https://user-images.githubusercontent.com/586552/200727326-0e20a620-5104-4fb1-87f0-541414b93a67.png)
 
-## Related Components
-- [ActionList](~https://primer.style/design/components/action-list~)
 
-## Accessibility
+## Related components
+- [Action list](~https://primer.style/design/components/action-list~)
+
+
 

--- a/content/components/components-temp/action-bar.md
+++ b/content/components/components-temp/action-bar.md
@@ -20,11 +20,15 @@ Use an action bar to render multiple icon buttons in a row. Buttons can be split
 An action bar should only contain icon buttons with the invisible variant (no border/background).
 
 `DO`
+
 ![image](https://user-images.githubusercontent.com/586552/200722583-48b3f80e-6832-480c-a916-ae48401c3990.png)
+
 *Use only invisible icon buttons in an action bar*
 
 `DON'T`
+
 ![image](https://user-images.githubusercontent.com/378023/193506488-44543352-f513-469e-8783-5d1cc7f44eaf.png)
+ 
  *Don't use other variants or components in an action bar.*
 
 #### Button states

--- a/content/components/components-temp/action-bar.md
+++ b/content/components/components-temp/action-bar.md
@@ -1,5 +1,6 @@
-# ActionBar
+# Action bar
 Type: Regular
+
 [React](#) | [Rails](#) | [Figma](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=17042%3A65285)
 
 ## Overview

--- a/content/components/components-temp/action-list.md
+++ b/content/components/components-temp/action-list.md
@@ -1,0 +1,89 @@
+# Action list
+
+**Type**: Regular
+
+[React](https://primer.style/react/ActionList) | Rails | [Figma](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=9677%3A44019
+)
+
+## Overview
+### Description
+An ActionList is a vertical list of interactive actions or options that can be activated or selected. It’s composed of items presented in a consistent single-column format, with room for icons, descriptions, side information, and other rich visuals. ActionList is the base component for many menu-type components, including ActionMenu and SelectPanel.
+
+![image](https://user-images.githubusercontent.com/293280/125994797-430b8376-30f8-4971-b476-c5186f9ef6ca.png)
+
+### Usage
+
+Action lists can have many applications:
+- They’re the foundation of menus, selection panels, and other overlay components
+- They can be applied to page sidebars for showing individual actions, handling local navigation, and displaying metadata
+
+Action lists support section dividers and headers for grouping items, and individual item dividers for added clarity. 
+
+Action lists use a mobile-friendly inset style. Their sizes are adapted on touch devices, and their single-column format should render consistently in any screen size. Items in an action list are generally interactive, and respond visually to hover, active, and focus states. Disabled and read-only items are also supported.
+
+
+### Anatomy
+An action list can be composed of:
+- Action list items
+- Item dividers
+- Section headers (subtle or filled styles)
+- Section dividers (subtle or filled styles)
+
+![image](https://user-images.githubusercontent.com/293280/125995889-12a2de9a-7e15-4638-87dd-6796a983f733.png)
+![image](https://user-images.githubusercontent.com/293280/125996049-e2af9cc7-c736-4adc-9800-a1d742b7929e.png)
+
+### Options
+
+#### Sizes
+- Action list items support three different sizes: small, medium, and large. The small size is the default and most common option. Medium sizes work well for relaxed local navigation, while large sizes can support items that need more breathing room.
+- Sizes only grow vertically. This behavior keeps the content aligned among items, and retains horizontal space for density.
+- On touch devices, the large size is used at all times to ensure usability when tapping.
+- Be cautious when mixing different sizes in the same list to avoid inconsistency.
+
+#### Leading visuals
+- Leading visuals are optional and appear at the start of an item. They can be octicons, avatars, and other custom visuals that fit a small area.
+- When listing system sections, features, or options, use leading visuals to improve the items' scannability. In user-generated objects, they can help to indicate the item's content type and status.
+- Depending on the context, displaying a leading visual may not be necessary. For example, a list of branches in a select panel may not need repeated icons if the surrounding UI provides enough hints about its content type.
+
+#### Trailing visuals, texts, and actions
+- Trailing visual and trailing text can display auxiliary information. They're placed at the right of the item, and can denote status, keyboard shortcuts, or be used to set expectations about what the action does.
+- Note these side visuals don't have dedicated interaction targets.
+- Use an [arrow-right](https://primer.style/octicons/arrow-right-16) octicon in menus to indicate the action will open more options, such as in a nested context. Use a [pencil](https://primer.style/octicons/pencil-16) octicon to indicate the item is going to be edited after clicking it.
+- Custom trailing elements are supported, such as counters, labels, and other custom visuals that may help identify the item.
+- When using a trailing text for displaying keyboard shortcuts, always confirm the characters match with the user's operating system. For example, to indicate a bold action in a Markdown toolbar, use "Ctrl+B" on Linux and Windows, and "⌘B" on Mac. [See reference for Mac keyboard glyphs](https://support.apple.com/en-us/HT201236).
+- Trailing action buttons can be used to present a secondary interaction related to the contents of the main item, such as opening a menu or dialog. They may appear when an item is hovered, and can be keyboard focused individually.
+
+#### Item dividers
+- Item dividers allow users to parse heavier amounts of information. They're placed between items and are useful in complex lists, particularly when descriptions or multi-line text is present.
+- When considering whether to use item dividers, make sure they truly make the presented information easier to parse, instead of only increasing visual clutter.
+- When using item dividers, increasing the action list item size may also help with legibility.
+
+#### Selection states
+- Action list items can be selected. Single selections are represented with a <code>[check](https://primer.style/octicons/check-16)</code> octicon, while multiple selections are represented with a checkbox component. These selection visuals are always placed at the beginning of the item.
+- When listing selectable items alongside non-selectable items in a menu, use dividers to differentiate between the item types.
+- Don't mix different types of selections in the same list.
+
+Danger items
+
+An action list item can have a special "danger" style, to be used in cases that require extra attention from the user.
+
+For destructive or irremediable actions, show a confirmation dialog for extra friction. If the action is not destructive, present the user a way to undo the action instead of asking for confirmation. [Never use a warning when you mean undo](https://alistapart.com/article/neveruseawarning/).
+
+Place danger items at the end of the list.
+
+
+### Application
+#### In overlays
+ - Action menus
+   -  Action menus are used for disambiguation, navigation, or to display secondary options. They appear when users interact with buttons, actions, or other controls.
+- Action menus with selection
+  - ActionMenu can be used for making a single selection among a small list of options. The list is usually predefined with system values, but in some cases it can include user-provided data when those are known not to grow into too many items.
+- Select panels 
+   - Select panels allow manipulating long lists of options, with filtering and other advanced interactions. They can be used for single or multi-selection.
+
+
+
+### Related Components
+- Action menu
+- Select panel
+

--- a/content/components/components-temp/action-list.md
+++ b/content/components/components-temp/action-list.md
@@ -47,6 +47,8 @@ An action list can be composed of:
 - Depending on the context, displaying a leading visual may not be necessary. For example, a list of branches in a select panel may not need repeated icons if the surrounding UI provides enough hints about its content type.
 
 ![image](https://user-images.githubusercontent.com/293280/125997571-d8b92b5e-5241-4f33-b223-825335b18f3d.png)
+
+
 *Use leading visuals to represent system sections, features, or options.*
 
 ![image](https://user-images.githubusercontent.com/293280/125997693-e0d9e379-19c1-4382-adbb-2a1882937373.png)

--- a/content/components/components-temp/action-list.md
+++ b/content/components/components-temp/action-list.md
@@ -35,6 +35,7 @@ An action list can be composed of:
 ### Options
 
 #### Sizes
+![image](https://user-images.githubusercontent.com/293280/125997468-fa064d6b-ace3-4dec-920d-178478d67ba9.png)
 - Action list items support three different sizes: small, medium, and large. The small size is the default and most common option. Medium sizes work well for relaxed local navigation, while large sizes can support items that need more breathing room.
 - Sizes only grow vertically. This behavior keeps the content aligned among items, and retains horizontal space for density.
 - On touch devices, the large size is used at all times to ensure usability when tapping.
@@ -45,6 +46,12 @@ An action list can be composed of:
 - When listing system sections, features, or options, use leading visuals to improve the items' scannability. In user-generated objects, they can help to indicate the item's content type and status.
 - Depending on the context, displaying a leading visual may not be necessary. For example, a list of branches in a select panel may not need repeated icons if the surrounding UI provides enough hints about its content type.
 
+![image](https://user-images.githubusercontent.com/293280/125997571-d8b92b5e-5241-4f33-b223-825335b18f3d.png)
+*Use leading visuals to represent system sections, features, or options.*
+
+![image](https://user-images.githubusercontent.com/293280/125997693-e0d9e379-19c1-4382-adbb-2a1882937373.png)
+*Use leading visuals in important menu items.*
+
 #### Trailing visuals, texts, and actions
 - Trailing visual and trailing text can display auxiliary information. They're placed at the right of the item, and can denote status, keyboard shortcuts, or be used to set expectations about what the action does.
 - Note these side visuals don't have dedicated interaction targets.
@@ -52,6 +59,18 @@ An action list can be composed of:
 - Custom trailing elements are supported, such as counters, labels, and other custom visuals that may help identify the item.
 - When using a trailing text for displaying keyboard shortcuts, always confirm the characters match with the user's operating system. For example, to indicate a bold action in a Markdown toolbar, use "Ctrl+B" on Linux and Windows, and "⌘B" on Mac. [See reference for Mac keyboard glyphs](https://support.apple.com/en-us/HT201236).
 - Trailing action buttons can be used to present a secondary interaction related to the contents of the main item, such as opening a menu or dialog. They may appear when an item is hovered, and can be keyboard focused individually.
+
+![image](https://user-images.githubusercontent.com/293280/125998961-24f90611-fe5f-4169-8943-eef68a6755a9.png)
+
+*A right arrow as a trailing visual indicates there are more options to choose after selecting an item.*
+
+![image](https://user-images.githubusercontent.com/293280/125999062-bc489a21-cdc6-455a-8363-b7c8c7faeb3a.png)
+
+*Trailing text with custom styling to indicate diff change.*
+
+![image](https://user-images.githubusercontent.com/18661030/193155140-ae9cca41-280b-4cc2-a0c0-1a830b12b5c9.png)
+
+*Trailing action buttons present a secondary action*
 
 #### Item dividers
 - Item dividers allow users to parse heavier amounts of information. They're placed between items and are useful in complex lists, particularly when descriptions or multi-line text is present.
@@ -63,14 +82,13 @@ An action list can be composed of:
 - When listing selectable items alongside non-selectable items in a menu, use dividers to differentiate between the item types.
 - Don't mix different types of selections in the same list.
 
-Danger items
+#### Danger items
 
 An action list item can have a special "danger" style, to be used in cases that require extra attention from the user.
 
 For destructive or irremediable actions, show a confirmation dialog for extra friction. If the action is not destructive, present the user a way to undo the action instead of asking for confirmation. [Never use a warning when you mean undo](https://alistapart.com/article/neveruseawarning/).
 
 Place danger items at the end of the list.
-
 
 ### Application
 #### In overlays

--- a/content/components/components-temp/action-list.md
+++ b/content/components/components-temp/action-list.md
@@ -30,6 +30,7 @@ An action list can be composed of:
 - Section dividers (subtle or filled styles)
 
 ![image](https://user-images.githubusercontent.com/293280/125995889-12a2de9a-7e15-4638-87dd-6796a983f733.png)
+
 ![image](https://user-images.githubusercontent.com/293280/125996049-e2af9cc7-c736-4adc-9800-a1d742b7929e.png)
 
 ### Options
@@ -47,7 +48,6 @@ An action list can be composed of:
 - Depending on the context, displaying a leading visual may not be necessary. For example, a list of branches in a select panel may not need repeated icons if the surrounding UI provides enough hints about its content type.
 
 ![image](https://user-images.githubusercontent.com/293280/125997571-d8b92b5e-5241-4f33-b223-825335b18f3d.png)
-
 
 *Use leading visuals to represent system sections, features, or options.*
 
@@ -79,10 +79,14 @@ An action list can be composed of:
 - When considering whether to use item dividers, make sure they truly make the presented information easier to parse, instead of only increasing visual clutter.
 - When using item dividers, increasing the action list item size may also help with legibility.
 
+![image](https://user-images.githubusercontent.com/293280/126000062-3fc62e04-670d-4346-b65b-57c2e70ceeb0.png)
+
 #### Selection states
 - Action list items can be selected. Single selections are represented with a <code>[check](https://primer.style/octicons/check-16)</code> octicon, while multiple selections are represented with a checkbox component. These selection visuals are always placed at the beginning of the item.
 - When listing selectable items alongside non-selectable items in a menu, use dividers to differentiate between the item types.
 - Don't mix different types of selections in the same list.
+
+![image](https://user-images.githubusercontent.com/293280/125999384-b2a322db-8ec3-4a69-a414-10050544813b.png)
 
 #### Danger items
 
@@ -94,13 +98,21 @@ Place danger items at the end of the list.
 
 ### Application
 #### In overlays
- - Action menus
+
+- Action menus
    -  Action menus are used for disambiguation, navigation, or to display secondary options. They appear when users interact with buttons, actions, or other controls.
+
+     ![image](https://user-images.githubusercontent.com/293280/123880964-95b3a700-d8f8-11eb-9775-cbaf165207ed.png)
+
 - Action menus with selection
   - ActionMenu can be used for making a single selection among a small list of options. The list is usually predefined with system values, but in some cases it can include user-provided data when those are known not to grow into too many items.
+
+   ![image](https://user-images.githubusercontent.com/293280/123881067-cdbaea00-d8f8-11eb-98e4-e57c64489308.png)
+
 - Select panels 
    - Select panels allow manipulating long lists of options, with filtering and other advanced interactions. They can be used for single or multi-selection.
 
+    ![image](https://user-images.githubusercontent.com/293280/123876997-4158f900-d8f1-11eb-85cb-461d9bbee0cb.png)
 
 
 ### Related Components

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "devDependencies": {
     "path-browserify": "^1.0.1"
   },
+  "resolutions": {
+    "sharp": "^0.31.2"
+  },
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3113,23 +3113,10 @@ application-config-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/application-config-path/-/application-config-path-0.1.0.tgz#193c5f0a86541a4c66fba1e2dc38583362ea5e8f"
   integrity sha512-lljTpVvFteShrHuKRvweZfa9o/Nc34Y8r5/1Lqh/yyKaspRT2J3fkEiSSk1YLG8ZSVyU7yHysRy9zcDDS2aH1Q==
 
-aproba@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
 arch@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
-  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -3192,11 +3179,6 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
-
-array-flatten@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-3.0.0.tgz#6428ca2ee52c7b823192ec600fa3ed2f157cd541"
-  integrity sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==
 
 array-includes@^3.1.4, array-includes@^3.1.5:
   version "3.1.5"
@@ -4192,11 +4174,6 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
-
 collapse-white-space@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
@@ -4210,7 +4187,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.3:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4234,7 +4211,7 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.6.0:
+color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
@@ -4247,13 +4224,13 @@ color2k@^1.2.4:
   resolved "https://registry.yarnpkg.com/color2k/-/color2k-1.2.5.tgz#3d8f08d213170f781fb6270424454dd3c0197b02"
   integrity sha512-G39qNMGyM/fhl8hcy1YqpfXzQ810zSGyiJAgdMFlreCI7Hpwu3Jpu4tuBM/Oxu1Bek1FwyaBbtrtdkTr4HDhLA==
 
-color@^3.1.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
-  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
   dependencies:
-    color-convert "^1.9.3"
-    color-string "^1.6.0"
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colord@^2.9.1:
   version "2.9.2"
@@ -4381,11 +4358,6 @@ confusing-browser-globals@^1.0.10:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
-
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
 constant-case@^2.0.0:
   version "2.0.0"
@@ -4866,13 +4838,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
-
 decompress-response@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
@@ -4954,11 +4919,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
-
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -4991,10 +4951,10 @@ details-element-polyfill@^2.4.0:
   resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz#e0622adef7902662faf27b4ab8acba5dc4e3a6e6"
   integrity sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g==
 
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+detect-libc@^2.0.0, detect-libc@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 detect-newline@^1.0.3:
   version "1.0.3"
@@ -7140,20 +7100,6 @@ gatsby@^3.7.2:
     xstate "^4.11.0"
     yaml-loader "^0.6.0"
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -7555,11 +7501,6 @@ has-tostringtag@^1.0.0:
   integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
     has-symbols "^1.0.2"
-
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -8198,13 +8139,6 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
-
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==
-  dependencies:
-    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
@@ -10269,11 +10203,6 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -10465,17 +10394,17 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-abi@^2.21.0:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
-  integrity sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
+node-abi@^3.3.0:
+  version "3.28.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.28.0.tgz#b0df8b317e1c4f2f323756c5fc8ffccc5bca4718"
+  integrity sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==
   dependencies:
-    semver "^5.4.1"
+    semver "^7.3.5"
 
-node-addon-api@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
-  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
 node-eta@^0.9.0:
   version "0.9.0"
@@ -10576,16 +10505,6 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1, npmlog@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
 nth-check@^1.0.1, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
@@ -10608,11 +10527,6 @@ null-loader@^4.0.1:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
-
 nwsapi@^2.0.7:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
@@ -10623,7 +10537,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -11538,22 +11452,21 @@ postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.5:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-prebuild-install@^6.0.1:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.4.tgz#ae3c0142ad611d58570b89af4986088a4937e00f"
-  integrity sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
   dependencies:
-    detect-libc "^1.0.3"
+    detect-libc "^2.0.0"
     expand-template "^2.0.3"
     github-from-package "0.0.0"
     minimist "^1.2.3"
     mkdirp-classic "^0.5.3"
     napi-build-utils "^1.0.1"
-    node-abi "^2.21.0"
-    npmlog "^4.0.1"
+    node-abi "^3.3.0"
     pump "^3.0.0"
     rc "^1.2.7"
-    simple-get "^3.0.3"
+    simple-get "^4.0.0"
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
 
@@ -12109,7 +12022,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@~2.3.6:
+readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -12803,6 +12716,13 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -12854,7 +12774,7 @@ serve-static@1.15.0:
     parseurl "~1.3.3"
     send "0.18.0"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
@@ -12886,19 +12806,17 @@ shallow-compare@^1.2.2:
   resolved "https://registry.yarnpkg.com/shallow-compare/-/shallow-compare-1.2.2.tgz#fa4794627bf455a47c4f56881d8a6132d581ffdb"
   integrity sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg==
 
-sharp@^0.27.0:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.27.2.tgz#a939775e630e88600c0b5e68f20593aea722252f"
-  integrity sha512-w3FVoONPG/x5MXCc3wsjOS+b9h3CI60qkus6EPQU4dkT0BDm0PyGhDCK6KhtfT3/vbeOMOXAKFNSw+I3QGWkMA==
+sharp@^0.27.0, sharp@^0.31.2:
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.31.2.tgz#a8411c80512027f5a452b76d599268760c4e5dfa"
+  integrity sha512-DUdNVEXgS5A97cTagSLIIp8dUZ/lZtk78iNVZgHdHbx1qnQR7JAHY0BnXnwwH39Iw+VKhO08CTYhIg0p98vQ5Q==
   dependencies:
-    array-flatten "^3.0.0"
-    color "^3.1.3"
-    detect-libc "^1.0.3"
-    node-addon-api "^3.1.0"
-    npmlog "^4.1.2"
-    prebuild-install "^6.0.1"
-    semver "^7.3.4"
-    simple-get "^4.0.0"
+    color "^4.2.3"
+    detect-libc "^2.0.1"
+    node-addon-api "^5.0.0"
+    prebuild-install "^7.1.1"
+    semver "^7.3.8"
+    simple-get "^4.0.1"
     tar-fs "^2.1.1"
     tunnel-agent "^0.6.0"
 
@@ -12955,16 +12873,7 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
-simple-get@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
-  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
-
-simple-get@^4.0.0:
+simple-get@^4.0.0, simple-get@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
   integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
@@ -13340,24 +13249,6 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -13366,6 +13257,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string.prototype.matchall@^4.0.7:
   version "4.0.7"
@@ -13452,7 +13352,7 @@ strip-ansi@6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
@@ -14871,13 +14771,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wide-align@^1.1.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
-  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
-  dependencies:
-    string-width "^1.0.2 || 2 || 3 || 4"
 
 widest-line@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
🚧 DRAFT 🚧 

Using this space to create a hidden folder for temporary component docs to live. (more info in this [EPIC](https://github.com/github/primer/issues/1066)). 

For now, I'm leaving this as plain markdown as it will likely be easier to port over to new infrastructure than Doctocat specific MDX documentation.
