### PR TITLE
Add extra link guidance

### DIFF
--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -3,74 +3,99 @@ title: Links
 ---
 
 ## Overview
-Links are user interface elements that *navigate* you to a new place or new content. Contrast this with buttons, which are designed to *activate* a feature.
+
+Links are user interface elements that _navigate_ you to a new place or new content. Contrast this with buttons, which are designed to _activate_ a feature.
 
 ## Why?
-Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through sites like Wikipedia. Links play a key part in your experience on the web, but without proper consideration they can be frustrating to use, skipped over, or completely unnoticed. 
 
-For screen reader assistive technology, links and buttons are expected to function differently from each other. If a link is activated and does not do what was expected, that can be disorienting and frustrating. 
+Links can do things like help with page context, reference similar items of interest, and allow for endless connected information surfing through sites like Wikipedia. Links play a key part in your experience on the web, but without proper consideration they can be frustrating to use, skipped over, or completely unnoticed.
 
-A common way a screen reader might navigate the page is by going through a list of all the links on the page. Without context, "read more" or "click here" links are not helpful. 
+For screen reader assistive technology, links and buttons are expected to function differently from each other. If a link is activated and does not do what was expected, that can be disorienting and frustrating.
+
+A common way a screen reader might navigate the page is by going through a list of all the links on the page. Without context, "read more" or "click here" links are not helpful.
 
 People who have low or colorblind vision may have trouble identifying links that just use color to distinguish them from plain text, this is why keeping the underline styling on links within body text is important for identification.
 
 ## How to test links
