### PR TITLE
Figma documentation links are outdated

### DIFF
--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -19,7 +19,7 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 
 ## Team libraries
 
-GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries](https://www.figma.com/@primer)" project. They include the following:
+GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
 
 - [Primer Primitives](https://www.figma.com/community/file/854766928300977832): All of the color, type, and spacing styles used within Primer.
 - [Primer Web](https://www.figma.com/community/file/854767373644076713): UI components used to design for GitHub's web interfaces.

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -21,7 +21,7 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 
 GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
 
-- [Primer Primitives](https://www.figma.com/community/file/854766928300977832): All of the color, type, and spacing styles used within Primer.
+- Primer Primitives ([Internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [Community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
 - [Primer Web](https://www.figma.com/community/file/854767373644076713): UI components used to design for GitHub's web interfaces.
 - [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -23,7 +23,7 @@ GitHub uses Figma to distribute Primer through team libraries. Each library cove
 
 - Primer Primitives ([internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
 - [Primer Mobile (internal only)](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
-- Primer Web ([internal](https://www.figma.com/community/file/854767373644076713) | [community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
+- Primer Web ([internal](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1406%3A0&t=kY6ZvRffnaGOaUib-1) | [community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
 - [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 
 ## Interface templates

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -21,9 +21,9 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 
 GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
 
-- Primer Primitives ([Internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [Community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
+- Primer Primitives ([internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
 - [Primer Mobile (internal only)](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
-- Primer Web ([internal](https://www.figma.com/community/file/854767373644076713) | [Community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
+- Primer Web ([internal](https://www.figma.com/community/file/854767373644076713) | [community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
 - [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 
 ## Interface templates

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -23,7 +23,7 @@ GitHub uses Figma to distribute Primer through team libraries. Each library cove
 
 - Primer Primitives ([Internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [Community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
 - [Primer Mobile (internal only)](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
-- Primer Web ([(internal)](https://www.figma.com/community/file/854767373644076713) | [Community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
+- Primer Web ([internal](https://www.figma.com/community/file/854767373644076713) | [Community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
 - [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 
 ## Interface templates

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -19,12 +19,11 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 
 ## Team libraries
 
-GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project. They include the following:
+GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries](https://www.figma.com/@primer)" project. They include the following:
 
-- [Primer Primitives](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives): All of the color, type, and spacing styles used within Primer.
-- [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web): UI components used to design for GitHub's web interfaces.
-- [Primer Mobile](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
-- [Octicons](https://www.figma.com/file/1ljgTFkT5NKNRfq5hw07JQ/Octicons): GitHub's custom icon library.
+- [Primer Primitives](https://www.figma.com/community/file/854766928300977832): All of the color, type, and spacing styles used within Primer.
+- [Primer Web](https://www.figma.com/community/file/854767373644076713): UI components used to design for GitHub's web interfaces.
+- [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 
 ## Interface templates
 

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -22,7 +22,8 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
 
 - Primer Primitives ([Internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [Community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
-- [Primer Web](https://www.figma.com/community/file/854767373644076713): UI components used to design for GitHub's web interfaces.
+- [Primer Mobile (internal only)](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
+- Primer Web ([(internal)](https://www.figma.com/community/file/854767373644076713) | [Community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
 - [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 
 ## Interface templates

--- a/content/tools/figma.mdx
+++ b/content/tools/figma.mdx
@@ -22,8 +22,8 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
 
 - Primer Primitives ([internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
-- [Primer Mobile (internal only)](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
 - Primer Web ([internal](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1406%3A0&t=kY6ZvRffnaGOaUib-1) | [community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
+- [Primer Mobile (internal only)](https://www.figma.com/file/csCViryWkkXwBsK1aLrO0X/Primer-Mobile): UI components used to design for GitHub's native mobile platforms.
 - [Octicons](https://www.figma.com/community/file/809920999413919915): GitHub's custom icon library.
 
 ## Interface templates


### PR DESCRIPTION
Hi guys,

I just noticed, that all figma links in this file lead to a 404 error page.
They're probably outdated.

https://github.com/primer/design/blob/main/content/tools/figma.mdx


Tried to find the correct links & corrected documentation