### PR TITLE
Move contribute repo content to primer.style/design

### DIFF
--- a/content/guides/component-lifecycle.mdx
+++ b/content/guides/component-lifecycle.mdx
@@ -1,0 +1,57 @@
+---
+title: Component lifecycle
+---
+
+These milestones summarize the maturity lifecycle of UI components in Primer. Components must meet all criteria _before_ proceeding to a given milestone.
+
+## Experimental
+
+Proof-of-concept, often built outside of Primer.
+
+- The component exists as a proof-of-concept. In many cases experimental components may be built outside of Primer, often in a GitHub application such as GitHub.com.
+
+## Alpha
+
+The component is ready for preliminary usage, with breaking changes expected.
+
+- The component does not have external dependencies. This could be external libraries or dependencies on libraries in an application (like GitHub.com)
+- The component is compatible with color modes and can adapt to different themes. The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.
+- The component is designed with responsiveness in mind. The component can adapt to different screen sizes, from mobile to large desktop screens. The component's interactive areas must be friendly to touch on devices with a coarse pointer method.
+- Component documentation includes example usage of the component.
+- Primary use cases tested and reviewed.
+- The component has robust unit test coverage on all critical paths, including branching logic and edge cases. This is measurable through metrics like 100% test coverage (where achievable).
+- The component has visual regression coverage of its default and interactive states.
+- The component has robust test coverage for its interactive (stateful) behaviour, which has been verified in end-to-end and/or open-box testing suites.
+- The component does not introduce any [axe](https://www.deque.com/axe/) violations.
+- The component has been manually reviewed for accessibility and any outstanding issues have been fixed.
+
+## Beta
+
+The component meets most maturity criteria, and use is encouraged for most scenarios.
+
+- The component is used in a production application in multiple instances. Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Uses of the component have been reviewed for correctness.
+- Usage guidelines and configuration documentation covers common use cases. Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.
+- The design has been reviewed and any resulting issues have been addressed. Systems Designers have reviewed the current implementation, validated its responsive strategy, and how it’s used in production.
+- The component does not introduce unnecessary performance regressions to the user experience or the Primer library.
+
+## Stable
+
+The component is significantly mature and usage is strongly encouraged, with long-term support expected.
+
+- The API remains stable, with no breaking changes for at least one month. Feedback on API usability has been sought from developers using the component and production use cases have been reviewed for correctness.
+- Documentation exists for the remaining implementation, usage, and design guidelines. Primer React and/or Primer ViewComponents documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.
+- Tooling (such as linters, codemods, etc.) exists to prevent further use of alternatives.
+
+## Deprecated
+
+The component will be removed in the future and should be avoided.
+
+- Documentation exists for the deprecation, including any alternative components to use instead.
+- When using the component, a warning is shown to the consumer.
+
+## Removed
+
+The component no longer exists in Primer.
+
+- The removal date has been announced and is at least one month away from the release date of the package that removes the component.
+- Manual and automated migration paths are documented and have been available for at least one month.

--- a/content/guides/contribute/design.mdx
+++ b/content/guides/contribute/design.mdx
@@ -1,0 +1,70 @@
+---
+title: Design
+description: These are some guidelines you should always keep in mind when creating Primer design patterns.
+---
+
+The key goals are to create flexible, robust, and useful patterns that advance Primer's incremental innovation, while building upon an existing set of solid foundations.
+
+## Design system foundations
+
+Primer is built on strong foundations that should remain stable. Become familiar with guidelines on typography, color, spacing, and layout.
+
+➡️ [Primer design guidelines](https://primer.style/design/)
+
+## Upcoming patterns and proposals
+
+It's important to know what's coming into Primer, to avoid duplicated efforts and to accommodate upcoming changes to elements that may interact with what you're planning to work on.
+
+Check what is currently being designed and built, as this may introduce new concepts and variations to existing patterns.
+
+➡️ [Primer backlog](https://github.com/github/primer/projects/1?fullscreen=true) (GitHub staff only)
+
+## Context and use cases
+
+Before you start to create mockups and think of solutions, it's good to always carry out an audit of where similar patterns are used in github.com, and where it can potentially be used once a new pattern exists. You can also audit different products to see how they've solved similar problems.
+
+Think about as many different use cases where the pattern can be used across github.com as possible. The goal is to create patterns that are flexible, but that solve concrete problems.
+
+Finally, consider where a pattern will live in the context of the larger product. Don't design a single pattern in isolation of its possible surroundings.
+
+## Design mockups and prototypes
+
+@todo Coming soon!
+
+<!-- Get started in Figma by duplicating the **Primer pattern template** file. You can find it in **Design Infrastructure > Contributions**. Follow the instructions in the file on how to name, and use the template, so that it accurately indicates the stage of the design work.
+
+You can also use an alternative prototyping tool like CodePen, Framer, or anything else that you're comfortable using — just make sure the prototypes are linked to from the pattern tracking issue. -->
+
+➡️ [Using Figma at GitHub](https://primer.style/design/tools/figma)
+
+<!-- @todo Naming, API: design and eng alignment -->
+
+## Share early, and often
+
+The work that you're doing shouldn't be a surprise that you only reveal when you're done.
+
+**Systems designers** can provide extra context and considerations that are helpful to create a solid design.
+
+**Product designers** can consider the designs in the context of their own product area and whether their specific use cases could benefit from your proposal.
+
+**Engineers** can consider how something may be implemented, what is realistic within the existing constraints, and what is unfeasible.
+
+There are different ways you can ask for and get feedback:
+
+- Async via [discussions](https://github.com/github/primer/discussions/categories/feedback) (GitHub staff only): Record a short video and/or links to a Figma prototype (or any other kind of prototype, like sketches or code), providing context and specifying what kind of feedback you're looking for
+- Primer open office hours: Attend office hours on Thursdays (1.30pm PT). The Zoom link is posted right before in #primer. Be prepared to give context and ask what kind of feedback you're looking for succinctly. Ideally, give a heads-up in #primer beforehand so we can be sure a designer will be present in the call
+- Ad-hoc in real-time: In #primer, ask for a short critique session with a systems designer, to get feedback on a specific issue
+
+## Design checklist
+
+All Primer design patterns should take into account the following areas:
+
+- [ ] Primer Primitives
+- [ ] Input types and devices (keyboard, pointer, touch, etc.)
+- [ ] Responsiveness (from very small to extra large screens)
+- [ ] Themeability
+- [ ] Accessibility
+- [ ] Content
+- [ ] Interaction states
+- [ ] Documentation/APIs
+- [ ] Figma assets

--- a/content/guides/contribute/documentation.mdx
+++ b/content/guides/contribute/documentation.mdx
@@ -1,0 +1,119 @@
+---
+title: Documentation
+description: Primer documentation should express the voices and contributions of different people, but for it to be useful it’s important to be consistent in tone and structure. 
+---
+
+Please read and follow these guidelines carefully when writing documentation, so that as many people as possible can benefit from Primer.
+
+## Primer documentation principles
+
+### Concise but friendly
+A large proportion of readers want to find an answer that helps them complete a task, so don't waste their time with unnecessary words. That doesn't mean talking like a robot though: a sprinkling of humor is fine as long as it doesn't make the documentation harder to parse or distract from instructions.
+
+### Universally understood
+Avoid using phrases or referencing examples that are only familiar internally at GitHub. Assume readers are either members of the public or new to GitHub.
+
+### Production quality
+Code examples should promote what we'd like to see used in production. People copy and paste code examples as a starting point for building interfaces, and/or reference the guidelines for examples of correct implementation. While examples might be simpler than what we'd use in production, the code should promote best practices and follow our principles and accessibility standards.
+
+## Audience
+Primer documentation is primarily aimed at GitHub designers and engineers at various levels of experience, but folks in other areas will also benefit from and use the guidelines.
+
+### Assumed knowledge
+
+**Do:**
+- In design docs, assume the reader knows basic design concepts and principles, such as the need for consistency, and terms such as “white space” or “scale”.
+- When referring to GitHub-specific terminology, link to a glossary of terms, or another document where the reader can learn more.
+- When referring to terms and ideas the reader may want to know more about, link to authoritative sources, such as [MDN](https://developer.mozilla.org/en-US/) and the [W3C](https://www.w3.org/).
+- In non-engineering docs, use code examples as necessary to ensure consistency and appropriate usage, but don't assume expertise in any programming language.
+
+**Don’t:**
+- Don’t assume the reader knows about internal GitHub terminology.
+
+## Aspirational guidelines
+
+Guidelines can be aspirational, as long as what is documented is possible to implement with Primer. Guidelines should document and promote what we want folks to do with Primer, and not cover all possible variations.
+
+Design guidelines should not document patterns that are not possible to create with the current system. If you're writing guidelines for a feature that is upcoming, but not yet ready in implementation, you can have the content ready in a pull request, to be published when the implementation ships.
+
+## Voice and tone
+
+- Write as you speak, then tidy it up.
+- Write affirmative sentences wherever possible. 
+- Be clear and concise. 
+- Use [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood), so that instructions are clear. 
+- Remove unnecessary words, like adverbs, and keep sentences and paragraphs short.
+- Don’t sound like a robot or too formal.
+- Don’t use sarcasm or irony, they may not translate well.
+- Avoid double negatives.
+- Avoid using expressions like “easy”, “simply”, “quick”, “just”. 
+- Avoid idioms, they can be hard to understand and translate.
+  - **Do:** “As a general rule”
+  - **Don’t:** “As a rule of thumb”
+- Don't use the passive voice to avoid using the word “you” (but remove it if unnecessary).
+  - **Do:** “Open Figma”, “Submit an issue if you find a bug”
+  - **Don’t:** “Figma can be opened”, “You can open Figma”, “If a bug is found, submit an issue”
+- Avoid the possessive "our", and avoid addressing Primer as "our design system”.
+	- **Do:** “In the Figma library…”
+	- **Don’t:** “In our Figma library…”
+- Use "we" consistently to refer to the Design Systems / Infrastructure team, not to GitHub as a whole.
+
+## Grammar and usage
+
+Follow the [GitHub content guidelines](https://github.com/github/brand/blob/main/content.md) (this link is only accessible to GitHub staff), in particular:
+
+- Follow US spelling.
+  - **Do:** “Color palette”
+  - **Don’t:** “Colour palette”
+- Use sentence case for titles.
+  - **Do:** “Utility classes”
+  - **Don’t:** “Utility Classes”
+- Capitalize only [proper nouns](https://en.wikipedia.org/wiki/Proper_noun) and [product names](https://github.com/github/brand/blob/main/content.md#products-ecosystem-and-programs) (this link is only accessible to GitHub staff).
+  - **Do:** “Open a pull request"
+  - **Don't:** "Open a Pull Request"
+- Avoid positional language.
+  - **Do:** “The list that follows”
+  - **Don’t:** “The list below”
+- Use contractions.
+  - **Do:** “Don’t use this class”, “We’re happy to see you!”
+  - **Don’t:** “Do not use this class”, “We are happy to see you.”
+- Exclamation points are OK, in moderation.
+
+You may also refer to the content style guide for GitHub docs (accessible to GitHub staff only), in specific:
+- [Keyboard shortcuts](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#keyboard-shortcuts)
+- [Procedural steps](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#procedural-steps)
+- [Titles](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#procedural-steps) (of articles)
+- [User interface elements](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#procedural-steps)
+
+## Images and other examples
+
+Use this [Figma template](https://www.figma.com/file/YQT3nlmvSdZRPBnkDXvTFk/Doctocat-content-template?node-id=0%3A1) (accessible to GitHub staff only) to create images that are consistent across Primer documentation.
+
+When creating images with example UI for docs make sure that:
+- All documentation examples should be of real github.com examples
+- Examples only include the most important part of the UI, and don't try to show the entire UI
+- Use meaningful copy (for example, use "New issue" instead of "Button" as the text inside a button)
+
+## References
+
+- If mentioning or referring to other styles and documentation, always link to the source.
+- Reference an existing guide by linking to it, rather than duplicating the content. However, if this makes the documentation harder to follow, consider providing that reference in the document itself (for example: spacing scale, abbreviations).
+
+## Publishing checklist
+
+- Spellcheck text with an automated tool
+- Spellcheck UI text in image examples
+- Ask someone else to proofread the document including images - they may catch something you missed
+- Test all the links
+  - Indicate links that only work for GitHub staff (for example, "for GitHub staff only", or "only accessible to GitHub staff")
+- Verify there isn’t any private or sensitive information
+- Verify that all images include an alt text
+
+## Review process
+
+All pull requests for new and updated guidelines should be reviewed and approved by a member of the Design Infrastructure team. 
+
+## Resources
+
+- [Docs writing tips video](https://github.rewatch.com/video/o73hl5dh5hntp3xc-primer-docs-writing-tips) (only accessible to GitHub staff)
+- [Design guidelines template](https://github.com/primer/design/blob/master/CONTRIBUTING.md#design-guidelines-template)

--- a/content/guides/contribute/how-to-contribute.mdx
+++ b/content/guides/contribute/how-to-contribute.mdx
@@ -1,0 +1,58 @@
+---
+title: How to contribute
+description: Contributions to Primer can take many different formats to align with your skills and available time.
+---
+
+There are several ways you can contribute to and participate in Primer:
+
+1. Participate in discussions
+2. Propose a new UI pattern
+3. Improve the documentation
+4. Design or build new patterns
+5. Give us feedback and report bugs
+6. Contribute to our open source repos
+
+All contributions to Primer need to follow our [code of conduct](https://github.com/github/primer/blob/main/CODE_OF_CONDUCT.md).
+
+If at any time you get stuck or need help, head to #primer on Slack or start a discussion in github/primer with your question.
+
+<Note>Please note that at this time, we are not looking for external contributions from non-GitHub staff. Some of the links included in these documents are only available to GitHub staff.</Note>
+
+## Participate in discussions
+
+If you have a question, feedback or suggestion, you can start a new [discussion](https://github.com/github/primer/discussions) (GitHub staff only), or have a look at existing ones.
+
+Primer office hours are held once a week and anyone at GitHub can join, ask questions and participate in ongoing conversations. The office hours Zoom invite links are posted in Slack before the meeting starts.
+
+## Propose a new UI pattern
+
+If you'd like to propose a new Primer pattern, big or small, let's talk! The best way to get started, especially if your proposal is in its early stages, is to start a new [discussion](https://github.com/github/primer/discussions) (GitHub staff only).
+
+If you're more certain about what you need, please open a [pattern request issue](https://github.com/github/primer/issues/new?assignees=&labels=type%3A+request&template=0-request.md&title=%5BRequest%5D+) (GitHub staff only). We will get back to you after our weekly backlog triaging session.
+
+## Improve the documentation
+
+Documentation is a core part of Primer, and, just as design and code, we’re always trying to make it better and more useful. If you notice something missing, a typo, or have an idea of how the docs can be improved, please start a new [discussion](https://github.com/github/primer/discussions), or submit a pull request with a fix (you can do this directly via the “Edit this page on GitHub” link on the footer of docs pages).
+
+Read the Primer guidelines for [writing documentation](https://primer.style/contribute/documentation).
+
+## Design or build new patterns
+
+You can contribute to new patterns either by design, prototype and build proofs of concept, test in dotcom, or directly to our Primer open source repos.
+
+Please read the [guidelines on designing Primer patterns](https://primer.style/contribute/design).
+
+From the [Primer project board](https://github.com/orgs/github/projects/2759) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
+
+## Give us feedback and report bugs
+
+If you spot something that doesn’t look right in our design, code or documentation, open an issue and we'll triage it accordingly.
+
+## Contribute to our open source repos
+
+When contributing to Primer open source repos, please follow the repo's contributing guidelines:
+
+- [Primer CSS](https://github.com/primer/css/blob/main/CONTRIBUTING.md)
+- [Primer React](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md)
+- [Primer ViewComponents](https://primer.style/view-components/contributing)
+- [Octicons](https://github.com/primer/octicons/blob/main/CONTRIBUTING.md)

--- a/content/guides/contribute/index.mdx
+++ b/content/guides/contribute/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Contribute
+---
+
+import {Box, Link, Text} from '@primer/react'
+
+<Box>
+    <div>
+        <Link href="/guides/contribute/design">Design</Link>
+        <Text as="p">
+            TODO: Text for Design Contributions
+        </Text>
+    </div>
+    <div>
+        <Link href="/guides/contribute/documentation">Documentation</Link>
+        <Text as="p">
+            TODO: Text for Documentation Contributions
+        </Text>
+    </div>
+    <div>
+        <Link href="/guides/contribute/documentation">How to Contribute</Link>
+        <Text as="p">
+            TODO: Text for How to contribute
+        </Text>
+    </div>
+
+</Box>

--- a/content/guides/contribute/index.mdx
+++ b/content/guides/contribute/index.mdx
@@ -1,27 +1,19 @@
 ---
-title: Contribute
+title: Contribution guidelines
 ---
 
-import {Box, Link, Text} from '@primer/react'
+If you're interested in contributing to Primer, you can find all the information you need here, including:
 
-<Box>
-    <div>
-        <Link href="/guides/contribute/design">Design</Link>
-        <Text as="p">
-            TODO: Text for Design Contributions
-        </Text>
-    </div>
-    <div>
-        <Link href="/guides/contribute/documentation">Documentation</Link>
-        <Text as="p">
-            TODO: Text for Documentation Contributions
-        </Text>
-    </div>
-    <div>
-        <Link href="/guides/contribute/documentation">How to Contribute</Link>
-        <Text as="p">
-            TODO: Text for How to contribute
-        </Text>
-    </div>
+- [How to contribute](/guides/contribute/how-to-contribute)
+- [Design contributions](/guides/contribute/design)
+- [Writing documentation](/guides/contribute/documentation)
 
-</Box>
+For contribution guidelines for specific Primer implementations, please go to its respective repository:
+
+- [Primer React contribution guidelines](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md)
+- [Primer ViewComponents contribution guidelines](https://primer.style/view-components/contributing)
+
+<Note>
+  Please note that at this time, we are not looking for external contributions from non-GitHub staff. Some of the links
+  included in these documents are only available to GitHub staff.
+</Note>

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -13,12 +13,12 @@
     - title: Contribute
       url: /guides/contribute
       children:
+        - title: How to contribute
+          url: /guides/contribute/how-to-contribute
         - title: Design
           url: /guides/contribute/design
         - title: Documentation
           url: /guides/contribute/documentation
-        - title: How to contribute
-          url: /guides/contribute/how-to-contribute
 - title: Foundations
   children:
     - title: Color

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -8,6 +8,17 @@
       url: /guides/zen
     - title: Figma
       url: /guides/figma
+    - title: Component Lifecycle
+      url: /guides/component-lifecycle
+    - title: Contribute
+      url: /guides/contribute
+      children:
+        - title: Design
+          url: /guides/contribute/design
+        - title: Documentation
+          url: /guides/contribute/documentation
+        - title: How to contribute
+          url: /guides/contribute/how-to-contribute
 - title: Foundations
   children:
     - title: Color

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -8,7 +8,7 @@
       url: /guides/zen
     - title: Figma
       url: /guides/figma
-    - title: Component Lifecycle
+    - title: Component lifecycle
       url: /guides/component-lifecycle
     - title: Contribute
       url: /guides/contribute


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1616

Moving the [contribute repo content](https://github.com/primer/contribute/tree/master/content) over to the primer.style/design as a part of https://github.com/github/primer/issues/1307

### TODO
- [x] Make sure the copied content here is up-to-date when merging it. (Check merged PRs since the day of this PR's creation date)
 