-- Check a link's function. If clicking a link activates a feature on the page, it should be a `<button>`, and vice versa. 
+
+- Check a link's function. If clicking a link activates a feature on the page, it should be a `<button>`, and vice versa.
 - Check a link's purpose. If you can't get an idea of where a link will take you based on the link text alone, the link text should be updated. [Learn how to write good link text](#writing-link-text).
 - [Check a link's contrast](https://webaim.org/resources/contrastchecker/). Because links are text-based, they need to pass 4.5:1 against the background color that they are on.
-- In body text, like a Markdown file, check to make sure that all links have underline styling. 
+- In body text, like a Markdown file, check to make sure that all links have underline styling.
 
 ## Guidelines
 
 ### For designers
+
 - Make sure you use the correct accent color for links in your designs. Double check the color you're using if you're using it on anything other than a white background. For more context on color, check out our [color documentation](https://primer.style/design/foundations/color).
-- Make sure a link's purpose can be understood on its own without the surrounding context in concise words. 
-- Links should always be underlined if they're in body text. 
+- Make sure a link's purpose can be understood on its own without the surrounding context in concise words.
+- Links should always be underlined if they're in body text.
 - Links should look like links, not buttons, except in rare circumstances, like calls to action. If the action takes you somewhere rather than doing something on the page, it should be semantically coded as a link regardless of the visual style.
 
 <DoDontContainer>
-    <Do>
-        <img src="https://user-images.githubusercontent.com/40274682/160483376-a88eb64f-ce80-4a11-93b5-6d882b1970eb.png" alt="Markdown paragraph with descriptive links"/>
-        <Caption>Be descriptive with your links so that they can stand alone and be understood.</Caption>
-    </Do>
-    <Dont>
-        <img src="https://user-images.githubusercontent.com/40274682/160474793-2fd3085f-0813-43ed-8b43-c1a5f14aaea9.png" alt="Markdown paragraph with links like 'Click here' and 'find out more'" />
-        <Caption>Don't use generic terms like 'click here' that can't be understood out of context.</Caption>
-    </Dont>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/40274682/160483376-a88eb64f-ce80-4a11-93b5-6d882b1970eb.png"
+      alt="Markdown paragraph with descriptive links"
+    />
+    <Caption>Be descriptive with your links so that they can stand alone and be understood.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/40274682/160474793-2fd3085f-0813-43ed-8b43-c1a5f14aaea9.png"
+      alt="Markdown paragraph with links like 'Click here' and 'find out more'"
+    />
+    <Caption>Don't use generic terms like 'click here' that can't be understood out of context.</Caption>
+  </Dont>
 </DoDontContainer>
 
 <DoDontContainer>
-    <Do>
-        <img src="https://user-images.githubusercontent.com/40274682/160474794-06a75b30-06d3-475e-863f-605e8a6dad72.png" alt="Underlined username link in issue subheading"/>
-        <img src="https://user-images.githubusercontent.com/40274682/160474798-175a588f-4a03-4b42-8787-0af13bc71311.png" alt="Underlined community guidelines link in text under a markdown comment text area." />
-        <Caption>Underline links in paragraphs and sentences</Caption>
-    </Do>
-    <Dont>
-        <img src="https://user-images.githubusercontent.com/40274682/160474800-b505369e-1730-4c14-b426-70b5bd016a6c.png" alt="Issue subheader with none of the links underlined"/>
-        <img src="https://user-images.githubusercontent.com/40274682/160474802-3fe6b792-3c79-40ce-a443-c2279a3a785b.png" alt="GitHub commnuity guideline link not underlined in sentence."/>
-        <Caption>Don't forget to underline links in paragraphs and sentences</Caption>
-    </Dont>
+  <Do>
+    <img
+      src="https://user-images.githubusercontent.com/40274682/160474794-06a75b30-06d3-475e-863f-605e8a6dad72.png"
+      alt="Underlined username link in issue subheading"
+    />
+    <img
+      src="https://user-images.githubusercontent.com/40274682/160474798-175a588f-4a03-4b42-8787-0af13bc71311.png"
+      alt="Underlined community guidelines link in text under a markdown comment text area."
+    />
+    <Caption>Underline links in paragraphs and sentences</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://user-images.githubusercontent.com/40274682/160474800-b505369e-1730-4c14-b426-70b5bd016a6c.png"
+      alt="Issue subheader with none of the links underlined"
+    />
+    <img
+      src="https://user-images.githubusercontent.com/40274682/160474802-3fe6b792-3c79-40ce-a443-c2279a3a785b.png"
+      alt="GitHub commnuity guideline link not underlined in sentence."
+    />
+    <Caption>Don't forget to underline links in paragraphs and sentences</Caption>
+  </Dont>
 </DoDontContainer>
 
-
 ### For engineers
+
 - Use Primer link components:
-	- [Link in Primer ViewComponents](https://primer.style/view-components/components/link)
-	- [Link in Primer React](https://primer.style/react/Link)
+  - [Link in Primer ViewComponents](https://primer.style/view-components/components/link)
+  - [Link in Primer React](https://primer.style/react/Link)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard (reference: [Focus management](https://primer.style/design/accessibility/focus-management))
 - Don't use the `title` attribute
   - Content within a `title` is inaccessible for many users, such as touch-only and keyboard-only users. If additional content needs to be associated with a link consider using a [tooltip](https://primer.style/view-components/components/alpha/tooltip) or [alternatives to a tooltip](https://primer.style/design/accessibility/tooltip-alternatives).
 - Avoid adding side effects to link click events. Links should navigate, not affect the page.
+- Don't force links to open in a new tab/window by setting the `target` property.
+- Links should always open in a new window when clicking them using Command/Control.
 
 ## Common mistakes
+
 - Only adding an underline to a link when it has focus or is hovered over
 - Underlining every link on the page. For example, a navigation list is a list of links but navigational links don't have to be underlined because the intent is understood and an underline is not needed to identify the interactive nature of the control.
 
 ## Writing link text
 
 Link text should be descriptive enough to convey the destination without relying on the surrounding text. Screen reader users often tab through links on a page to quickly find content without needing to listen to the full page.
-When link text is too generic like "Read more", the destination of the link is not conveyed. 
+When link text is too generic like "Read more", the destination of the link is not conveyed.
 
 It may be acceptable in some scenarios to provide a more descriptive link text for screen reader users by setting the `aria-label`. However, this technique will result in divergence between the label and the text and is not an ideal, future-proof solution.
 Whenever possible, prefer a single descriptive link text that is available for both sighted users and screen reader users.
@@ -81,26 +106,33 @@ If you must resort to the ARIA technique to provide a descriptive link text, fol
 2. The sentence that the link is a part of is well-formed and grammatical when read with both the visible text and the accessible name.
 
 <DoDontContainer>
-    <Do>
-      <Caption>Accessible name fully includes the visible link text, "Learn more" and is well-formed with either label.</Caption>
-      <Code className="language-html">{`There are various plans available. <a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>`}</Code>
-      <br />
-    </Do>
-    <Dont>
-      <Caption>Accessible name results in poorly-formed sentence, "Learn more about keyboard shortcuts allow you to access common commands more quickly". </Caption>
-      <Code className="language-html">{`<a href="..." aria-label="Learn more about keyboard shortcuts">Keyboard shortcuts</a> allow you to access common commands more quickly.`}</Code>
-    </Dont>
+  <Do>
+    <Caption>
+      Accessible name fully includes the visible link text, "Learn more" and is well-formed with either label.
+    </Caption>
+    <Code className="language-html">{`There are various plans available. <a href="..." aria-label="Learn more about GitHub pricing plans">Learn more</button>`}</Code>
+    <br />
+  </Do>
+  <Dont>
+    <Caption>
+      Accessible name results in poorly-formed sentence, "Learn more about keyboard shortcuts allow you to access common
+      commands more quickly".{' '}
+    </Caption>
+    <Code className="language-html">{`<a href="..." aria-label="Learn more about keyboard shortcuts">Keyboard shortcuts</a> allow you to access common commands more quickly.`}</Code>
+  </Dont>
 </DoDontContainer>
 
 As demonstrated in the examples, this technique adds more complexity to the code and can introduce more problems than it solves so only use this technique if absolutely necessary.
 
 ## Additional resources
+
 - [Color to Distinguish Links from Text](https://dequeuniversity.com/class/visual-design/color/distinguish-links-from-text) (requires a subscription to access the content)
 - [Accessibility Insights plugin](https://accessibilityinsights.io/en/): With the Accessibility Insights plugin installed, open the plugin, visit the **Assessment** option and select **7. Links**
 - [WebAIM: Links and Hypertext - Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
 - [erblint-github: Avoid generic link text](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/avoid-generic-link-text-counter.md)
 
 ### Related WCAG guidelines and success criteria
+
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
 - [Authoring Practices Guide - Links](https://www.w3.org/TR/wai-aria-practices-1.2/#link)
 - [Accessible Rich Internet Applications (WAI-ARIA) 1.2 (w3.org)](https://www.w3.org/TR/wai-aria-1.2/#link)

--- a/content/accessibility/links.mdx
+++ b/content/accessibility/links.mdx
@@ -85,7 +85,7 @@ People who have low or colorblind vision may have trouble identifying links that
   - Content within a `title` is inaccessible for many users, such as touch-only and keyboard-only users. If additional content needs to be associated with a link consider using a [tooltip](https://primer.style/view-components/components/alpha/tooltip) or [alternatives to a tooltip](https://primer.style/design/accessibility/tooltip-alternatives).
 - Avoid adding side effects to link click events. Links should navigate, not affect the page.
 - Don't force links to open in a new tab/window by setting the `target` property.
-- Links should always open in a new window when clicking them using Command/Control.
+- Links should always open in a new window when clicking while holding Command/Control.
 
 ## Common mistakes
 


### PR DESCRIPTION
Added two extra bullet points around usage of the `target` property on links.

<img width="1076" alt="Screenshot 2023-01-03 at 17 49 11" src="https://user-images.githubusercontent.com/980622/210412887-233feef5-737a-4da4-b561-81ad2a12a311.png">

Prettier also formatted the page using the config in the root. Sorry for that.
