### PR TITLE
Introduce markdownlinting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Lint
 on: [push]
 jobs:
-  all:
+  eslint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -10,7 +10,16 @@ jobs:
           version: 14
       - name: install
         run: yarn
-      - name: lint
+      - name: Lint with ESLint
         run: yarn lint
-      - name: markdownlint
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          version: 14
+      - name: install
+        run: yarn
+      - name: Lint with markdownlint
         run: yarn markdownlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,5 @@ jobs:
         run: yarn
       - name: lint
         run: yarn lint
+      - name: markdownlint
+        run: yarn markdownlint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     # SHA for security hardening. Points at last verified HEAD of main branch.
     uses: primer/.github/.github/workflows/deploy.yml@0cec9b9914f358846163f2428663b58da41028c9
     with:
-      node_version: 12
+      node_version: 14
       install: yarn
       build: yarn build
       output_dir: public

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -17,7 +17,7 @@ jobs:
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
-      node_version: 12
+      node_version: 14
       install: yarn
       build: yarn build:preview
       output_dir: public

--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,0 +1,21 @@
+const githubMarkdownOpinions = require('@github/markdownlint-github')
+
+const options = githubMarkdownOpinions.init({
+  'line-length': false,
+  'blanks-around-headings': false,
+  'no-hard-tabs': false,
+  'no-trailing-spaces': false,
+  'no-multiple-blanks': false,
+  'ul-style': false,
+  'ul-indent': false,
+  'blanks-around-lists': false,
+  'no-trailing-punctuation': false,
+  'no-space-in-code': false,
+  'single-trailing-newline': false,
+  'link-image-reference-definitions': false // flaky
+})
+
+module.exports = {
+  config: options,
+  customRules: ["@github/markdownlint-github"],
+}

