### PR TITLE
Bump `markdownlint-github` and add formatter

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -16,4 +16,7 @@ const options = githubMarkdownOpinions.init({
 module.exports = {
   config: options,
   customRules: ["@github/markdownlint-github"],
+  outputFormatters: [
+    [ "markdownlint-cli2-formatter-pretty", { "appendLink": true } ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "yarn": "^1.22.18"
   },
   "devDependencies": {
-    "@github/markdownlint-github": "^0.2.1",
+    "@github/markdownlint-github": "^0.3.0",
     "markdownlint-cli2": "^0.5.1",
+    "markdownlint-cli2-formatter-pretty": "^0.0.3",
     "path-browserify": "^1.0.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,10 +1208,10 @@
     html-entities "^2.3.3"
     strip-ansi "^6.0.0"
 
-"@github/markdownlint-github@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@github/markdownlint-github/-/markdownlint-github-0.2.1.tgz#71c783b0f39e9ee0bd3bf5f3acf8b364a5637b84"
-  integrity sha512-4yVd+5QhvvPIbRxRbcQBMU/4MRGFd3Dhs/JU3DIokRyC2Iuhh+D4dcne0nMuHnUZkk+dUkuVxOq3XE68jyusVw==
+"@github/markdownlint-github@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@github/markdownlint-github/-/markdownlint-github-0.3.0.tgz#ead81eb18240f1c83afdfe4d67c308ae4d087adc"
+  integrity sha512-q35L9LA4trt/raFfOFt03UL2g1dsoimbdtIjspECvSx34KMS42FhKCGrBj0BazM5u4dbovHsAbtjzVQ7ZEWIEA==
   dependencies:
     lodash "^4.17.15"
 
@@ -3039,6 +3039,13 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-5.0.0.tgz#b6a0caf0eef0c41af190e9a749e0c00ec04bb2a6"
+  integrity sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==
+  dependencies:
+    type-fest "^1.0.2"
+
 ansi-html-community@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
@@ -3943,6 +3950,11 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
+  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
 
 chalk@^3.0.0:
   version "3.0.0"
@@ -9659,6 +9671,14 @@ markdownlint-cli2-formatter-default@0.0.3:
   resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.3.tgz#5aecd6e576ad18801b76e58bbbaf0e916c583ab8"
   integrity sha512-QEAJitT5eqX1SNboOD+SO/LNBpu4P4je8JlR02ug2cLQAqmIhh8IJnSK7AcaHBHhNADqdGydnPpQOpsNcEEqCw==
 
+markdownlint-cli2-formatter-pretty@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli2-formatter-pretty/-/markdownlint-cli2-formatter-pretty-0.0.3.tgz#e2e2b6667591f33304b90159a32c3018729aca25"
+  integrity sha512-J+j4TwP/up97N7eEwq3vhhs5GNWENLaBGZZU+H2XodshOl9eQD8BYHOUq/8mN9t0nz7jFj79jQCBMgJvHL9rKQ==
+  dependencies:
+    chalk "5.0.0"
+    terminal-link "3.0.0"
+
 markdownlint-cli2@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/markdownlint-cli2/-/markdownlint-cli2-0.5.1.tgz#b55b89301f422231a0fc6265794b28cf4da95a82"
@@ -13634,6 +13654,14 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
+  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -13729,6 +13757,14 @@ term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
+
+terminal-link@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-3.0.0.tgz#91c82a66b52fc1684123297ce384429faf72ac5c"
+  integrity sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==
+  dependencies:
+    ansi-escapes "^5.0.0"
+    supports-hyperlinks "^2.2.0"
 
 terser-webpack-plugin@^5.1.1, terser-webpack-plugin@^5.1.3:
   version "5.3.3"
@@ -14033,6 +14069,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-fest@^2.5.3:
   version "2.18.0"


### PR DESCRIPTION
This PR:

- bumps `markdownlint-github` to latest 
- add formatter configuration. By default, the markdownlint error message doesn't include a link to the rule doc. This configures a formatter which will ensure the error message includes a link to the relevant doc like so:

   ```
   CONTRIBUTING.md:7 GH002/no-generic-link-text Avoid using generic link text like `Learn more` or `Click here` [For link: here] https://github.com/github/markdownlint-github/blob/main/docs/rules/GH002-no-generic-link-text.md
   ```

I think this is especially helpful because the rule docs might be in either  `markdownlint-github` or `markdownlint` and we don't want consumers spending time looking for it.