### PR TITLE
Fix index page links on /design

### DIFF
--- a/content/guides/accessibility/index.mdx
+++ b/content/guides/accessibility/index.mdx
@@ -8,19 +8,19 @@ import {Box, Link, Text, Label} from '@primer/react'
   <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
     <h2>General</h2>
     <div>
-      <Link href="/guides/accessibility/accessibility-at-github" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/accessibility-at-github" sx={{fontWeight: 'bold'}}>
         Accessibility at GitHub
       </Link>
       <Text as="p">Get started with accessibility at GitHub.</Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/guidelines" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/guidelines" sx={{fontWeight: 'bold'}}>
         Guidelines
       </Link>
       <Text as="p">Basic guidelines for designers when creating or updating features.</Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/tools" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/tools" sx={{fontWeight: 'bold'}}>
         Tools
       </Link>
       <Text as="p">A selection of tools to help designers create accessible designs.</Text>
@@ -29,7 +29,7 @@ import {Box, Link, Text, Label} from '@primer/react'
   <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
     <h2>Specific</h2>
     <div>
-      <Link href="/guides/accessibility/alternative-text-for-images" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/alternative-text-for-images" sx={{fontWeight: 'bold'}}>
         Alternative text for images
       </Link>
       <Text as="p">
@@ -38,7 +38,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/announcements" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/announcements" sx={{fontWeight: 'bold'}}>
         Assistive technology announcements
       </Link>
       <Text as="p">
@@ -48,7 +48,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/descriptive-buttons" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/descriptive-buttons" sx={{fontWeight: 'bold'}}>
         Descriptive buttons
       </Link>
       <Text as="p">
@@ -57,7 +57,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/focus-management" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/focus-management" sx={{fontWeight: 'bold'}}>
         Focus management
       </Link>
       <Text as="p">
@@ -66,7 +66,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/headings" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/headings" sx={{fontWeight: 'bold'}}>
         Headings
       </Link>
       <Text as="p">
@@ -75,7 +75,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/links" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/links" sx={{fontWeight: 'bold'}}>
         Links
       </Link>
       <Text as="p">
@@ -83,7 +83,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/semantic-html" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/semantic-html" sx={{fontWeight: 'bold'}}>
         Semantic HTML
       </Link>
       <Text as="p">
@@ -91,7 +91,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/text-resize-and-respacing" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/text-resize-and-respacing" sx={{fontWeight: 'bold'}}>
         Text resize and respacing
       </Link>
       <Text as="p">
@@ -100,7 +100,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/guides/accessibility/tooltip-alternatives" sx={{fontWeight: 'bold'}}>
+      <Link href="/design/guides/accessibility/tooltip-alternatives" sx={{fontWeight: 'bold'}}>
         Tooltip alternatives
       </Link>
       <Text as="p">

--- a/content/guides/index.mdx
+++ b/content/guides/index.mdx
@@ -6,43 +6,43 @@ import {Box, Link, Text} from '@primer/react'
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
   <div>
-    <Link href="/guides/introduction" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/introduction" sx={{fontWeight: 'bold'}}>
       Introduction
     </Link>
     <Text as="p">Get started with the principles of Primer, standards, and recommendations for designing Github.</Text>
   </div>
   <div>
-    <Link href="/guides/content" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/content" sx={{fontWeight: 'bold'}}>
       Content
     </Link>
     <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
   </div>
     <div>
-    <Link href="/guides/zen" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/zen" sx={{fontWeight: 'bold'}}>
       Zen
     </Link>
     <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
   </div>
     <div>
-    <Link href="/guides/figma" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/figma" sx={{fontWeight: 'bold'}}>
       Figma
     </Link>
     <Text as="p">Getting started with Figma for GitHub.</Text>
   </div>
     <div>
-    <Link href="/guides/component-lifecycle" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/component-lifecycle" sx={{fontWeight: 'bold'}}>
       Component lifecycle
     </Link>
     <Text as="p">Milestones that summarize the maturity lifecycle of UI components in Primer.</Text>
   </div>
     <div>
-    <Link href="/guides/accessibility" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/accessibility" sx={{fontWeight: 'bold'}}>
       Accessibility
     </Link>
     <Text as="p">How to create accessible interfaces for GitHub.</Text>
   </div>
     <div>
-    <Link href="/guides/contribute" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/contribute" sx={{fontWeight: 'bold'}}>
       Contribute
     </Link>
     <Text as="p">How to contribute to Primer.</Text>

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -12,18 +12,18 @@ export default HeroLayout
     interfaces.
   </Text>
   <div>
+  <div>
+    <Link href="/design/guides" sx={{fontWeight: 'bold'}}>
+      Guides
+    </Link>
+    <Text as="p">Standards, guidelines, and tools to getting started with Primer.</Text>
+  </div>
     <Link href="/design/foundations" sx={{fontWeight: 'bold'}}>
       Foundations
     </Link>
     <Text as="p">
       The fundamental parts of the design system that underpin all GitHub interfaces, such as color and typography.
     </Text>
-  </div>
-  <div>
-    <Link href="/design/guides/accessibility" sx={{fontWeight: 'bold'}}>
-      Accessibility
-    </Link>
-    <Text as="p">Standards, guidelines, and tools to design accessible GitHub interfaces.</Text>
   </div>
   <div>
     <Link href="/design/ui-patterns" sx={{fontWeight: 'bold'}}>
@@ -36,12 +36,6 @@ export default HeroLayout
       Components
     </Link>
     <Text as="p">Design and usage guidelines for individual Primer components.</Text>
-  </div>
-  <div>
-    <Link href="/design/guides/figma" sx={{fontWeight: 'bold'}}>
-      Using Figma
-    </Link>
-    <Text as="p">A guide on how to get started using Figma to design interfaces at GitHub.</Text>
   </div>
 </Box>
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -20,7 +20,7 @@ export default HeroLayout
     </Text>
   </div>
   <div>
-    <Link href="/design/accessibility" sx={{fontWeight: 'bold'}}>
+    <Link href="/design/guides/accessibility" sx={{fontWeight: 'bold'}}>
       Accessibility
     </Link>
     <Text as="p">Standards, guidelines, and tools to design accessible GitHub interfaces.</Text>


### PR DESCRIPTION
The primer.style/design index page should reflect the correct top level sections:

- Guides
- Foundations
- UI patterns
- Components

*and (eventually) Native platforms

To do
- [x] Update the index page content to include those links
- [x] Fix top level links on /guides and /accessibility