### PR TITLE
Adjust dates and times guidelines

### DIFF
--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -59,7 +59,6 @@ The relative dates can be used within a sentence, following the action that it's
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
   <div>
     <img
-      width="460"
       alt=""
       src="https://user-images.githubusercontent.com/912236/208956681-5129e245-2752-4efb-9605-9fd33d762ceb.png"
     />
@@ -67,7 +66,6 @@ The relative dates can be used within a sentence, following the action that it's
   </div>
   <div>
     <img
-      width="460"
       alt=""
       src="https://user-images.githubusercontent.com/912236/208956687-503e9f34-2e95-46d1-9333-cd9cc7238ed3.png"
     />
@@ -121,7 +119,6 @@ For dates which represent a precise date and time which the user should be aware
     <img
       src="https://user-images.githubusercontent.com/912236/208942068-7811e2bd-d7cd-4677-a655-c6588cc776c1.png"
       role="presentation"
-      width="456"
     />
     <Caption>Use precise dates for future relevant dates.</Caption>
   </Do>
@@ -129,7 +126,6 @@ For dates which represent a precise date and time which the user should be aware
     <img
       src="https://user-images.githubusercontent.com/912236/208943614-6e2645a7-b7c6-40d1-9888-b3afef12e898.png"
       role="presentation"
-      width="456"
     />
     <Caption>Don't use relative dates for future specific dates.</Caption>
   </Dont>
@@ -138,17 +134,15 @@ For dates which represent a precise date and time which the user should be aware
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/912236/208942072-9089caae-8575-4bb6-afc8-8d45326b650a.png"
+      src="https://user-images.githubusercontent.com/912236/208960479-f3a9fdbf-21b4-4612-913a-15bb8b70b8ee.png"
       role="presentation"
-      width="456"
     />
     <Caption>Use precise dates when the user needs to know the exact time of past dates.</Caption>
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/912236/208942073-7f45fd9f-4a5f-413d-8730-bca0d620940b.png"
+      src="https://user-images.githubusercontent.com/912236/208960486-6f6574d8-4e4b-486b-9765-742014d4c9bc.png"
       role="presentation"
-      width="456"
     />
     <Caption>Don't use relative dates for past specific dates.</Caption>
   </Dont>

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -99,6 +99,44 @@ For dates which represent the start or (expected) end of a currently running tas
 
 For dates which represent a precise date and time which the user should be aware of, dates should be displayed in a precise format that includes the weekday, date, month and if appropriate the hours minutes and seconds. This will take the format of `weekday, MMM D, YYYY, HH:MM:SS [AP]M`. The placement of these items may be different depending on locale.
 
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/912236/208942068-7811e2bd-d7cd-4677-a655-c6588cc776c1.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Use precise dates when the user should be aware of future specific dates.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/912236/208943614-6e2645a7-b7c6-40d1-9888-b3afef12e898.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't use relative dates for future specific dates.</Caption>
+  </Dont>
+</DoDontContainer>
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/912236/208942072-9089caae-8575-4bb6-afc8-8d45326b650a.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Use precise dates when the user needs to know the exact time of past specific dates.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/912236/208942073-7f45fd9f-4a5f-413d-8730-bca0d620940b.png"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't use relative dates for past specific dates.</Caption>
+  </Dont>
+</DoDontContainer>
+
 ## Usage
 
 A relative time can be used within a sentence, following the action that it's relative to.

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -21,14 +21,9 @@ Some dates and times represent the start or (expected) end of an actively runnin
 
 #### Past dates
 
-For past dates, the relative time component outputs different formats depending on the time difference.
-
-Within a month's time, the output shows a relative time[^1] in the format of `X seconds/minutes/hours/days ago`. If the time difference is less than 1 minute, it shows `just now`.
+For past dates, the relative time component outputs different formats depending on the time difference. Within a month's time, the output shows a relative time[^1] in the format of `X seconds/minutes/hours/days ago`. If the time difference is less than 1 minute, it shows `just now`. If the date is in past months, the date time[^2] format `on D MMM` is used. If the date is in the past years, the format `on D MMM, YYYY` is used.
 
 [^1]: Relative time data is derived from the [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) API.