--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,18 +1,16 @@
 const githubMarkdownOpinions = require('@github/markdownlint-github')
 
 const options = githubMarkdownOpinions.init({
+  // Disable rules we don't currently care to enforce.
   'line-length': false,
   'blanks-around-headings': false,
-  'no-hard-tabs': false,
+  'blanks-around-lists': false,
   'no-trailing-spaces': false,
   'no-multiple-blanks': false,
-  'ul-style': false,
-  'ul-indent': false,
-  'blanks-around-lists': false,
   'no-trailing-punctuation': false,
-  'no-space-in-code': false,
   'single-trailing-newline': false,
-  'link-image-reference-definitions': false // flaky
+  'ul-indent': false,
+  'no-hard-tabs': false
 })
 
 module.exports = {

--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,7 +1,7 @@
 const githubMarkdownOpinions = require('@github/markdownlint-github')
 
 const options = githubMarkdownOpinions.init({
-  // Disable rules we don't currently care to enforce.
+  // Disable rules we don't currently care to enforce pertaining to stylistic things.
   'line-length': false,
   'blanks-around-headings': false,
   'blanks-around-lists': false,

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,0 @@
-node_modules

--- a/content/components/component-documentation-guidelines/component-documentation-guidelines.md
+++ b/content/components/component-documentation-guidelines/component-documentation-guidelines.md
@@ -19,7 +19,7 @@ When documenting components, consider the core elements needed to convey its mai
 
 See our full [documentation guidelines here](https://primer.style/contribute/documentation/). 
 
-#### Types of components 
+### Types of components 
 - **Regular**: Standard components used to build Primer UI. See [ActionList](https://primer.style/design/components/action-list).
 - **Internal**: Components used by other components that do not exist on their own. See [Overlay](https://primer.style/react/Overlay).
 - **Behavioral**: Components with no real anatomy or structure, rather behaviors. See [Truncate](https://primer.style/react/Truncate).

--- a/content/components/data-table.mdx
+++ b/content/components/data-table.mdx
@@ -164,7 +164,7 @@ These factors make it difficult to recommend an “ideal” page size for all us
 
 #### Communicate when the table has no data to show
 
-Show a [Blankslate]() component in place of the table
+Show a `Blankslate` component in place of the table
 
 #### Consider small screens
 

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -32,7 +32,7 @@ For example use `bg-default` for the background of the page and `fg-default` for
   src="https://user-images.githubusercontent.com/813754/187436947-875dbf46-1b26-42da-b96f-e7cbe315f0eb.png"
 />
 
-#### Color design tokens are grouped based on their purpose:
+### Color design tokens are grouped based on their purpose:
 
 - **Presentational:** To represent a color. For example, the color steps in the Primer scale are named by color and lightness, such as `scale.blue.5`. These design tokens don't support color modes.
 - **Functional:** To convey a meaning or a state. For example, from a functional perspective the color green is used to reinforce positive messaging. In a functional system, green design tokens are named with the suffix `.success`.

--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -74,21 +74,21 @@ Foreground elements are **text and icons**. You can apply color to them by using
 
 | Foundations                                                                       | Usage                                                                                                                                |
 | :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.default) `fg.default`       | Primary color for text and icons in any given interface. It should be used for body content, titles and labels.                      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.muted) `fg.muted`           | Use for content that is secondary or that provides additional context but is not critical to understanding the flow of an interface. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`         | Use for placeholder text, icons or decorative foregrounds.                                                                           |
-| ![](https://swatch-sid.vercel.app?mode=light&token=fg.onEmphasis) `fg.onEmphasis` | On emphasis is the text color designed to combine with `.emphasis` backgrounds for optimal contrast.                                 |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=fg.default) `fg.default`       | Primary color for text and icons in any given interface. It should be used for body content, titles and labels.                      |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=fg.muted) `fg.muted`           | Use for content that is secondary or that provides additional context but is not critical to understanding the flow of an interface. |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=fg.subtle) `fg.subtle`         | Use for placeholder text, icons or decorative foregrounds.                                                                           |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=fg.onEmphasis) `fg.onEmphasis` | On emphasis is the text color designed to combine with `.emphasis` backgrounds for optimal contrast.                                 |
 
 | Color roles                                                                     | Usage                                                               |
 | :------------------------------------------------------------------------------ | :------------------------------------------------------------------ |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.fg) `fg.accent`       | Use for interactive text or icons like links or buttons.            |
-| ![](https://swatch-sid.vercel.app?mode=light&token=success.fg) `fg.success`     | Use to emphasize a positive message.                                |
-| ![](https://swatch-sid.vercel.app?mode=light&token=attention.fg) `fg.attention` | Use to highlight text or icons that require the user's attention.   |
-| ![](https://swatch-sid.vercel.app?mode=light&token=danger.fg) `fg.danger`       | Use to emphasize an error or a blocking status. Action is required. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=severe.fg) `fg.severe`       | Use to emphasize a level of severity between attention and danger.  |
-| ![](https://swatch-sid.vercel.app?mode=light&token=open.fg) `fg.open`           | Use to style text that refers to open tasks or workflows.           |
-| ![](https://swatch-sid.vercel.app?mode=light&token=closed.fg) `fg.closed`       | Use to style text that refers to closed tasks or workflows.         |
-| ![](https://swatch-sid.vercel.app?mode=light&token=done.fg) `fg.done`           | Use to style text that refers to completed tasks or workflows.      |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=accent.fg) `fg.accent`       | Use for interactive text or icons like links or buttons.            |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=success.fg) `fg.success`     | Use to emphasize a positive message.                                |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=attention.fg) `fg.attention` | Use to highlight text or icons that require the user's attention.   |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=danger.fg) `fg.danger`       | Use to emphasize an error or a blocking status. Action is required. |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=severe.fg) `fg.severe`       | Use to emphasize a level of severity between attention and danger.  |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=open.fg) `fg.open`           | Use to style text that refers to open tasks or workflows.           |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=closed.fg) `fg.closed`       | Use to style text that refers to closed tasks or workflows.         |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=done.fg) `fg.done`           | Use to style text that refers to completed tasks or workflows.      |
 
 ### Backgrounds
 
@@ -96,22 +96,22 @@ Background colors apply to surfaces of components or UI elements, such as pages,
 
 | Foundations                                                                            | Usage                                                                                                              |
 | :------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=neutral.emphasisPlus) `bg.emphasis` | Provides the highest contrast against the default background, such as in tooltips.                                 |
-| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.default) `bg.default`        | Primary background color.                                                                                          |
-| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.subtle) `bg.subtle`          | Provides visual rest and contrast against the default background.                                                  |
-| ![](https://swatch-sid.vercel.app?mode=light&token=canvas.inset) `bg.inset`            | Can be used instead of the default background to create a focal point, such as in conversations or activity feeds. |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=neutral.emphasisPlus) `bg.emphasis` | Provides the highest contrast against the default background, such as in tooltips.                                 |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=canvas.default) `bg.default`        | Primary background color.                                                                                          |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=canvas.subtle) `bg.subtle`          | Provides visual rest and contrast against the default background.                                                  |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=canvas.inset) `bg.inset`            | Can be used instead of the default background to create a focal point, such as in conversations or activity feeds. |
 
 | Color roles                                                                                      | Usage                                                                          |
 | :----------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.subtle) `bg.accent`                    | Use to accentuate interactive areas in the UI like selected elements.          |
-| ![](https://swatch-sid.vercel.app?mode=light&token=success.subtle) `bg.success`                  | Use to highlight a positive message.                                           |
-| ![](https://swatch-sid.vercel.app?mode=light&token=attention.subtle) `bg.attention`              | Use to highlight elements that require a user's attention or pending statuses. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=danger.subtle) `bg.danger`                    | Use to emphasize an error or a blocking status, where action is required.      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=severe.subtle) `bg.severe`                    | Use to emphasize an extra level of severity between attention and danger.      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=open.subtle) `bg.open`                        | Use to style text that refers to open tasks or workflows.                      |
-| ![](https://swatch-sid.vercel.app?mode=light&token=closed.subtle) `bg.closed`                    | Use to style text that refers to closed tasks or workflows.                    |
-| ![](https://swatch-sid.vercel.app?mode=light&token=done.subtle) `bg.done`                        | Use to style text that refers to completed tasks or workflows.                 |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `bg.[ANY_OF_ABOVE].emphasis` | Use to highlight the most important item of a view or an interface.            |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=accent.subtle) `bg.accent`                    | Use to accentuate interactive areas in the UI like selected elements.          |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=success.subtle) `bg.success`                  | Use to highlight a positive message.                                           |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=attention.subtle) `bg.attention`              | Use to highlight elements that require a user's attention or pending statuses. |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=danger.subtle) `bg.danger`                    | Use to emphasize an error or a blocking status, where action is required.      |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=severe.subtle) `bg.severe`                    | Use to emphasize an extra level of severity between attention and danger.      |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=open.subtle) `bg.open`                        | Use to style text that refers to open tasks or workflows.                      |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=closed.subtle) `bg.closed`                    | Use to style text that refers to closed tasks or workflows.                    |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=done.subtle) `bg.done`                        | Use to style text that refers to completed tasks or workflows.                 |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `bg.[ANY_OF_ABOVE].emphasis` | Use to highlight the most important item of a view or an interface.            |
 
 ### Borders
 
@@ -119,20 +119,20 @@ Borders can be used to group content or to create a visible separation between s
 
 | Foundations                                                                         | Usage                                                                                                                                 |
 | :---------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| ![](https://swatch-sid.vercel.app?mode=light&token=border.default) `border.default` | Use to create bounds around content, for example elements inside a card. Default borders are critical to understanding a page layout. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=border.muted) `border.muted`     | Use for dividers to emphasize the separation between items, columns or sections.                                                      |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=border.default) `border.default` | Use to create bounds around content, for example elements inside a card. Default borders are critical to understanding a page layout. |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=border.muted) `border.muted`     | Use for dividers to emphasize the separation between items, columns or sections.                                                      |
 
 | Color roles                                                                                  | Usage                                                                         |
 | :------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.muted) `border.accent`             | Use to accentuate interactive areas in the UI like selected elements.         |
-| ![](https://swatch-sid.vercel.app?mode=light&token=success.muted) `border.success`           | Use to highlight a positive message.                                          |
-| ![](https://swatch-sid.vercel.app?mode=light&token=attention.muted) `border.attention`       | Use to highlight elements that require a users attention or pending statuses. |
-| ![](https://swatch-sid.vercel.app?mode=light&token=danger.muted) `border.danger`             | Use to emphasize an error or a blocking status. Action is required.           |
-| ![](https://swatch-sid.vercel.app?mode=light&token=severe.muted) `border.severe`             | Use to emphasize an extra level of severity between attention and danger.     |
-| ![](https://swatch-sid.vercel.app?mode=light&token=open.muted) `border.open`                 | Use to style text that refers to open tasks or workflows.                     |
-| ![](https://swatch-sid.vercel.app?mode=light&token=closed.muted) `border.closed`             | Use to style text that refers to closed tasks or workflows.                   |
-| ![](https://swatch-sid.vercel.app?mode=light&token=done.muted) `border.done`                 | Use to style text that refers to completed tasks or workflows.                |
-| ![](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `border.[ROLE].emphasis` | Use to highlight the most important item of a view or an interface.           |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=accent.muted) `border.accent`             | Use to accentuate interactive areas in the UI like selected elements.         |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=success.muted) `border.success`           | Use to highlight a positive message.                                          |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=attention.muted) `border.attention`       | Use to highlight elements that require a users attention or pending statuses. |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=danger.muted) `border.danger`             | Use to emphasize an error or a blocking status. Action is required.           |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=severe.muted) `border.severe`             | Use to emphasize an extra level of severity between attention and danger.     |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=open.muted) `border.open`                 | Use to style text that refers to open tasks or workflows.                     |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=closed.muted) `border.closed`             | Use to style text that refers to closed tasks or workflows.                   |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=done.muted) `border.done`                 | Use to style text that refers to completed tasks or workflows.                |
+| ![""](https://swatch-sid.vercel.app?mode=light&token=accent.emphasis) `border.[ROLE].emphasis` | Use to highlight the most important item of a view or an interface.           |
 
 ## Functional system in action
 

--- a/content/foundations/typography.mdx
+++ b/content/foundations/typography.mdx
@@ -29,19 +29,19 @@ We utilize system fonts at GitHub, which allow for optimized performance. This d
 
 **System Fonts**—default GitHub font-stack with ample fallbacks alongside emoji support
 
-```
+```css
 font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 ```
 
 **Monospace**—used within GitHub product to display metadata or captions, and used in marketing contexts as subheaders
 
-```
+```css
 $mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;
 ```
 
 **Display face**—the font stack that implements Inter UI
 
-```
+```css
 font-family: InterUI, -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", Oxygen, Ubuntu, Cantarell, "Open Sans", sans-serif;
 ```
 

--- a/content/ui-patterns/button-usage.mdx
+++ b/content/ui-patterns/button-usage.mdx
@@ -116,13 +116,13 @@ Buttons that only use an icon should still have a label that is invisible to sig
 
 Counters can be added in appropriate scenarios to provide context. For example, showing social proof by displaying the number of people watching a repo.
 
-#### Counter inside button
+### Counter inside button
 
 A count can be displayed inside of a button using a [CounterLabel](https://primer.style/react/CounterLabel).
 
 ![button with count inside](https://user-images.githubusercontent.com/2313998/129626580-465111c8-9237-4e33-af42-b2e830ea9cc3.png)
 
-#### Counter attached to a button
+### Counter attached to a button
 
 A count can be displayed as a separate element that is attached to a button. Only display a count as separate element that is attached to a button when the button uses the "small" size variant and the button type is "Default" or "Outline".
 

--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -29,7 +29,7 @@ Blankslates can and are encouraged to use one primary action. This button should
 
 ### Secondary action
 
-Secondary actions are optional and are represented by a text link located below the primary action button. A secondary action is used to direct a user to additional content about the feature. This might look like "[Learn more about X](#)" or "[Check out the guide on X](#)".
+Secondary actions are optional and are represented by a text link located below the primary action button. A secondary action is used to direct a user to additional content about the feature. This might look like `Learn more about X` or "`Check out the guide on X`.
 
 ### Border
 

--- a/content/ui-patterns/empty-states.mdx
+++ b/content/ui-patterns/empty-states.mdx
@@ -29,7 +29,7 @@ Blankslates can and are encouraged to use one primary action. This button should
 
 ### Secondary action
 
-Secondary actions are optional and are represented by a text link located below the primary action button. A secondary action is used to direct a user to additional content about the feature. This might look like "[Learn more about X](#)" or "[Check out the guide on X](#)" or simply "[Learn more](#)".
+Secondary actions are optional and are represented by a text link located below the primary action button. A secondary action is used to direct a user to additional content about the feature. This might look like "[Learn more about X](#)" or "[Check out the guide on X](#)".
 
 ### Border
 

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -133,7 +133,7 @@ Treat feature onboarding as a story or a journey with a beginning, middle, and e
 
 A teaching bubble is a [popover](https://primer.style/css/components/popover) that calls attention to a feature in a specific part of the page. Generally, teaching bubbles should be used to educate the user and enrich the task at hand.
 
-### Usage guidelines
+### Usage guidelines for teaching bubble
 
 Teaching bubble Figma [sticker sheet](https://www.figma.com/file/Y2xJLFBrU7yyiDLlEkQXcF/Primer-Interfaces?node-id=2%3A1295&t=2xX6FwLSJ0Cq9Qkp-1).
 

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -313,7 +313,7 @@ Use inline banners in a page with multiple steps or actions.
 
 Use empty states as an integrated way to onboard users to new features. Read more about [empty states](/ui-patterns/empty-states).
 
-**In-product marketing empty state**
+#### In-product marketing empty state
 
 For special occasions, a first time experience may be more unique than the typical blank state. Take a more branded approach to engage and guide the user through complex experiences. Be aware of how the experience will change once the first-time UI is no longer there.
 

--- a/content/ui-patterns/forms.mdx
+++ b/content/ui-patterns/forms.mdx
@@ -35,7 +35,7 @@ A caption may be used to provide additional context about the field to help user
 
 Caption text may be displayed alongside a validation message, or it may be hidden if it only provides redundant information.
 
-Caption text may be used to augment the [label](#label), but should not be redundant with the label or any other parts of the form control. If the caption feels redundant, try removing it.
+Caption text may be used to augment the [label](#label-required), but should not be redundant with the label or any other parts of the form control. If the caption feels redundant, try removing it.
 
 <DoDontContainer>
   <Do>
@@ -104,7 +104,7 @@ For more information about form validation, see the [validation guidelines](#val
 
 ![Text input, open-ended autocomplete text input, plain text input, textarea](https://user-images.githubusercontent.com/2313998/170069913-325a987b-9a75-4e83-826a-bb7ae73d6831.png)
 
-Use an open-ended text field when the field does not have a list of possible values. If the input is able to suggest values, use [autocomplete](#autocomplete) to allow users to pick a value or enter their own.
+Use an open-ended text field when the field does not have a list of possible values. If the input is able to suggest values, use [autocomplete](/components/avatar-pair) to allow users to pick a value or enter their own.
 
 ### A set of selectable options
 

--- a/content/ui-patterns/messaging.mdx
+++ b/content/ui-patterns/messaging.mdx
@@ -60,7 +60,7 @@ Toasts should be brief and not bog down the experience with superfluous copy. If
 
 ### Accessibility
 
-Toasts are non-modal components and should contain `role=log`, which implies the element has `aria-live="polite"`. This notifies the user of the toast via Assistance Technologies without having to change focus to the toast. You can read more about `role=log` [here](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA23).
+Toasts are non-modal components and should contain `role=log`, which implies the element has `aria-live="polite"`. This notifies the user of the toast via Assistance Technologies without having to change focus to the toast. You can read more about `role=log` at [W3: Using `role=log` to identify sequential information updates](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA23).
 
 Toasts are generally informative and should not receive focus when they appear. For that reason, we suggest you **avoid using interactive elements** in the component (aside from a dismiss action). Keep in mind that, even without an explicit dismiss action, the user can always hit `esc` to dismiss the toast. For more information on how interactive children affect web accessibility, [check out this issue](https://github.com/jackbsteinberg/std-toast/issues/29).
 

--- a/docs/content.md
+++ b/docs/content.md
@@ -2,7 +2,7 @@
 
 ## Guidelines
 
-###  Principles
+### Principles
 
 * Accessibility: (Inclusive) consider a11y in design early, list of tools
 * Safety: designing for safety

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "gatsby build --prefix-paths",
     "build:preview": "gatsby build",
     "now-build": "yarn build",
-    "lint": "eslint . & markdownlint-cli2 \"**/*.{md,mdx}\" \"!.github\" \"!node_modules\""
+    "lint": "eslint .",
+    "markdownlint": "markdownlint-cli2 \"**/*.{md,mdx}\" \"!.github\" \"!node_modules\""
   },
   "dependencies": {
     "@github/prettier-config": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "yarn": "^1.22.18"
   },
   "devDependencies": {
-    "@github/markdownlint-github": "^0.2.0",
+    "@github/markdownlint-github": "^0.2.1",
     "markdownlint-cli2": "^0.5.1",
     "path-browserify": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "gatsby build --prefix-paths",
     "build:preview": "gatsby build",
     "now-build": "yarn build",
-    "lint": "eslint ."
+    "lint": "eslint . & markdownlint-cli2 \"**/*.{md,mdx}\" \"!.github\" \"!node_modules\""
   },
   "dependencies": {
     "@github/prettier-config": "^0.0.4",
@@ -25,6 +25,8 @@
     "yarn": "^1.22.18"
   },
   "devDependencies": {
+    "@github/markdownlint-github": "^0.2.0",
+    "markdownlint-cli2": "^0.5.1",
     "path-browserify": "^1.0.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,6 +1208,13 @@
     html-entities "^2.3.3"
     strip-ansi "^6.0.0"
 
+"@github/markdownlint-github@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@github/markdownlint-github/-/markdownlint-github-0.2.0.tgz#71d71f9a41313ed24a66084ec128416490d61d78"
+  integrity sha512-Hze+8jMqcgcXYYKCIyfqcwO5hqFWokzqufpI7m1CJzJSklOVIaBx2xA3BrJgS+QYzMhgnv2ihqO7/cB81ljojA==
+  dependencies:
+    lodash "^4.17.15"
+
 "@github/prettier-config@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@github/prettier-config/-/prettier-config-0.0.4.tgz#cbfddb36a7f29a81c5af155dc5827e95b23b9ccd"
@@ -5328,7 +5335,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^3.0.1:
+entities@^3.0.1, entities@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
@@ -6125,6 +6132,17 @@ fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.11:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -7294,6 +7312,17 @@ globby@11.0.3:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+globby@13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
+  integrity sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
 
 globby@^10.0.1:
   version "10.0.2"
@@ -9212,6 +9241,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -9595,6 +9631,17 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-it@13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-table@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
@@ -9606,6 +9653,30 @@ markdown-table@^2.0.0:
   integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
   dependencies:
     repeat-string "^1.0.0"
+
+markdownlint-cli2-formatter-default@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.3.tgz#5aecd6e576ad18801b76e58bbbaf0e916c583ab8"
+  integrity sha512-QEAJitT5eqX1SNboOD+SO/LNBpu4P4je8JlR02ug2cLQAqmIhh8IJnSK7AcaHBHhNADqdGydnPpQOpsNcEEqCw==
+
+markdownlint-cli2@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.5.1.tgz#b55b89301f422231a0fc6265794b28cf4da95a82"
+  integrity sha512-f3Nb1GF/c8YSrV/FntsCWzpa5mLFJRlO+wzEgv+lkNQjU6MZflUwc2FbyEDPTo6oVhP2VyUOkK0GkFgfuktl1w==
+  dependencies:
+    globby "13.1.2"
+    markdownlint "0.26.2"
+    markdownlint-cli2-formatter-default "0.0.3"
+    micromatch "4.0.5"
+    strip-json-comments "5.0.0"
+    yaml "2.1.1"
+
+markdownlint@0.26.2:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.26.2.tgz#11d3d03e7f0dd3c2e239753ee8fd064a861d9237"
+  integrity sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==
+  dependencies:
+    markdown-it "13.0.1"
 
 md5-file@^5.0.0:
   version "5.0.0"
@@ -9767,7 +9838,7 @@ mdn-data@2.0.14:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
-mdurl@^1.0.0:
+mdurl@^1.0.0, mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
@@ -10138,6 +10209,14 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
+micromatch@4.0.5, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -10156,14 +10235,6 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
-
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
-  dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
@@ -12898,6 +12969,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -13393,6 +13469,11 @@ strip-indent@^3.0.0:
   integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
   dependencies:
     min-indent "^1.0.0"
+
+strip-json-comments@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-5.0.0.tgz#ec101b766476a703031bc607e3c712569de2aa06"
+  integrity sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -13992,6 +14073,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -14929,6 +15015,11 @@ yaml-loader@^0.6.0:
   dependencies:
     loader-utils "^1.4.0"
     yaml "^1.8.3"
+
+yaml@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
+  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
 
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2, yaml@^1.8.3:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,10 +1208,10 @@
     html-entities "^2.3.3"
     strip-ansi "^6.0.0"
 
-"@github/markdownlint-github@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@github/markdownlint-github/-/markdownlint-github-0.2.0.tgz#71d71f9a41313ed24a66084ec128416490d61d78"
-  integrity sha512-Hze+8jMqcgcXYYKCIyfqcwO5hqFWokzqufpI7m1CJzJSklOVIaBx2xA3BrJgS+QYzMhgnv2ihqO7/cB81ljojA==
+"@github/markdownlint-github@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@github/markdownlint-github/-/markdownlint-github-0.2.1.tgz#71c783b0f39e9ee0bd3bf5f3acf8b364a5637b84"
+  integrity sha512-4yVd+5QhvvPIbRxRbcQBMU/4MRGFd3Dhs/JU3DIokRyC2Iuhh+D4dcne0nMuHnUZkk+dUkuVxOq3XE68jyusVw==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
Related: https://github.com/github/accessibility/issues/2542

This PR enables markdown linting pulling in configs from [markdownlint-github](https://github.com/github/markdownlint-github). 

_Why?_ This repo is primarily composed of markdown files. There are valuable markdownlint rules that encourage best accessibility practices. We have config recs centralized in `markdownlint-github` now that should be pulled in.

`markdownlint-github` configs enables the [`markdownlint` defaults](https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.jsonc), but then adds some GitHub custom rules and overrides. Some of markdownlint's defaults are related to stylistic things like `line-length` and `blanks-around-headings`. I don't know how much value Primer gets in enforcing these stylistic things so I decided to turn them off. There's also a lot to resolve, but if you think they should be enabled, it should probably be done in a follow-up.

I made sure the rules pertaining to accessibility are kept on since these provide a lot of value and encourage accessibility practices. I think those should be addressed as part of this PR. Open to reviewer opinions!
