### PR TITLE
Use markdown on index.js

### DIFF
--- a/content/components/anchored-overlay.mdx
+++ b/content/components/anchored-overlay.mdx
@@ -5,7 +5,7 @@ figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1552
 description: Anchored overlay opens an overlay relative to the anchor position.
 ---
 
-import {Box, Button, Heading, Link} from '@primer/react'
+import {Box, Button, Heading} from '@primer/react'
 
 ## Overview
 

--- a/content/components/checkbox.mdx
+++ b/content/components/checkbox.mdx
@@ -30,14 +30,13 @@ Checkboxes are capable of showing two forms of selection: checked (left) or inde
 />
 <Caption>The indeterminate state is colored in some browsers (e.g. Safari) and grey in others (e.g. Chrome).</Caption>
 
-
 ### Best practices
 
 - An individual checkbox or radio should not have its own validation message or style. For more information, see the [Validation Message](../ui-patterns/forms#validation) section in the Forms documentation.
 
 - An individual checkbox or radio button cannot be marked as required. For more information, see the [Required field indicator](../ui-patterns/forms/#required-field-indicator) in the Forms documentation.
 
-- A selection can be marked as required using a [checkbox group](/design/components/checkbox-group).
+- A selection can be marked as required using a [checkbox group](/components/checkbox-group).
 
 ## Related links
 

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -2,11 +2,12 @@
 title: Components
 ---
 
-import {Box, Link, Text} from '@primer/react'
+import {Box, Text} from '@primer/react'
+import {Link} from 'gatsby'
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
-    <Link href="/design/components/action-bar" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/action-bar" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/378023/188890108-a587272b-56fd-4833-9b4b-b79eece66643.png"
@@ -14,7 +15,7 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/action-bar" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/action-bar" sx={{fontWeight: 'bold'}}>
       Action bar
     </Link>
     <Text as="p">
@@ -23,7 +24,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/components/action-list" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/action-list" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png"
@@ -31,7 +32,7 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/action-list" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/action-list" sx={{fontWeight: 'bold'}}>
       Action list
     </Link>
     <Text as="p">
@@ -40,7 +41,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/components/autocomplete">
+    <Link href="/components/autocomplete">
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png"
@@ -48,7 +49,7 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/autocomplete" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/autocomplete" sx={{fontWeight: 'bold'}}>
       Autocomplete
     </Link>
     <Text as="p">
@@ -57,7 +58,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/components/comment-box" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/comment-box" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/378023/191678010-124e429a-4eed-4f68-980a-a0bbf0c4f907.png"
@@ -65,13 +66,13 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/comment-box" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/comment-box" sx={{fontWeight: 'bold'}}>
       Comment box
     </Link>
     <Text as="p">A comment box allows users to write and preview comments.</Text>
   </div>
   <div>
-    <Link href="/design/components/dialog" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/dialog" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png"
@@ -79,7 +80,7 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/dialog" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/dialog" sx={{fontWeight: 'bold'}}>
       Dialog
     </Link>
     <Text as="p">
@@ -88,7 +89,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/components/filter-input" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/filter-input" sx={{fontWeight: 'bold'}}>
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png"
@@ -96,13 +97,13 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/filter-input" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/filter-input" sx={{fontWeight: 'bold'}}>
       Filter input
     </Link>
     <Text as="p">A input that provides suggestions through qualifiers and highlights complex filter syntax.</Text>
   </div>
   <div>
-    <Link href="/design/components/toggle-switch">
+    <Link href="/components/toggle-switch">
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png"
@@ -110,13 +111,13 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/toggle-switch" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/toggle-switch" sx={{fontWeight: 'bold'}}>
       Toggle switch
     </Link>
     <Text as="p">A toggle switch is used to immediately toggle a setting on or off.</Text>
   </div>
   <div>
-    <Link href="/design/components/tokens">
+    <Link href="/components/tokens">
       <img
         role="presentation"
         src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png"
@@ -124,7 +125,7 @@ import {Box, Link, Text} from '@primer/react'
     </Link>
   </div>
   <div>
-    <Link href="/design/components/tokens" sx={{fontWeight: 'bold'}}>
+    <Link href="/components/tokens" sx={{fontWeight: 'bold'}}>
       Tokens
     </Link>
     <Text as="p">

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -7,7 +7,7 @@ import {Box} from '@primer/react'
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
 
-[![](https://user-images.githubusercontent.com/378023/188890108-a587272b-56fd-4833-9b4b-b79eece66643.png)](/components/action-bar)
+[![''](https://user-images.githubusercontent.com/378023/188890108-a587272b-56fd-4833-9b4b-b79eece66643.png)](/components/action-bar)
 
   </div>
   <div>
@@ -19,7 +19,7 @@ An action bar contains a collection of horizontally aligned icon buttons. When t
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png)](/components/action-list)
+[![''](https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png)](/components/action-list)
 
   </div>
   <div>
@@ -31,7 +31,7 @@ An action list is a vertical list of interactive actions or options. It’s comp
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png)](/components/autocomplete)
+[![''](https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png)](/components/autocomplete)
 
   </div>
   <div>
@@ -43,7 +43,7 @@ Autocomplete inputs allow users to quickly filter through a list of options to p
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/378023/191678010-124e429a-4eed-4f68-980a-a0bbf0c4f907.png)](/components/comment-box)
+[![''](https://user-images.githubusercontent.com/378023/191678010-124e429a-4eed-4f68-980a-a0bbf0c4f907.png)](/components/comment-box)
 
   </div>
   <div>
@@ -55,7 +55,7 @@ A comment box allows users to write and preview comments.
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png)](/components/dialog)
+[![''](https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png)](/components/dialog)
 
   </div>
   <div>
