### PR TITLE
Update content for filtering in DataTable to render markdown link

### DIFF
--- a/content/components/data-table.mdx
+++ b/content/components/data-table.mdx
@@ -523,8 +523,10 @@ If one of the actions is heavily used, pull it out for easier access. Do not pul
 <Box display="flex" flexDirection={['column', 'column', 'column', 'column', 'row']} sx={{gap: 3}}>
 
 <Box as="p" flex={1}>
+
   A [filter input](https://primer.style/design/components/filter-input) is used to write a query and only show rows that
   match that query.
+
 </Box>
 
 <img


### PR DESCRIPTION
Update the rendered link for filtering

**Before**

<img width="470" alt="The rendered text for filtering in a data table includes a broken markdown link" src="https://user-images.githubusercontent.com/3901764/212967493-cfc5e2e5-a082-4656-a97d-8ceb1edf3549.png">

**After**

<img width="456" alt="The rendered text for filtering in a data table includes a markdown link" src="https://user-images.githubusercontent.com/3901764/212967968-05c315ca-a571-4e67-9161-bd8c301082c7.png">