-
-If the date is in past months, the date time[^2] format `on D MMM` is used. If the date is in the past years, the format `on D MMM, YYYY` is used.
-
 [^2]: Date time data is derived from the [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) API.
 
 | Time difference | Format                           | Examples                                                                                  |
@@ -48,11 +43,7 @@ If the date is in past months, the date time[^2] format `on D MMM` is used. If t
 
 #### Future dates
 
-Future dates also use different formats depending on the time difference.
-
-If the future date is due to happen within the a month's time, the relative time outputs the format of `in X seconds/minutes/hours/days`. If the time difference is less than 1 minute, it shows `just now`.
-
-If the date is in the following months, the format `on D MMM` is used. If the date is in the next year or further, the format `on D MMM, YYYY` is used.
+Future dates also use different formats depending on the time difference. If the future date is due to happen within the a month's time, the relative time outputs the format of `in X seconds/minutes/hours/days`. If the time difference is less than 1 minute, it shows `just now`. If the date is in the following months, the format `on D MMM` is used. If the date is in the next year or further, the format `on D MMM, YYYY` is used.
 
 | Time difference | Format                                | Examples                                                                            |
 | --------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
@@ -86,7 +77,7 @@ The relative dates can be used within a sentence, following the action that it's
 
 #### Links
 
-The relative dates are used as plain text in most cases. However, it can be used as an anchor link to point to an element that contains relevant or nested information. For example, as a link to a comment in a conversation.
+The relative dates are used as plain text in most cases. However, they can be used as an anchor link to point to an element that contains relevant or nested information. For example, as a link to a comment in a conversation.
 
 <img
   width="960"

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -75,7 +75,7 @@ The relative dates can be used within a sentence, following the action that it's
 
 #### Links
 
-The relative dates are used as plain text in most cases. However, they can be used as an anchor link to point to an element that contains relevant or nested information. For example, as a link to a comment in a conversation.
+The relative dates are used as plain text in most cases. However, they can be used to point to a list of historical changes, a timeline, or as an anchor link for nested information in a view. For example, a date could be used to link to a comment in a conversation thread.
 
 <img
   width="960"
@@ -114,14 +114,14 @@ For dates that needs to represent a precise date and time which the user should 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/912236/209102810-71be5fdb-8ba6-4004-89f2-6ed64d1fdb40.png"
+      src="https://user-images.githubusercontent.com/912236/209115253-82ea4a79-62a2-494b-9367-1f31786ba99c.png"
       role="presentation"
     />
     <Caption>Use precise dates for future relevant dates.</Caption>
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/912236/209102811-f726b4ab-233d-458b-9117-84824976f5d8.png"
+      src="https://user-images.githubusercontent.com/912236/209115031-e493457c-f62b-454a-ab52-4ec62b17ce11.png"
       role="presentation"
     />
     <Caption>Don't use relative dates for future specific dates.</Caption>
@@ -131,14 +131,14 @@ For dates that needs to represent a precise date and time which the user should 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/912236/208960479-f3a9fdbf-21b4-4612-913a-15bb8b70b8ee.png"
+      src="https://user-images.githubusercontent.com/912236/209114717-1019f9f1-d0ae-4342-8ae3-849eda5dd835.png"
       role="presentation"
     />
     <Caption>Use precise dates when the user needs to know the exact time of past dates.</Caption>
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/912236/208960486-6f6574d8-4e4b-486b-9765-742014d4c9bc.png"
+      src="https://user-images.githubusercontent.com/912236/209114722-6eedf092-49b2-4c61-8657-1a462710ebee.png"
       role="presentation"
     />
     <Caption>Don't use relative dates for past specific dates.</Caption>
@@ -153,6 +153,16 @@ For dates which represent the start or (expected) end of a currently running tas
 | --------- | ----------------- | ------------------------------------- |
 | second    | Xy Xm Xd Xh Xm Xs | `4s`, `5m 32s`, `1d 4h 32s`           |
 | day       | Xy Xm Xd          | `2y 3m`, `2y 8m 5d`, `2m 2d`, `1y 4d` |
+
+<div>
+  <img
+    alt=""
+    src="https://user-images.githubusercontent.com/912236/209115404-1100b345-da19-4d17-b42b-b78c2619cec9.png"
+  />
+  <Caption>
+    Use elapsed dates to represent the real-time duration of a single or multiple tasks at the same time.
+  </Caption>
+</div>
 
 ## Accessibility
 

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -132,7 +132,7 @@ For dates which represent a precise date and time which the user should be aware
       role="presentation"
       width="456"
     />