@@ -67,7 +67,7 @@ A Dialog is a floating surface used to display transient content such as confirm
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png)](/components/filter-input)
+[![''](https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png)](/components/filter-input)
 
   </div>
   <div>
@@ -79,7 +79,7 @@ A input that provides suggestions through qualifiers and highlights complex filt
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png)](/components/toggle-switch)
+[![''](https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png)](/components/toggle-switch)
 
   </div>
   <div>
@@ -91,7 +91,7 @@ A toggle switch is used to immediately toggle a setting on or off.
   </div>
   <div>
 
-[![](https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png)](/components/tokens)
+[![''](https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png)](/components/tokens)
 
   </div>
   <div>

--- a/content/components/index.mdx
+++ b/content/components/index.mdx
@@ -2,134 +2,103 @@
 title: Components
 ---
 
-import {Box, Text} from '@primer/react'
-import {Link} from 'gatsby'
+import {Box} from '@primer/react'
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 2fr']} gridGap={4}>
   <div>
-    <Link href="/components/action-bar" sx={{fontWeight: 'bold'}}>
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/378023/188890108-a587272b-56fd-4833-9b4b-b79eece66643.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/378023/188890108-a587272b-56fd-4833-9b4b-b79eece66643.png)](/components/action-bar)
+
   </div>
   <div>
-    <Link href="/components/action-bar" sx={{fontWeight: 'bold'}}>
-      Action bar
-    </Link>
-    <Text as="p">
-      An action bar contains a collection of horizontally aligned icon buttons. When there is not enough space, icon
-      buttons that don't fit will be added to an overflow menu.
-    </Text>
+
+#### [Action bar](/components/action-bar)
+
+An action bar contains a collection of horizontally aligned icon buttons. When there is not enough space, icon buttons that don't fit will be added to an overflow menu.
+
   </div>
   <div>
-    <Link href="/components/action-list" sx={{fontWeight: 'bold'}}>
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/293280/123880841-54bb9280-d8f8-11eb-9a6f-4c33c8196fbf.png)](/components/action-list)
+
   </div>
   <div>
-    <Link href="/components/action-list" sx={{fontWeight: 'bold'}}>
-      Action list
-    </Link>
-    <Text as="p">
-      An action list is a vertical list of interactive actions or options. It’s composed of items presented in a
-      consistent single-column format, with room for icons, descriptions, side information, and other rich visuals.
-    </Text>
+
+#### [Action list](/components/action-list)
+
+An action list is a vertical list of interactive actions or options. It’s composed of items presented in a consistent single-column format, with room for icons, descriptions, side information, and other rich visuals.
+
   </div>
   <div>
-    <Link href="/components/autocomplete">
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/2313998/138136338-046aa39b-51bc-4009-b465-b9d47500ee88.png)](/components/autocomplete)
+
   </div>
   <div>
-    <Link href="/components/autocomplete" sx={{fontWeight: 'bold'}}>
-      Autocomplete
-    </Link>
-    <Text as="p">
-      Autocomplete inputs allow users to quickly filter through a list of options to pick one or more values for a
-      field.
-    </Text>
+
+#### [Autocomplete](/components/autocomplete)
+
+Autocomplete inputs allow users to quickly filter through a list of options to pick one or more values for a field.
+
   </div>
   <div>
-    <Link href="/components/comment-box" sx={{fontWeight: 'bold'}}>
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/378023/191678010-124e429a-4eed-4f68-980a-a0bbf0c4f907.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/378023/191678010-124e429a-4eed-4f68-980a-a0bbf0c4f907.png)](/components/comment-box)
+
   </div>
   <div>
-    <Link href="/components/comment-box" sx={{fontWeight: 'bold'}}>
-      Comment box
-    </Link>
-    <Text as="p">A comment box allows users to write and preview comments.</Text>
+
+#### [Comment box](/components/comment-box)
+
+A comment box allows users to write and preview comments.
+
   </div>
   <div>
-    <Link href="/components/dialog" sx={{fontWeight: 'bold'}}>
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png)](/components/dialog)
+
   </div>
   <div>
-    <Link href="/components/dialog" sx={{fontWeight: 'bold'}}>
-      Dialog
-    </Link>
-    <Text as="p">
-      A Dialog is a floating surface used to display transient content such as confirmation actions, selection options,
-      and more.
-    </Text>
+
+#### [Dialog](/components/dialog)
+
+A Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and more.
+
   </div>
   <div>
