### PR TITLE
Fix date and times link

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -1,6 +1,5 @@
 ---
 title: Action list
-status: Alpha
 react: https://primer.style/react/ActionList
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1927%3A0
 description:

--- a/content/components/autocomplete.mdx
+++ b/content/components/autocomplete.mdx
@@ -1,6 +1,5 @@
 ---
 title: Autocomplete
-status: Alpha
 description: Autocomplete allows users to quickly filter through a list of options and pick one or more values for a field.
 react: https://primer.style/react/Autocomplete
 rails: https://primer.style/view-components/components/beta/autocomplete

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -1,6 +1,5 @@
 ---
 title: Dialog
-status: Alpha
 description:
   A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and
   more.

--- a/content/components/segmented-control.mdx
+++ b/content/components/segmented-control.mdx
@@ -1,6 +1,5 @@
 ---
 title: Segmented control
-status: Alpha
 description:
   A segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply
   that selection.

--- a/content/components/textInputField.mdx
+++ b/content/components/textInputField.mdx
@@ -1,4 +1,0 @@
----
-title: TextInputField
-status: Alpha
----

--- a/content/components/toggle-switch.mdx
+++ b/content/components/toggle-switch.mdx
@@ -1,7 +1,6 @@
 ---
 title: Toggle switch
 description: A toggle switch is used to immediately toggle a setting on or off.
-status: Alpha
 react: https://primer.style/react/ToggleSwitch
 rails: https://primer.style/view-components/components/alpha/toggleswitch
 ---

--- a/content/components/tokens.mdx
+++ b/content/components/tokens.mdx
@@ -1,6 +1,5 @@
 ---
 title: Tokens
-status: Alpha
 react: https://primer.style/react/Token
 description: A token is a compact representation of an object, and is typically used to show a collection of related metadata.
 ---

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -1,6 +1,5 @@
 ---
 title: Dates & Times
-status: Experimental
 description: A relative time displays the time difference between the current time and the specified date-time.
 ---
 
@@ -91,10 +90,10 @@ The `micro` format shows a shorter version of the relative time. This can be use
 
 For dates which represent the start or (expected) end of a currently running task or job, it is more useful to display the elapsed time since the task began, or remaining time until the task ends. This takes the long format of `X years, X months, X days, X hours, X minutes, X seconds` or the compact format of `Xy Xm Xd Xh Xm Xs`. Any `0` values will not be displayed. For some tasks where the expected end time is further away and second precision is not needed, it may be useful to display less precise data, such as down-to-the-day, taking the format of `Xy Xm Xd`.
 
-| Precision         | Format             | Examples                              |
-| ----------------- | ------------------ | ------------------------------------- |
-| second            | Xy Xm Xd Xh Xm Xs  | `4s`, `5m 32s`, `1d 4h 32s`           |
-| day               | Xy Xm Xd           | `2y 3m`, `2y 8m 5d`, `2m 2d`, `1y 4d` |
+| Precision | Format            | Examples                              |
+| --------- | ----------------- | ------------------------------------- |
+| second    | Xy Xm Xd Xh Xm Xs | `4s`, `5m 32s`, `1d 4h 32s`           |
+| day       | Xy Xm Xd          | `2y 3m`, `2y 8m 5d`, `2m 2d`, `1y 4d` |
 
 ### Precise dates
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -49,6 +49,8 @@
   children:
     - title: Button usage
       url: /ui-patterns/button-usage
+    - title: Dates and times
+      url: /ui-patterns/dates-and-times
     - title: Empty states
       url: /ui-patterns/empty-states
     - title: Feature onboarding
@@ -102,8 +104,6 @@
       url: /components/dialog
     - title: Filter input
       url: /components/filter-input
-    - title: Relative time
-      url: /components/relative-time
     - title: Segmented control
       url: /components/segmented-control
     - title: Toggle switch


### PR DESCRIPTION
- [x] Fixed broken link to Dates and Times patterns (formerly Relative Time)
- [x] Removed empty `textInputField` file
- [x] Removed status in components other than `Experimental` as there is no way to mark PRC and PVC status separately. Working on a draft layout in Doctocat to fix that. See preview:  https://primer-7c6b3006f4-26493675.drafts.github.io/components/test