-    <Caption>Use precise dates when the user should be aware of future specific dates.</Caption>
+    <Caption>Use precise dates for future relevant dates.</Caption>
   </Do>
   <Dont>
     <img
@@ -151,7 +151,7 @@ For dates which represent a precise date and time which the user should be aware
       role="presentation"
       width="456"
     />
-    <Caption>Use precise dates when the user needs to know the exact time of past specific dates.</Caption>
+    <Caption>Use precise dates when the user needs to know the exact time of past dates.</Caption>
   </Do>
   <Dont>
     <img

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -166,4 +166,4 @@ For dates which represent the start or (expected) end of a currently running tas
 
 ## Accessibility
 
-The relative date are treated like a [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) element. It contains a [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) showing the precise localised date.
+A relative date is treated like a [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) element. It contains a [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) showing the precise localised date.

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -159,9 +159,7 @@ For dates which represent the start or (expected) end of a currently running tas
     alt=""
     src="https://user-images.githubusercontent.com/912236/209115404-1100b345-da19-4d17-b42b-b78c2619cec9.png"
   />
-  <Caption>
-    Use elapsed dates to represent the real-time duration of a single or multiple tasks at the same time.
-  </Caption>
+  <Caption>Use elapsed dates to represent the duration of a single or multiple running tasks.</Caption>
 </div>
 
 ## Accessibility

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -9,13 +9,17 @@ import {Box} from '@primer/react'
 
 All dates and times displayed should use the relative time component, which is able to format and localise dates into the users given locale, as well as display times relative to the current date, while also updating in real-time.
 