-    <Link href="/components/filter-input" sx={{fontWeight: 'bold'}}>
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/18661030/187487523-49383638-cbf8-4b27-89f3-b9a288aebfe7.png)](/components/filter-input)
+
   </div>
   <div>
-    <Link href="/components/filter-input" sx={{fontWeight: 'bold'}}>
-      Filter input
-    </Link>
-    <Text as="p">A input that provides suggestions through qualifiers and highlights complex filter syntax.</Text>
+
+#### [Filter input](/components/filter-input)
+
+A input that provides suggestions through qualifiers and highlights complex filter syntax.
+
   </div>
   <div>
-    <Link href="/components/toggle-switch">
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/2313998/159758160-9d6b52ec-34f3-4fd8-b4ae-25b523dd3c0f.png)](/components/toggle-switch)
+
   </div>
   <div>
-    <Link href="/components/toggle-switch" sx={{fontWeight: 'bold'}}>
-      Toggle switch
-    </Link>
-    <Text as="p">A toggle switch is used to immediately toggle a setting on or off.</Text>
+
+#### [Toggle switch](/components/toggle-switch)
+
+A toggle switch is used to immediately toggle a setting on or off.
+
   </div>
   <div>
-    <Link href="/components/tokens">
-      <img
-        role="presentation"
-        src="https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png"
-      />
-    </Link>
+
+[![](https://user-images.githubusercontent.com/2313998/138136341-c85ccaf9-f83f-4933-9fde-9a7b9c630fe4.png)](/components/tokens)
+
   </div>
   <div>
-    <Link href="/components/tokens" sx={{fontWeight: 'bold'}}>
-      Tokens
-    </Link>
-    <Text as="p">
-      A token is a compact representation of an object, and is typically used to show a collection of related metadata.
-    </Text>
+
+#### [Tokens](/components/tokens)
+
+A token is a compact representation of an object, and is typically used to show a collection of related metadata.
+
   </div>
 </Box>

--- a/content/components/toggle-switch.mdx
+++ b/content/components/toggle-switch.mdx
@@ -6,6 +6,7 @@ rails: https://primer.style/view-components/components/alpha/toggleswitch
 ---
 
 import {Box} from '@primer/react'
+import {Link} from 'gatsby'
 
 ## Anatomy
 
@@ -142,8 +143,8 @@ import {Box} from '@primer/react'
   sx={{gap: 3}}
 >
   <Box as="p" mt="0">
-    The <a href="/design/ui-patterns/progressive-disclosure">progressive disclosure pattern</a> may be used to hide or show
-    content based on whether a toggle switch is on. Content revealed on toggle switch activation should always come{' '}
+    The <Link href="/ui-patterns/progressive-disclosure">progressive disclosure pattern</Link> may be used to hide or
+    show content based on whether a toggle switch is on. Content revealed on toggle switch activation should always come{' '}
     <em>after</em> the toggle switch.
   </Box>
   <img

--- a/content/components/toggle-switch.mdx
+++ b/content/components/toggle-switch.mdx
@@ -6,7 +6,6 @@ rails: https://primer.style/view-components/components/alpha/toggleswitch
 ---
 
 import {Box} from '@primer/react'
-import {Link} from 'gatsby'
 
 ## Anatomy
 
@@ -143,8 +142,8 @@ import {Link} from 'gatsby'
   sx={{gap: 3}}
 >
   <Box as="p" mt="0">
-    The <Link href="/ui-patterns/progressive-disclosure">progressive disclosure pattern</Link> may be used to hide or
-    show content based on whether a toggle switch is on. Content revealed on toggle switch activation should always come{' '}
+    The <a href="/ui-patterns/progressive-disclosure">progressive disclosure pattern</a> may be used to hide or show
+    content based on whether a toggle switch is on. Content revealed on toggle switch activation should always come{' '}
     <em>after</em> the toggle switch.
   </Box>
   <img

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -2,29 +2,30 @@
 title: Foundations
 ---
 
-import {Box, Link, Text} from '@primer/react'
+import {Box, Text} from '@primer/react'
+import {Link} from 'gatsby'
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
   <div>
-    <Link href="/design/foundations/introduction" sx={{fontWeight: 'bold'}}>
+    <Link href="/foundations/introduction" sx={{fontWeight: 'bold'}}>
       Introduction
     </Link>
     <Text as="p">Get started with the principles of Primer, standards, and recommendations for designing Github.</Text>
   </div>
   <div>
-    <Link href="/design/foundations/color" sx={{fontWeight: 'bold'}}>
+    <Link href="/foundations/color" sx={{fontWeight: 'bold'}}>
       Color
     </Link>
     <Text as="p">How to work with color modes and themes, and how to apply color to GitHub interfaces.</Text>
   </div>
   <div>
-    <Link href="/design/foundations/typography" sx={{fontWeight: 'bold'}}>
+    <Link href="/foundations/typography" sx={{fontWeight: 'bold'}}>
       Typography
     </Link>
     <Text as="p">How to use and apply typography to GitHub interfaces.</Text>
   </div>
   <div>
-    <Link href="/design/foundations/content" sx={{fontWeight: 'bold'}}>
+    <Link href="/foundations/content" sx={{fontWeight: 'bold'}}>
       Content
     </Link>
     <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>

--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -2,32 +2,18 @@
 title: Foundations
 ---
 
-import {Box, Text} from '@primer/react'
-import {Link} from 'gatsby'
+#### [Introduction](/foundations/introduction)
 
-<Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
-  <div>
-    <Link href="/foundations/introduction" sx={{fontWeight: 'bold'}}>
-      Introduction
-    </Link>
-    <Text as="p">Get started with the principles of Primer, standards, and recommendations for designing Github.</Text>
-  </div>
-  <div>
-    <Link href="/foundations/color" sx={{fontWeight: 'bold'}}>
-      Color
-    </Link>
-    <Text as="p">How to work with color modes and themes, and how to apply color to GitHub interfaces.</Text>
-  </div>
-  <div>
-    <Link href="/foundations/typography" sx={{fontWeight: 'bold'}}>
-      Typography
-    </Link>
-    <Text as="p">How to use and apply typography to GitHub interfaces.</Text>
-  </div>
-  <div>
-    <Link href="/foundations/content" sx={{fontWeight: 'bold'}}>
-      Content
-    </Link>
-    <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
-  </div>
-</Box>
+Get started with the principles of Primer, standards, and recommendations for designing Github.
+
+#### [Color](/foundations/color)
+
+How to work with color modes and themes, and how to apply color to GitHub interfaces.
+
+#### [Typography](/foundations/typography)
+
+How to use and apply typography to GitHub interfaces.
+
+#### [Content](/foundations/content)
+
+How to create interfaces that follow GitHub's content guidelines.

--- a/content/guides/accessibility/index.mdx
+++ b/content/guides/accessibility/index.mdx
@@ -2,7 +2,7 @@
 title: Accessibility
 ---
 
-## General
+### General
 
 #### [Accessibility at GitHub](/guides/accessibility/accessibility-at-github)
 
@@ -16,7 +16,7 @@ Basic guidelines for designers when creating or updating features.
 
 Tools to help you design accessible interfaces.
 
-## Specific
+### Specific
 
 #### [Alternative text for images](/guides/accessibility/alternative-text-for-images)
 

--- a/content/guides/accessibility/index.mdx
+++ b/content/guides/accessibility/index.mdx
@@ -2,25 +2,26 @@
 title: Accessibility
 ---
 
-import {Box, Link, Text, Label} from '@primer/react'
+import {Box, Text, Label} from '@primer/react'
+import {Link} from 'gatsby'
 
 <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
   <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
     <h2>General</h2>
     <div>
-      <Link href="/design/guides/accessibility/accessibility-at-github" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/accessibility-at-github" sx={{fontWeight: 'bold'}}>
         Accessibility at GitHub
       </Link>
       <Text as="p">Get started with accessibility at GitHub.</Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/guidelines" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/guidelines" sx={{fontWeight: 'bold'}}>
         Guidelines
       </Link>
       <Text as="p">Basic guidelines for designers when creating or updating features.</Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/tools" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/tools" sx={{fontWeight: 'bold'}}>
         Tools
       </Link>
       <Text as="p">A selection of tools to help designers create accessible designs.</Text>
@@ -29,7 +30,7 @@ import {Box, Link, Text, Label} from '@primer/react'
   <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
     <h2>Specific</h2>
     <div>
-      <Link href="/design/guides/accessibility/alternative-text-for-images" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/alternative-text-for-images" sx={{fontWeight: 'bold'}}>
         Alternative text for images
       </Link>
       <Text as="p">
@@ -38,7 +39,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/announcements" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/announcements" sx={{fontWeight: 'bold'}}>
         Assistive technology announcements
       </Link>
       <Text as="p">
@@ -48,7 +49,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/descriptive-buttons" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/descriptive-buttons" sx={{fontWeight: 'bold'}}>
         Descriptive buttons
       </Link>
       <Text as="p">
@@ -57,7 +58,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/focus-management" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/focus-management" sx={{fontWeight: 'bold'}}>
         Focus management
       </Link>
       <Text as="p">
@@ -66,7 +67,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/headings" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/headings" sx={{fontWeight: 'bold'}}>
         Headings
       </Link>
       <Text as="p">
@@ -75,7 +76,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/links" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/links" sx={{fontWeight: 'bold'}}>
         Links
       </Link>
       <Text as="p">
@@ -83,7 +84,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/semantic-html" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/semantic-html" sx={{fontWeight: 'bold'}}>
         Semantic HTML
       </Link>
       <Text as="p">
@@ -91,7 +92,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/text-resize-and-respacing" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/text-resize-and-respacing" sx={{fontWeight: 'bold'}}>
         Text resize and respacing
       </Link>
       <Text as="p">
@@ -100,7 +101,7 @@ import {Box, Link, Text, Label} from '@primer/react'
       </Text>
     </div>
     <div>
-      <Link href="/design/guides/accessibility/tooltip-alternatives" sx={{fontWeight: 'bold'}}>
+      <Link href="/guides/accessibility/tooltip-alternatives" sx={{fontWeight: 'bold'}}>
         Tooltip alternatives
       </Link>
       <Text as="p">

--- a/content/guides/accessibility/index.mdx
+++ b/content/guides/accessibility/index.mdx
@@ -2,111 +2,58 @@
 title: Accessibility
 ---
 
-import {Box, Text, Label} from '@primer/react'
-import {Link} from 'gatsby'
+## General
 
-<Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
-  <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
-    <h2>General</h2>
-    <div>
-      <Link href="/guides/accessibility/accessibility-at-github" sx={{fontWeight: 'bold'}}>
-        Accessibility at GitHub
-      </Link>
-      <Text as="p">Get started with accessibility at GitHub.</Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/guidelines" sx={{fontWeight: 'bold'}}>
-        Guidelines
-      </Link>
-      <Text as="p">Basic guidelines for designers when creating or updating features.</Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/tools" sx={{fontWeight: 'bold'}}>
-        Tools
-      </Link>
-      <Text as="p">A selection of tools to help designers create accessible designs.</Text>
-    </div>
-  </Box>
-  <Box display="grid" gridTemplateColumns="1fr" gridGap={4}>
-    <h2>Specific</h2>
-    <div>
-      <Link href="/guides/accessibility/alternative-text-for-images" sx={{fontWeight: 'bold'}}>
-        Alternative text for images
-      </Link>
-      <Text as="p">
-        Alternative text on images allows assistive technology like screen readers to understand the purpose of an image
-        on a page or allow them to skip it if purely decorative.{' '}
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/announcements" sx={{fontWeight: 'bold'}}>
-        Assistive technology announcements
-      </Link>
-      <Text as="p">
-        Events like toasts and status messages are visually communicated to GitHub users. Making sure those
-        announcements are read via assistive technology allows users with low or no vision to get that status
-        information.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/descriptive-buttons" sx={{fontWeight: 'bold'}}>
-        Descriptive buttons
-      </Link>
-      <Text as="p">
-        Labeling buttons properly let's users know what will happen when they activate the control, lessens errors, and
-        increases confidence.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/focus-management" sx={{fontWeight: 'bold'}}>
-        Focus management
-      </Link>
-      <Text as="p">
-        Managing focus within a page or application is essential for users to successfully navigate, complete actions,
-        and understand where they are.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/headings" sx={{fontWeight: 'bold'}}>
-        Headings
-      </Link>
-      <Text as="p">
-        Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to
-        create an accessible hierarchy in your pages.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/links" sx={{fontWeight: 'bold'}}>
-        Links
-      </Link>
-      <Text as="p">
-        Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/semantic-html" sx={{fontWeight: 'bold'}}>
-        Semantic HTML
-      </Link>
-      <Text as="p">
-        Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/text-resize-and-respacing" sx={{fontWeight: 'bold'}}>
-        Text resize and respacing
-      </Link>
-      <Text as="p">
-        People on the web should be able to resize text to improve legibility without blocking or obscuring any other
-        part of the UI.
-      </Text>
-    </div>
-    <div>
-      <Link href="/guides/accessibility/tooltip-alternatives" sx={{fontWeight: 'bold'}}>
-        Tooltip alternatives
-      </Link>
-      <Text as="p">
-        Most UI cases don't call for tooltips. Learn some alternative methods to use in place of tooltips.
-      </Text>
-    </div>
-  </Box>
-</Box>
+#### [Accessibility at GitHub](/guides/accessibility/accessibility-at-github)
+
+Get started with accessibility at GitHub.
+
+#### [Guidelines](/guides/accessibility/guidelines)
+
+Basic guidelines for designers when creating or updating features.
+
+#### [Tools](/guides/accessibility/tools)
+
+Tools to help you design accessible interfaces.
+
+## Specific
+
+#### [Alternative text for images](/guides/accessibility/alternative-text-for-images)
+
+Alternative text on images allows assistive technology like screen readers to understand the purpose of an image on a page or allow them to skip it if purely decorative.
+
+#### [Assistive technology announcements](/guides/accessibility/announcements)
+
+Events like toasts and status messages are visually communicated to GitHub users. Making sure those announcements are read via assistive technology allows users with low or no vision to get that status information.
+
+#### [DesDescriptive buttons](/guides/accessibility/descriptive-buttons)
+
+Labeling buttons properly let's users know what will happen when they activate the control, lessens errors, and
+increases confidence.
+
+#### [Focus management](/guides/accessibility/focus-management)
+
+Managing focus within a page or application is essential for users to successfully navigate, complete actions,
+and understand where they are.
+
+#### [Headings](/guides/accessibility/headings)
+
+Headings play a critical role in communicating the structure of a page. Find out why they're critical and how to
+create an accessible hierarchy in your pages.
+
+#### [Links](/guides/accessibility/links)
+
+Links help us navigate a website. Learn how to style links appropriately to keep them usable by all.
+
+#### [Semantic HTML](/guides/accessibility/semantic-html)
+
+Understand when and how to use semantic HTML to improve the experience of the largest number of users possible.
+
+#### [Text resize and respacing](/guides/accessibility/text-resize-and-respacing)
+
+People on the web should be able to resize text to improve legibility without blocking or obscuring any other
+part of the UI.
+
+#### [Tooltip alternatives](/guides/accessibility/tooltip-alternatives)
+
+Most UI cases don't call for tooltips. Learn some alternative methods to use in place of tooltips.

--- a/content/guides/index.mdx
+++ b/content/guides/index.mdx
@@ -2,50 +2,30 @@
 title: Guides
 ---
 
-import {Box, Text} from '@primer/react'
-import {Link} from 'gatsby'
+#### [Introduction](/guides/introduction)
 
-<Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
-  <div>
-    <Link href="/guides/introduction" sx={{fontWeight: 'bold'}}>
-      Introduction
-    </Link>
-    <Text as="p">Get started with the principles of Primer, standards, and recommendations for designing Github.</Text>
-  </div>
-  <div>
-    <Link href="/guides/content" sx={{fontWeight: 'bold'}}>
-      Content
-    </Link>
-    <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
-  </div>
-  <div>
-    <Link href="/guides/zen" sx={{fontWeight: 'bold'}}>
-      Zen
-    </Link>
-    <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
-  </div>
-  <div>
-    <Link href="/guides/figma" sx={{fontWeight: 'bold'}}>
-      Figma
-    </Link>
-    <Text as="p">Getting started with Figma for GitHub.</Text>
-  </div>
-  <div>
-    <Link href="/guides/component-lifecycle" sx={{fontWeight: 'bold'}}>
-      Component lifecycle
-    </Link>
-    <Text as="p">Milestones that summarize the maturity lifecycle of UI components in Primer.</Text>
-  </div>
-  <div>
-    <Link href="/guides/accessibility" sx={{fontWeight: 'bold'}}>
-      Accessibility
-    </Link>
-    <Text as="p">How to create accessible interfaces for GitHub.</Text>
-  </div>
-  <div>
-    <Link href="/guides/contribute" sx={{fontWeight: 'bold'}}>
-      Contribute
-    </Link>
-    <Text as="p">How to contribute to Primer.</Text>
-  </div>
-</Box>
+Get started with the principles of Primer, standards, and recommendations for designing Github.
+
+#### [Content](/guides/content)
+
+How to create interfaces that follow GitHub's content guidelines.
+
+#### [Zen](/guides/zen)
+
+How to create interfaces that follow GitHub's content guidelines.
+
+#### [Figma](/guides/figma)
+
+Getting started with Figma for GitHub.
+
+#### [Component lifecycle](/guides/component-lifecycle)
+
+Milestones that summarize the maturity lifecycle of UI components in Primer.
+
+#### [Accessibility](/guides/accessibility)
+
+How to create accessible interfaces for GitHub.
+
+#### [Contribute](/guides/contribute)
+
+How to contribute to Primer.

--- a/content/guides/index.mdx
+++ b/content/guides/index.mdx
@@ -2,47 +2,48 @@
 title: Guides
 ---
 
-import {Box, Link, Text} from '@primer/react'
+import {Box, Text} from '@primer/react'
+import {Link} from 'gatsby'
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
   <div>
-    <Link href="/design/guides/introduction" sx={{fontWeight: 'bold'}}>
+    <Link href="/guides/introduction" sx={{fontWeight: 'bold'}}>
       Introduction
     </Link>
     <Text as="p">Get started with the principles of Primer, standards, and recommendations for designing Github.</Text>
   </div>
   <div>
-    <Link href="/design/guides/content" sx={{fontWeight: 'bold'}}>
+    <Link href="/guides/content" sx={{fontWeight: 'bold'}}>
       Content
     </Link>
     <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
   </div>
-    <div>
-    <Link href="/design/guides/zen" sx={{fontWeight: 'bold'}}>
+  <div>
+    <Link href="/guides/zen" sx={{fontWeight: 'bold'}}>
       Zen
     </Link>
     <Text as="p">How to create interfaces that follow GitHub's content guidelines.</Text>
   </div>
-    <div>
-    <Link href="/design/guides/figma" sx={{fontWeight: 'bold'}}>
+  <div>
+    <Link href="/guides/figma" sx={{fontWeight: 'bold'}}>
       Figma
     </Link>
     <Text as="p">Getting started with Figma for GitHub.</Text>
   </div>
-    <div>
-    <Link href="/design/guides/component-lifecycle" sx={{fontWeight: 'bold'}}>
+  <div>
+    <Link href="/guides/component-lifecycle" sx={{fontWeight: 'bold'}}>
       Component lifecycle
     </Link>
     <Text as="p">Milestones that summarize the maturity lifecycle of UI components in Primer.</Text>
   </div>
-    <div>
-    <Link href="/design/guides/accessibility" sx={{fontWeight: 'bold'}}>
+  <div>
+    <Link href="/guides/accessibility" sx={{fontWeight: 'bold'}}>
       Accessibility
     </Link>
     <Text as="p">How to create accessible interfaces for GitHub.</Text>
   </div>
-    <div>
-    <Link href="/design/guides/contribute" sx={{fontWeight: 'bold'}}>
+  <div>
+    <Link href="/guides/contribute" sx={{fontWeight: 'bold'}}>
       Contribute
     </Link>
     <Text as="p">How to contribute to Primer.</Text>

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -3,7 +3,8 @@ title: Interface guidelines
 ---
 
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
-import {Box, Link, Text, Label} from '@primer/react'
+import {Box, Text, Label} from '@primer/react'
+import {Link} from 'gatsby'
 export default HeroLayout
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
@@ -12,13 +13,13 @@ export default HeroLayout
     interfaces.
   </Text>
   <div>
-  <div>
-    <Link href="/design/guides" sx={{fontWeight: 'bold'}}>
-      Guides
-    </Link>
-    <Text as="p">Standards, guidelines, and tools to getting started with Primer.</Text>
-  </div>
-    <Link href="/design/foundations" sx={{fontWeight: 'bold'}}>
+    <div>
+      <Link href="/guides" sx={{fontWeight: 'bold'}}>
+        Guides
+      </Link>
+      <Text as="p">Standards, guidelines, and tools to getting started with Primer.</Text>
+    </div>
+    <Link href="/foundations" sx={{fontWeight: 'bold'}}>
       Foundations
     </Link>
     <Text as="p">
@@ -26,13 +27,13 @@ export default HeroLayout
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns" sx={{fontWeight: 'bold'}}>
       UI patterns
     </Link>
     <Text as="p">Design guidelines covering common user workflows.</Text>
   </div>
   <div>
-    <Link href="/design/components" sx={{fontWeight: 'bold'}}>
+    <Link href="/components" sx={{fontWeight: 'bold'}}>
       Components
     </Link>
     <Text as="p">Design and usage guidelines for individual Primer components.</Text>
@@ -41,6 +42,6 @@ export default HeroLayout
 
 ## Need help?
 
-If you found a bug on this website, please [open a new issue](https://github.com/primer/design/issues/new) with as much detail as possible, including steps to replicate the bug, screenshots, links, and expected results.
+If you found a bug on this website, please [open a new issue](https://github.com/primer/issues/new) with as much detail as possible, including steps to replicate the bug, screenshots, links, and expected results.
 
 If you need help using and designing with Primer, and you are GitHub staff, please visit the #primer Slack channel.

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -3,42 +3,26 @@ title: Interface guidelines
 ---
 
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
-import {Box, Text, Label} from '@primer/react'
-import {Link} from 'gatsby'
 export default HeroLayout
 
-<Box display="grid" gridTemplateColumns={['1fr', null, null, null]} gridGap={4}>
-  <Text>
-    Primer's interface guidelines are a collection of principles, standards, and usage guidelines for designing GitHub
-    interfaces.
-  </Text>
-  <div>
-    <div>
-      <Link href="/guides" sx={{fontWeight: 'bold'}}>
-        Guides
-      </Link>
-      <Text as="p">Standards, guidelines, and tools to getting started with Primer.</Text>
-    </div>
-    <Link href="/foundations" sx={{fontWeight: 'bold'}}>
-      Foundations
-    </Link>
-    <Text as="p">
-      The fundamental parts of the design system that underpin all GitHub interfaces, such as color and typography.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns" sx={{fontWeight: 'bold'}}>
-      UI patterns
-    </Link>
-    <Text as="p">Design guidelines covering common user workflows.</Text>
-  </div>
-  <div>
-    <Link href="/components" sx={{fontWeight: 'bold'}}>
-      Components
-    </Link>
-    <Text as="p">Design and usage guidelines for individual Primer components.</Text>
-  </div>
-</Box>
+Primer's interface guidelines are a collection of principles, standards, and usage guidelines for designing GitHub
+interfaces.
+
+#### [Guides](/guides)
+
+Standards, guidelines, and tools to getting started with Primer.
+
+#### [Foundations](/foundations)
+
+The fundamental parts of the design system that underpin all GitHub interfaces, such as color and typography.
+
+#### [UI patterns](/ui-patterns)
+
+Design guidelines covering common user workflows.
+
+#### [Components](/components)
+
+Design and usage guidelines for individual Primer components.
 
 ## Need help?
 

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -2,11 +2,12 @@
 title: UI patterns
 ---
 
-import {Box, Link, Text} from '@primer/react'
+import {Box, Text} from '@primer/react'
+import {Link} from 'gatsby'
 
 <Box display="grid" gridGap={4}>
   <div>
-    <Link href="/design/ui-patterns/button-usage" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/button-usage" sx={{fontWeight: 'bold'}}>
       Button usage
     </Link>
     <Text as="p">
@@ -15,7 +16,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns/empty-states" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/empty-states" sx={{fontWeight: 'bold'}}>
       Empty states
     </Link>
     <Text as="p">
@@ -25,7 +26,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns/feature-onboarding" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/feature-onboarding" sx={{fontWeight: 'bold'}}>
       Feature onboarding
     </Link>
     <Text as="p">
@@ -35,7 +36,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns/forms" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/forms" sx={{fontWeight: 'bold'}}>
       Forms
     </Link>
     <Text as="p">
@@ -44,7 +45,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns/messaging" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/messaging" sx={{fontWeight: 'bold'}}>
       Messaging
     </Link>
     <Text as="p">
@@ -54,7 +55,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns/progressive-disclosure" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/progressive-disclosure" sx={{fontWeight: 'bold'}}>
       Progressive disclosure
     </Link>
     <Text as="p">
@@ -63,7 +64,7 @@ import {Box, Link, Text} from '@primer/react'
     </Text>
   </div>
   <div>
-    <Link href="/design/ui-patterns/saving" sx={{fontWeight: 'bold'}}>
+    <Link href="/ui-patterns/saving" sx={{fontWeight: 'bold'}}>
       Saving
     </Link>
     <Text as="p">

--- a/content/ui-patterns/index.mdx
+++ b/content/ui-patterns/index.mdx
@@ -2,74 +2,35 @@
 title: UI patterns
 ---
 
-import {Box, Text} from '@primer/react'
-import {Link} from 'gatsby'
+#### [Button usage](/ui-patterns/button-usage)
 
-<Box display="grid" gridGap={4}>
-  <div>
-    <Link href="/ui-patterns/button-usage" sx={{fontWeight: 'bold'}}>
-      Button usage
-    </Link>
-    <Text as="p">
-      Buttons are a fundamental building block of the GitHub UI. These guidelines summarize how to use buttons across
-      the product.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns/empty-states" sx={{fontWeight: 'bold'}}>
-      Empty states
-    </Link>
-    <Text as="p">
-      Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature
-      of the feature. These guidelines demonstrate best practices for using the blankslate component and designing empty
-      states.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns/feature-onboarding" sx={{fontWeight: 'bold'}}>
-      Feature onboarding
-    </Link>
-    <Text as="p">
-      Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for
-      designing onboarding for the product and does not include what to do for marketing pages, email announcements,
-      social media, etc.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns/forms" sx={{fontWeight: 'bold'}}>
-      Forms
-    </Link>
-    <Text as="p">
-      Forms are used to complete tasks that require data input from the user. These guidelines aim to minimize the
-      effort and cognitive load required to complete a task that involves a form.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns/messaging" sx={{fontWeight: 'bold'}}>
-      Messaging
-    </Link>
-    <Text as="p">
-      Messaging components are used to provide important and relevant information to the user, including feedback,
-      contextual information, product updates, and more. Primer includes three different messaging components: toasts,
-      flash alerts, popovers.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns/progressive-disclosure" sx={{fontWeight: 'bold'}}>
-      Progressive disclosure
-    </Link>
-    <Text as="p">
-      These guidelines summarize how to use progressive disclosure, as well as guiding principles, best practices, and
-      implementation support.
-    </Text>
-  </div>
-  <div>
-    <Link href="/ui-patterns/saving" sx={{fontWeight: 'bold'}}>
-      Saving
-    </Link>
-    <Text as="p">
-      Saving and submitting data is critical to task completion. Use these guidelines to ensure your workflows are
-      consistent and accessible.
-    </Text>
-  </div>
-</Box>
+Buttons are a fundamental building block of the GitHub UI. These guidelines summarize how to use buttons across the product.
+
+#### [Dates and times](/ui-patterns/dates-and-times)
+
+Dates and times are used to provide context and information about when something happened or will happen. These guidelines summarize how to use dates and times across the product.
+
+#### [Empty states](/ui-patterns/empty-states)
+
+Empty states are used to fill spaces when no content has been added yet, or is temporarily empty due to the nature of the feature. These guidelines demonstrate best practices for using the blankslate component and designing empty states.
+
+#### [Feature onboarding](/ui-patterns/feature-onboarding)
+
+Onboarding is a virtual unboxing experience that helps users get started with a feature. This is a guide for designing onboarding for the product and does not include what to do for marketing pages, email announcements, social media, etc.
+
+#### [Forms](/ui-patterns/forms)
+
+Forms are used to complete tasks that require data input from the user. These guidelines aim to minimize the effort and cognitive load required to complete a task that involves a form.
+
+#### [Messaging](/ui-patterns/messaging)
+
+Messaging components are used to provide important and relevant information to the user, including feedback, contextual information, product updates, and more. Primer includes three different messaging components: toasts, flash alerts, popovers.
+
+#### [Progressive disclosure](/ui-patterns/progressive-disclosure)
+
+These guidelines summarize how to use progressive disclosure, as well as guiding principles, best practices, and implementation support.
+
+#### [Saving](/ui-patterns/saving)
+
+Saving and submitting data is critical to task completion. Use these guidelines to ensure your workflows are
+consistent and accessible.


### PR DESCRIPTION
Remove the `Text` and `Link` components from index files in favor of plain markdown language. This simplifies the code and outputs the same documentation styles for links, headings, and body text.

Related comment: https://github.com/primer/design/pull/370#discussion_r1089230569 