-Dates and times almost always appear relative to the current date, using short-hand formats to help users quickly determine how old something is or how soon something will be. For this, we use Relative Time which displays dates rounded to the nearest unit, for example, "a minute ago" or "20 days ago". For dates that are more than 1 month from the current date, it can be more useful to display the date-time, as these items are less "current" and more "historical".
+Dates and times almost always appear [relative](#relative-dates) to the current date, using short-hand formats to help users quickly determine how old something is or how soon something will be. For this, we use the relative time component which displays dates rounded to the nearest unit, for example, "a minute ago" or "20 days ago". For dates that are more than 1 month from the current date, it can be more useful to display the date-time, as these items are less "current" and more "historical".
 
-Some dates and times represent the start or (expected) end of an actively running task, for these the elapsed or remaining time should be displayed, as this information is more useful than when a task started. This format should display all units that are greater than zero, for example, "2 minutes, 24 seconds" or "8 hours, 15 seconds". For ephemeral tasks where timing needs to be quickly consumed, or where a lot of times may be displayed together, a compact time notation can be used, for example, "2m 24s" or "8h 15s".
+Some dates are especially sensitive and always should be displayed in a [precise](#precise-dates) date-time format, such as the creation or expiration of certificates and keys. When a user needs to take action before a particular time (such as an expiry date) then the precise date time should be displayed. These should display the weekday, the date, the month, and the year (if the year is not the current year), for example, "Thursday, 26 August 2021" or "Saturday, 31 December 2022".
 
-Some dates are especially sensitive and always should be displayed in a precise date-time format, such as the creation or expiration of certificates and keys. When a user needs to take action before a particular time (such as an expiry date) then the precise date time should be displayed. These should display the weekday, the date, the month, and the year (if the year is not the current year), for example, "Thursday, 26 August 2021" or "Saturday, 31 December 2022".
+Some dates and times represent the start or (expected) end of an actively running task, for these the [elapsed or remaining](#elapsed-or-remaining-dates) time should be displayed, as this information is more useful than when a task started. This format should display all units that are greater than zero, for example, "2 minutes, 24 seconds" or "8 hours, 15 seconds". For ephemeral tasks where timing needs to be quickly consumed, or where a lot of times may be displayed together, a compact time notation can be used, for example, "2m 24s" or "8h 15s".
 
-### Past dates
+## Usage
+
+### Relative dates
+
+#### Past dates
 
 For past dates, the relative time component outputs different formats depending on the time difference.
 
@@ -42,7 +46,7 @@ If the date is in past months, the date time[^2] format `on D MMM` is used. If t
   />
 </p>
 
-### Future dates
+#### Future dates
 
 Future dates also use different formats depending on the time difference.
 
@@ -57,17 +61,48 @@ If the date is in the following months, the format `on D MMM` is used. If the da
 | > 1 month       | on D MMM                              | `on 18 Nov`                                                                         |
 | Next year       | on D MMM, YYYY                        | `on 26 Aug, 2021`                                                                   |
 
-### Micro format
+#### Standalone
 
-The `micro` format shows a shorter version of the relative time. This can be used in cases where it's useful to display the relative time in a more compact space or in a mobile environment. For both past and future dates, the output shows the relative time in the format of `Xs/h/d`. If the date is in the following or past months, the format `D MMM` is used. If the date is in the following or past years, the format `D MMM, YYYY` is used.
+The relative dates can be used within a sentence, following the action that it's relative to, or as an independent elements when the content and the surrounding elements make it clear what the time is related to.
 
-| Time difference   | Format      | Examples                              |
-| ----------------- | ----------- | ------------------------------------- |
-| < 1 month         | Xs/h/d      | `1s`, `20s`, `5m`, `40m`, `1d`, `20d` |
-| > 1 month         | D MMM       | `18 Nov`                              |
-| Past or next year | D MMM, YYYY | `26 Aug, 2021`                        |
+<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
+  <div>
+    <img
+      width="460"
+      alt=""
+      src="https://user-images.githubusercontent.com/912236/208956681-5129e245-2752-4efb-9605-9fd33d762ceb.png"
+    />
+    <Caption>Use standalone relative dates on items where its title references the action.</Caption>
+  </div>
+  <div>
+    <img
+      width="460"
+      alt=""
+      src="https://user-images.githubusercontent.com/912236/208956687-503e9f34-2e95-46d1-9333-cd9cc7238ed3.png"
+    />
+    <Caption>Use standalone relative dates a timeline item where the section title references the action.</Caption>
+  </div>
+</Box>
 
-<DoDontContainer>
+#### Links
+
+The relative dates are used as plain text in most cases. However, it can be used as an anchor link to point to an element that contains relevant or nested information. For example, as a link to a comment in a conversation.
+
+<img
+  width="960"
+  alt="A relative time as a link to a comment in a conversation."
+  src="https://user-images.githubusercontent.com/912236/208957419-46174cce-00c1-4d18-8551-62c7a89c8148.png"
+/>
+
+#### Responsive design and micro format
+
+Relative dates must remain readable and accessible in different screen sizes. We encourage to avoid using the `micro` formats on mobile enviroments or narrow spaces, as it can be difficult for users to understand, browser translation is not supported, and causes issues with assistive technologies. For example some screen readers (such as VoiceOver for mac) will read out `1m` as `1 meter`.
+
+<!-- Micro format should only be used when there's a prominent space constraint, such as in a timeline or a list of items. -->
+<!-- However, if you need to use it, make sure that the content and the surrounding elements make it clear what the time is related to. -->
+<!-- WIP Do's and don'ts (avoid microformat or narrow formats on mobile) -->
+
+<!-- <DoDontContainer>
   <Do>
     <img
       src="https://user-images.githubusercontent.com/912236/191981619-4b2a5625-aa28-44d4-a650-fcda9f349b6f.png"
@@ -84,16 +119,7 @@ The `micro` format shows a shorter version of the relative time. This can be use
     />
     <Caption>Don't use the micro format when there's a prominent space. Use the default option instead.</Caption>
   </Dont>
-</DoDontContainer>
-
-### Elapsed or remaining dates
-
-For dates which represent the start or (expected) end of a currently running task or job, it is more useful to display the elapsed time since the task began, or remaining time until the task ends. This takes the long format of `X years, X months, X days, X hours, X minutes, X seconds` or the compact format of `Xy Xm Xd Xh Xm Xs`. Any `0` values will not be displayed. For some tasks where the expected end time is further away and second precision is not needed, it may be useful to display less precise data, such as down-to-the-day, taking the format of `Xy Xm Xd`.
-
-| Precision | Format            | Examples                              |
-| --------- | ----------------- | ------------------------------------- |
-| second    | Xy Xm Xd Xh Xm Xs | `4s`, `5m 32s`, `1d 4h 32s`           |
-| day       | Xy Xm Xd          | `2y 3m`, `2y 8m 5d`, `2m 2d`, `1y 4d` |
+</DoDontContainer> -->
 
 ### Precise dates
 
@@ -137,59 +163,15 @@ For dates which represent a precise date and time which the user should be aware
   </Dont>
 </DoDontContainer>
 
-## Usage
+### Elapsed or remaining dates
 
-A relative time can be used within a sentence, following the action that it's relative to.
+For dates which represent the start or (expected) end of a currently running task or job, it is more useful to display the elapsed time since the task began, or remaining time until the task ends. This takes the long format of `X years, X months, X days, X hours, X minutes, X seconds` or the compact format of `Xy Xm Xd Xh Xm Xs`. Any `0` values will not be displayed. For some tasks where the expected end time is further away and second precision is not needed, it may be useful to display less precise data, such as down-to-the-day, taking the format of `Xy Xm Xd`.
 
-<img
-  width="960"
-  alt=""
-  src="https://user-images.githubusercontent.com/912236/191977760-bccc2197-6ecb-4487-9c5d-0d3732cc7f9e.png"
-/>
-
-### Standalone
-
-A relative time can be used as an independent element when the content and the surrounding elements make it clear what the time is related to.
-
-<Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={5}>
-  <div>
-    <img
-      width="460"
-      alt=""
-      src="https://user-images.githubusercontent.com/912236/191997579-7a5be204-91ed-4163-97fc-18cd6e82a0c7.png"
-    />
-    <Caption>Use it in a list item where each item title references the action that was performed.</Caption>
-  </div>
-  <div>
-    <img
-      width="460"
-      alt=""
-      src="https://user-images.githubusercontent.com/912236/191965093-80c1858f-5d36-4caf-aecf-fd333c2c104c.png"
-    />
-    <Caption>Use it in a timeline item where the section title references the action.</Caption>
-  </div>
-</Box>
-
-#### Responsive design
-
-When used as standalone element, the default format can change to `micro` to fit in a narrow area.
-
-<CustomVideoPlayer
-  width="100%"
-  loop
-  src="https://user-images.githubusercontent.com/912236/192255353-88749767-f1d1-49af-8145-86b60f5215b8.mp4"
-/>
-
-### Links
-
-A relative time is used as plain text in most cases. However, it can be used as an anchor link to point to an element within a view that contains relevant or nested information. For example, as a link to a comment in a conversation.
-
-<img
-  width="960"
-  alt="A relative time as a link to a comment in a conversation."
-  src="https://user-images.githubusercontent.com/912236/192507200-d764ff4e-2fae-4f72-b179-be39b41b7210.png"
-/>
+| Precision | Format            | Examples                              |
+| --------- | ----------------- | ------------------------------------- |
+| second    | Xy Xm Xd Xh Xm Xs | `4s`, `5m 32s`, `1d 4h 32s`           |
+| day       | Xy Xm Xd          | `2y 3m`, `2y 8m 5d`, `2m 2d`, `1y 4d` |
 
 ## Accessibility
 
-A relative time is treated like a [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) element. It contains a [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) showing the precise localised date.
+The relative date are treated like a [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) element. It contains a [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) showing the precise localised date.

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -38,7 +38,7 @@ If the date is in past months, the date time[^2] format `on D MMM` is used. If t
   <img
     width="960"
     alt="Relative time examples"
-    src="https://user-images.githubusercontent.com/912236/192233477-8c30b28b-5f48-44c6-b373-39a482f745a1.png"
+    src="https://user-images.githubusercontent.com/912236/208934714-3bd0763c-c4b9-4df4-89ea-47332beca61d.png"
   />
 </p>
 

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -85,46 +85,43 @@ The relative dates are used as plain text in most cases. However, they can be us
 
 #### Responsive design and micro format
 
-Relative dates must remain readable and accessible in different screen sizes. We encourage to avoid using the `micro` formats on mobile enviroments or narrow spaces, as it can be difficult for users to understand, browser translation is not supported, and causes issues with assistive technologies. For example some screen readers (such as VoiceOver for mac) will read out `1m` as `1 meter`.
-
-<!-- Micro format should only be used when there's a prominent space constraint, such as in a timeline or a list of items. -->
-<!-- However, if you need to use it, make sure that the content and the surrounding elements make it clear what the time is related to. -->
-<!-- WIP Do's and don'ts (avoid microformat or narrow formats on mobile) -->
-
-<!-- <DoDontContainer>
-  <Do>
-    <img
-      src="https://user-images.githubusercontent.com/912236/191981619-4b2a5625-aa28-44d4-a650-fcda9f349b6f.png"
-      role="presentation"
-      width="456"
-    />
-    <Caption>Use the micro format to display time in a more compact space or in a mobile environment.</Caption>
-  </Do>
-  <Dont>
-    <img
-      src="https://user-images.githubusercontent.com/912236/191997424-821afe8a-39d9-47c4-9203-ebaee182f3b1.png"
-      role="presentation"
-      width="456"
-    />
-    <Caption>Don't use the micro format when there's a prominent space. Use the default option instead.</Caption>
-  </Dont>
-</DoDontContainer> -->
-
-### Precise dates
-
-For dates which represent a precise date and time which the user should be aware of, dates should be displayed in a precise format that includes the weekday, date, month and if appropriate the hours minutes and seconds. This will take the format of `weekday, MMM D, YYYY, HH:MM:SS [AP]M`. The placement of these items may be different depending on locale.
+Relative dates must remain readable and accessible in different screen sizes. We encourage to use long date formats (e.g. `2 months ago`) instead of the `micro` format (e.g. `2mo`) on mobile screens or narrow spaces, as it can be difficult for users to understand, it doesn't support browser translation, and causes issues with assistive technologies. For example, some screen readers, such as VoiceOver for mac, will read out `1m` as `1 meter`.
 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/912236/208942068-7811e2bd-d7cd-4677-a655-c6588cc776c1.png"
+      src="https://user-images.githubusercontent.com/912236/209098128-37111f46-3b53-4201-82d3-be5721effe5a.png"
+      role="presentation"
+    />
+    <Caption>Use readable, long date formats, and adapt the layout to the available space.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/912236/209098133-3452047c-4931-4460-bb3b-d4b9d9e51fb4.png"
+      role="presentation"
+    />
+    <Caption>
+      Don't use narrow date formats, specially if there's a prominent space available or the layout can be adapted to
+      the screen size.
+    </Caption>
+  </Dont>
+</DoDontContainer>
+
+### Precise dates
+
+For dates that needs to represent a precise date and time which the user should be aware of, dates should be displayed in a precise format that includes the weekday, date, month and if appropriate the hours minutes and seconds. This will take the format of `weekday, MMM D, YYYY, HH:MM:SS [AP]M`. The placement of these items may be different depending on locale.
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/912236/209102810-71be5fdb-8ba6-4004-89f2-6ed64d1fdb40.png"
       role="presentation"
     />
     <Caption>Use precise dates for future relevant dates.</Caption>
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/912236/208943614-6e2645a7-b7c6-40d1-9888-b3afef12e898.png"
+      src="https://user-images.githubusercontent.com/912236/209102811-f726b4ab-233d-458b-9117-84824976f5d8.png"
       role="presentation"
     />
     <Caption>Don't use relative dates for future specific dates.</Caption>

--- a/content/ui-patterns/dates-and-times.mdx
+++ b/content/ui-patterns/dates-and-times.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dates & Times
-description: A relative time displays the time difference between the current time and the specified date-time.
+description: These guidelines summarize how to display time in a way that is clear, concise, and accessible.
 ---
 
 import {Box} from '@primer/react'


### PR DESCRIPTION
Improve dates and times guidelines according to the latest changes of the [relative-time-element](https://github.com/github/relative-time-element), aligning to the three main behaviors that we use to format dates: `relative`, `precise`, and `elapsed/duration`.

Among others, this change affects `micro` usage. This format causes accessibility issues with assistive technologies and native browser translation, and we recommend using a relative, long format instead.

<img width="851" alt="Screenshot 2022-12-22 at 14 20 59" src="https://user-images.githubusercontent.com/912236/209143099-1893e4d5-d562-462b-b3be-ee98f7cdda2b.png">

More info: https://github.com/github/relative-time-element/issues/220 

cc: @keithamus 