### PR TITLE
Copy content from primer.style/cli → primer.style/design

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This is currently a work in progress! Follow along on our [project board](https:
    git clone https://github.com/primer/design
    ```
 
-1. In the terminal, navigate (`cd`) to the repo directory
-1. `nvm use --default` to use the correct node version.
-1. `yarn` to install dependencies
-1. `yarn start` to start the dev server
+2. In the terminal, navigate (`cd`) to the repo directory
+3. `nvm use --default` to use the correct node version.
+4. `yarn` to install dependencies
+5. `yarn start` to start the dev server
 
 ## Deployment
 

--- a/content/native/cli/components.mdx
+++ b/content/native/cli/components.mdx
@@ -1,5 +1,6 @@
 ---
 title: Components
+description: Design guidance on how we format content in in the Terminal through text formatting, color and font weights.
 ---
 
 import {DoDontContainer, Do, Dont, Caption} from '@primer/gatsby-theme-doctocat'

--- a/content/native/cli/components.mdx
+++ b/content/native/cli/components.mdx
@@ -44,7 +44,7 @@ Use consistent syntax in [help pages](https://github.com/cli/cli/blob/trunk/docs
 
 Use plain text for parts of the command that cannot be changed
 
-```
+```bash
 gh help
 ```
 
@@ -54,7 +54,7 @@ gh help
 
 Use angled brackets to represent a value the user must replace. No other expressions can be contained within the angled brackets.
 
-```
+```bash
 gh pr view <issue-number>
 ```
 
@@ -64,13 +64,13 @@ gh pr view <issue-number>
 
 Place optional arguments in square brackets. Mutually exclusive arguments can be included inside square brackets if they are separated with vertical bars.
 
-```
+```bash
 gh pr checkout [--web]
 ```
 
 <Caption>The argument `--web` is optional.</Caption>
 
-```
+```bash
 gh pr view [<number> | <url>]
 ```
 
@@ -80,7 +80,7 @@ gh pr view [<number> | <url>]
 
 Place required mutually exclusive arguments inside braces, separate arguments with vertical bars.
 
-```
+```bash
 gh pr {view | create}
 ```
 
@@ -88,7 +88,7 @@ gh pr {view | create}
 
 Ellipsis represent arguments that can appear multiple times
 
-```
+```bash
 gh pr close <pr-number>...
 ```
 
@@ -96,7 +96,7 @@ gh pr close <pr-number>...
 
 For multi-word variables use dash-case (all lower case with words separated by dashes)
 
-```
+```bash
 gh pr checkout <issue-number>
 ```
 
@@ -104,19 +104,19 @@ gh pr checkout <issue-number>
 
 Optional argument with placeholder:
 
-```
+```bash
 <command> <subcommand> [<arg>]
 ```
 
 Required argument with mutually exclusive options:
 
-```
+```bash
 <command> <subcommand> {<path> | <string> | literal}
 ```
 
 Optional argument with mutually exclusive options:
 
-```
+```bash
 <command> <subcommand> [<path> | <string>]
 ```
 

--- a/content/native/cli/components.mdx
+++ b/content/native/cli/components.mdx
@@ -175,7 +175,7 @@ Use to select multiple options
 
 ## State
 
-The CLI reflects how GitHub.com displays state through [color](#color) and [iconography](#iconography).
+The CLI reflects how GitHub.com displays state through [color](/native/cli/foundations#color) and [iconographhy](/native/cli/foundations#iconography).
 
 <img
   src="https://user-images.githubusercontent.com/980622/215497462-02b78963-a977-4801-aef1-c693787aca62.png"

--- a/content/native/cli/components.mdx
+++ b/content/native/cli/components.mdx
@@ -1,0 +1,282 @@
+---
+title: Components
+---
+
+import {DoDontContainer, Do, Dont, Caption} from '@primer/gatsby-theme-doctocat'
+
+## Syntax
+
+We show meaning or objects through syntax such as angled brackets, square brackets, curly brackets, parenthesis, and color.
+
+### Branches
+
+Display branch names in brackets and/or cyan
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497467-7cf94a73-4b35-4352-81a4-a6c00d1f3486.png"
+  alt="A branch name in brackets and cyan"
+/>
+
+### Labels
+
+Display labels in parenthesis and/or gray
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497505-182904ee-019e-41c9-825f-cf21ecbabdfb.png"
+  alt="A label name in parenthesis and gray"
+/>
+
+### Repository
+
+Display repository names in bold where appropriate
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497508-3d5f1879-54f0-4c8f-9156-9143e35eec3a.png"
+  alt="A repository name in bold"
+/>
+
+### Help
+
+Use consistent syntax in [help pages](https://github.com/cli/cli/blob/trunk/docs/command-line-syntax.md) to explain command usage.
+
+#### Literal text
+
+Use plain text for parts of the command that cannot be changed
+
+```
+gh help
+```
+
+<Caption>The argument help is required in this command</Caption>
+
+#### Placeholder values
+
+Use angled brackets to represent a value the user must replace. No other expressions can be contained within the angled brackets.
+
+```
+gh pr view <issue-number>
+```
+
+<Caption>Replace "issue-number" with an issue number</Caption>
+
+#### Optional arguments
+
+Place optional arguments in square brackets. Mutually exclusive arguments can be included inside square brackets if they are separated with vertical bars.
+
+```
+gh pr checkout [--web]
+```
+
+<Caption>The argument `--web` is optional.</Caption>
+
+```
+gh pr view [<number> | <url>]
+```
+
+<Caption>The "number" and "url" arguments are optional.</Caption>
+
+#### Required mutually exclusive arguments
+
+Place required mutually exclusive arguments inside braces, separate arguments with vertical bars.
+
+```
+gh pr {view | create}
+```
+
+#### Repeatable arguments
+
+Ellipsis represent arguments that can appear multiple times
+
+```
+gh pr close <pr-number>...
+```
+
+#### Variable naming
+
+For multi-word variables use dash-case (all lower case with words separated by dashes)
+
+```
+gh pr checkout <issue-number>
+```
+
+#### Additional examples
+
+Optional argument with placeholder:
+
+```
+<command> <subcommand> [<arg>]
+```
+
+Required argument with mutually exclusive options:
+
+```
+<command> <subcommand> {<path> | <string> | literal}
+```
+
+Optional argument with mutually exclusive options:
+
+```
+<command> <subcommand> [<path> | <string>]
+```
+
+## Prompts
+
+Generally speaking, prompts are the CLI’s version of forms.
+
+- Use prompts for entering information
+- Use a prompt when user intent is unclear
+- Make sure to provide flags for all prompts
+
+### Yes/No
+
+Use for yes/no questions, usually a confirmation. The default (what will happen if you enter nothing and hit enter) is in caps.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497458-36deca06-477d-47e6-8656-d83b71edbe82.png"
+  alt="An example of a yes/no prompt."
+/>
+
+### Short text
+
+Use to enter short strings of text. Enter will accept the auto fill if available
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497453-0d3fc9a0-96e7-4285-8a28-464abad66ad6.png"
+  alt="An example of a short text prompt."
+/>
+
+### Long text
+
+Use to enter large bodies of text. E key will open the user’s preferred editor, and Enter will skip.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497445-4397c8e2-5900-4863-b5f7-bb6ceaba34d8.png"
+  alt="An example of a long text prompt."
+/>
+
+### Radio select
+
+Use to select one option
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497450-589acfd9-f1a4-45da-a9e3-146cc48452a4.png"
+  alt="An example of a radio select prompt"
+/>
+
+### Multi select
+
+Use to select multiple options
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497447-5a6628d8-339a-479a-8a72-fea5ac78df2a.png"
+  alt="An example of a multi select prompt"
+/>
+
+## State
+
+The CLI reflects how GitHub.com displays state through [color](#color) and [iconography](#iconography).
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497462-02b78963-a977-4801-aef1-c693787aca62.png"
+  alt="A collection of examples of state from various command outputs"
+/>
+
+## Progress indicators
+
+For processes that might take a while, include a progress indicator with context on what’s happening.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497460-92b83be7-829a-4b78-adeb-f2d369f95a8a.png"
+  alt="An example of a loading spinner when forking a repository"
+/>
+
+## Headers
+
+When viewing output that could be unclear, headers can quickly set context for what the user is seeing and where they are.
+
+### Examples
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497394-b2ec59b2-5082-41ee-9ccb-2bbe80f21fe5.png"
+  alt="An example of the header of the gh pr create command"
+/>
+<Caption>
+  The header of the "gh pr create" command reassures the user that they're creating the correct pull request
+</Caption>
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497378-70bbe5b1-74dc-4b95-a329-c8f7e2908bae.png"
+  alt="An example of the header of the gh pr list command"
+/>
+<Caption>The header of the "gh pr list" command sets context for what list the user is seeing</Caption>
+
+## Lists
+
+Lists use tables to show information.
+
+- State is shown in color.
+- A header is used for context.
+- Information shown may be branch names, dates, or what is most relevant in context.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497378-70bbe5b1-74dc-4b95-a329-c8f7e2908bae.png"
+  alt="An example of gh pr list"
+/>
+
+## Detail views
+
+Single item views show more detail than list views. The body of the item is rendered indented. The item’s URL is shown at the bottom.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497374-4410111c-b2c9-4f04-8bab-1acd7bcd4135.png"
+  alt="An example of gh issue view"
+/>
+
+## Empty states
+
+Make sure to include empty messages in command outputs when appropriate.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497357-142ef375-ea50-4156-b00a-82f511935b11.png"
+  alt="The empty state of the gh pr status command"
+/>
+<Caption>The empty state of "gh pr status"</Caption>
+<img
+  src="https://user-images.githubusercontent.com/980622/215497363-b43175f4-9b3a-4ad8-8a1e-b9c3bf31e042.png"
+  alt="The empty state of the gh issue list command"
+/>
+<Caption>The empty state of "gh issue list"</Caption>
+
+## Help pages
+
+Help commands can exist at any level:
+
+- Top level (`gh`)
+- Second level (`gh [command]`)
+- Third level (`gh [command] [subcommand]`)
+
+Each can be accessed using the `--help` flag, or using `gh help [command]`.
+
+Each help page includes a combination of different sections.
+
+### Required sections
+
+- Usage
+- Core commands
+- Flags
+- Learn more
+- Inherited flags
+
+### Other available sections
+
+- Additional commands
+- Examples
+- Arguments
+- Feedback
+
+### Example
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497399-8a13ace4-d795-4014-ac23-5ecfd5eac237.png"
+  alt="The output of gh help"
+/>

--- a/content/native/cli/foundations.mdx
+++ b/content/native/cli/foundations.mdx
@@ -1,10 +1,9 @@
 ---
 title: Foundations
+description: Design concepts and constraints that can help create a better Terminal like experience for GitHub.
 ---
 
 import {DoDontContainer, Do, Dont, Caption} from '@primer/gatsby-theme-doctocat'
-
-These are the foundational design concepts and constraints that can help inform design decisions.
 
 ## Language
 
@@ -64,7 +63,7 @@ _Tip: To get a better sense of what feels right, try writing out the commands in
 
 **When designing your command’s language system:**
 
-- Use [GitHub language](/getting-started/principles#make-it-feel-like-github)
+- Use [GitHub language](/native/cli/getting-started#make-it-feel-like-github)
 - Use unambiguous language that can’t be confused for something else
 - Use shorter phrases if possible and appropriate
 
@@ -168,14 +167,14 @@ Terminals reliably recognize the 8 basic ANSI colors. There are also bright vers
 - Background color is available but we haven’t taken advantage of it yet.
 - Some terminals do not reliably support 256-color escape sequences.
 - Users can customize how their terminal displays the 8 basic colors, but that’s opt-in (for example, the user knows they’re making their greens not green).
-- Only use color to [enhance meaning](https://primer.style/design/accessibility/guidelines#use-of-color), not to communicate meaning.
+- Only use color to [enhance meaning](/components/icon#usage), not to communicate meaning.
 
 ## Iconography
 
 Since graphical image support in terminal emulators is unreliable, we rely on Unicode for iconography. When applying iconography consider:
 
 - People use different fonts that will have varying Unicode support
-- Only use iconography to [enhance meaning](https://primer.style/design/global/accessibility#visual-accessibility), not to communicate meaning
+- Only use iconography to [enhance meaning](/components/icon#usage), not to communicate meaning
 
 _Note: In Windows, Powershell’s default font (Lucida Console) has poor Unicode support. Microsoft suggests changing it for more Unicode support._
 

--- a/content/native/cli/foundations.mdx
+++ b/content/native/cli/foundations.mdx
@@ -180,7 +180,7 @@ _Note: In Windows, Powershell’s default font (Lucida Console) has poor Unicode
 
 **Symbols currently used:**
 
-```
+```bash
 ✓ 	Success
 - 	Neutral
 ✗   Failure

--- a/content/native/cli/foundations.mdx
+++ b/content/native/cli/foundations.mdx
@@ -1,0 +1,273 @@
+---
+title: Foundations
+---
+
+import {DoDontContainer, Do, Dont, Caption} from '@primer/gatsby-theme-doctocat'
+
+These are the foundational design concepts and constraints that can help inform design decisions.
+
+## Language
+
+Language is the most important tool at our disposal for creating a clear, understandable product. Having clear language helps us create memorable commands that are clear in what they will do.
+
+We generally follow this structure:
+
+| gh  | `<command>` | `<subcommand>` | [value] | [flags]   | [value] |
+| --- | ----------- | -------------- | ------- | --------- | ------- |
+| gh  | issue       | view           | 234     | --web     | -       |
+| gh  | pr          | create         | -       | --title   | “Title” |
+| gh  | repo        | fork           | cli/cli | --clone   | false   |
+| gh  | pr          | status         | -       | -         | -       |
+| gh  | issue       | list           | -       | --state   | closed  |
+| gh  | pr          | review         | 234     | --approve | -       |
+
+**Command:** The object you want to interact with
+
+**Subcommand:** The action you want to take on that object. Most `gh` commands contain a command and subcommand. These may take arguments, such as issue/PR numbers, URLs, file names, OWNER/REPO, etc.
+
+**Flag:** A way to modify the command, also may be called “options”. You can use multiple flags. Flags can take values, but don’t always. Flags always have a long version with two dashes `(--state)` but often also have a shortcut with one dash and one letter `(-s)`. It’s possible to chain shorthand flags: `-sfv` is the same as `-s -f -v`
+
+**Values:** Are passed to the commands or flags
+
+- The most common command values are:
+  - Issue or PR number
+  - The “owner/repo” pair
+  - URLs
+  - Branch names
+  - File names
+- The possible flag values depend on the flag:
+  - `--state` takes `{closed | open | merged}`
+  - `--clone` is a boolean flag
+  - `--title` takes a string
+  - `--limit` takes an integer
+
+_Tip: To get a better sense of what feels right, try writing out the commands in the CLI a few different ways._
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497420-8ab255c3-62b4-42d7-a126-028984471cb2.png"
+      width="100%"
+    />
+    <Caption>Use a flag for modifiers of actions</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497413-06bb4d3c-e543-45d1-99f4-9e2cfc218179.png"
+      width="100%"
+    />
+    <Caption>Avoid making modifiers their own commands</Caption>
+  </Dont>
+</DoDontContainer>
+
+**When designing your command’s language system:**
+
+- Use [GitHub language](/getting-started/principles#make-it-feel-like-github)
+- Use unambiguous language that can’t be confused for something else
+- Use shorter phrases if possible and appropriate
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497419-5b3785c7-5360-4553-975d-27c492feb5d9.png"
+      width="100%"
+    />
+    <Caption>Use language that can't be misconstrued</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497411-0d5c778e-e03a-49da-9628-d0d34d11c4ec.png"
+      width="100%"
+    />
+    <Caption>
+      Avoid language that can be interpreted in multiple ways ("open in browser" or "open a pull request" here)
+    </Caption>
+  </Dont>
+</DoDontContainer>
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497417-c8e5d51c-9280-4cae-9b4b-6a3f70b88786.png"
+      width="100%"
+    />
+    <Caption>Use understood shorthands to save characters to type</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497409-678c95f4-0c47-41ac-b81b-f1cadfe69516.png"
+      width="100%"
+    />
+    <Caption>Avoid long words in commands if there's a reasonable alternative</Caption>
+  </Dont>
+</DoDontContainer>
+
+## Typography
+
+Everything in a command line interface is text, so type hierarchy is important. All type is the same size and font, but you can still create type hierarchy using font weight and space.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497511-7162553d-a1a7-4703-a640-b349ba06e7bf.png"
+  alt="An example of normal weight, and bold weight. Italics is striked through since it's not used."
+/>
+
+- People customize their fonts, but you can assume it will be a monospace
+- Monospace fonts inherently create visual order
+- Fonts may have variable unicode support
+
+### Accessibility
+
+If you want to ensure that a screen reader will read a pause, you can use a:
+
+- period (`.`)
+- comma (`,`)
+- colon (`:`)
+
+## Spacing
+
+You can use the following to create hierarchy and visual rhythm:
+
+- Line breaks
+- Tables
+- Indentation
+
+<DoDontContainer stacked>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497385-27dc586e-92c9-414f-9b19-92688f096119.png"
+    />
+    <Caption>Use space to create more legible output</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497381-34fff043-bcc9-4307-9459-f1a549ca399b.png"
+    />
+    <Caption>Not using space makes output difficult to parse</Caption>
+  </Dont>
+</DoDontContainer>
+
+## Color
+
+Terminals reliably recognize the 8 basic ANSI colors. There are also bright versions of each of these colors that you can use, but less reliably.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497351-fd41be98-14fc-4b52-b8dc-32fb65f76eb2.png"
+  alt="A table describing the usage of the 8 basic colors."
+/>
+
+### Things to note
+
+- Background color is available but we haven’t taken advantage of it yet.
+- Some terminals do not reliably support 256-color escape sequences.
+- Users can customize how their terminal displays the 8 basic colors, but that’s opt-in (for example, the user knows they’re making their greens not green).
+- Only use color to [enhance meaning](https://primer.style/design/accessibility/guidelines#use-of-color), not to communicate meaning.
+
+## Iconography
+
+Since graphical image support in terminal emulators is unreliable, we rely on Unicode for iconography. When applying iconography consider:
+
+- People use different fonts that will have varying Unicode support
+- Only use iconography to [enhance meaning](https://primer.style/design/global/accessibility#visual-accessibility), not to communicate meaning
+
+_Note: In Windows, Powershell’s default font (Lucida Console) has poor Unicode support. Microsoft suggests changing it for more Unicode support._
+
+**Symbols currently used:**
+
+```
+✓ 	Success
+- 	Neutral
+✗   Failure
++ 	Changes requested
+! 	Alert
+```
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497402-6d7a375c-9530-4f8b-82e1-06653f42e15b.png"
+      width="100%"
+    />
+    <Caption>Use checks for success messages</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497405-ce95e7f7-574c-4aae-ae52-0c4ef2c6b050.png"
+      width="100%"
+    />
+    <Caption>Don't use checks for failure messages</Caption>
+  </Dont>
+</DoDontContainer>
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497406-95470c4c-7d90-4254-b7a2-39371eee716c.png"
+      width="100%"
+    />
+    <Caption>Use checks for success of closing or deleting</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497407-373927e0-ab3b-44e6-846d-1d1d70bc6c01.png"
+      width="100%"
+    />
+    <Caption>Don't use alerts when closing or deleting</Caption>
+  </Dont>
+</DoDontContainer>
+
+## Scriptability
+
+Make choices that ensure that creating automations or scripts with GitHub commands is obvious and frictionless. Practically, this means:
+
+- Create flags for anything interactive
+- Ensure flags have clear language and defaults
+- Consider what should be different for terminal vs machine output
+
+### In terminal
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497378-70bbe5b1-74dc-4b95-a329-c8f7e2908bae.png"
+  alt="An example of gh pr list"
+/>
+
+### Through pipe
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497375-a872df76-840a-489b-b0ed-61e37afed9c8.png"
+  alt="An example of gh pr list piped through the cat command"
+/>
+
+### Differences to note in machine output
+
+- No color or styling
+- State is explicitly written, not implied from color
+- Tabs between columns instead of table layout, since `cut` uses tabs as a delimiter
+- No truncation
+- Exact date format
+- No header
+
+## Customizability
+
+Be aware that people exist in different environments and may customize their setups. Customizations include:
+
+- **Shell:** shell prompt, shell aliases, PATH and other environment variables, tab-completion behavior
+- **Terminal:** font, color scheme, and keyboard shortcuts
+- **Operating system**: language input options, accessibility settings
+
+The CLI tool itself is also customizable. These are all tools at your disposal when designing new commands.
+
+- Aliasing: [`gh alias set`](https://cli.github.com/manual/gh_alias_set)
+- Preferences: [`gh config set`](https://cli.github.com/manual/gh_config_set)
+- Environment variables: `NO_COLOR`, `EDITOR`, etc

--- a/content/native/cli/getting-started.mdx
+++ b/content/native/cli/getting-started.mdx
@@ -1,10 +1,9 @@
 ---
 title: Getting started
+description: Primer is also a design system for Terminal like implementations of GitHub. If you’re just starting out with creating those kind of experiences, here’s a list of principles and design foundations to get you started.
 ---
 
 import {DoDontContainer, Do, Dont, Caption} from '@primer/gatsby-theme-doctocat'
-
-These guidelines are a collection of principles, foundations and usage guidelines for designing GitHub command line products.
 
 ## Principles
 
@@ -56,7 +55,7 @@ Using this tool, it should be obvious that it’s GitHub and not anything else. 
 
 **Resources**
 
-- [GitHub Brand Content Guide](https://brand.github.com/content/)
+- [GitHub Brand Content Guide](https://brand.github.com)
 
 ### Reduce cognitive load
 
@@ -108,14 +107,14 @@ When designing for the command line, consider:
 
 ### 2. What the command is called
 
-- What should the [command language system](/foundations/language) be?
+- What should the [command language system](/native/cli/foundations#language) be?
 - What should be a command vs a flag?
 - How can you align the language of the new command with the existing commands?
 
 ### 3. What the command outputs
 
-- What can you do to make the CLI version [feel like the GitHub.com version](/principles#make-it-feel-like-github), using [color](/foundations/color), [language](/foundations/language), [spacing](/foundations/spacing), info shown, etc?
-- How should the [machine output](/foundations/scriptability) differ from the interactive behavior?
+- What can you do to make the CLI version [feel like the GitHub.com version](/native/cli/getting-started#make-it-feel-like-github), using [color](/native/cli/foundations#color), [language](/native/cli/foundations#language), [spacing](/native/cli/foundations#spacing), info shown, etc?
+- How should the [machine output](/native/cli/foundations#scriptability) differ from the interactive behavior?
 
 ### 4. How you explain your command
 

--- a/content/native/cli/getting-started.mdx
+++ b/content/native/cli/getting-started.mdx
@@ -53,7 +53,7 @@ Using this tool, it should be obvious that it’s GitHub and not anything else. 
   </Dont>
 </DoDontContainer>
 
-**Resources**
+#### Resources
 
 - [GitHub Brand Content Guide](https://brand.github.com)
 
@@ -63,7 +63,7 @@ Command line interfaces are not as visually intuitive as graphical interfaces. T
 
 Reducing cognitive load is necessary for [making an accessible product](https://www.w3.org/TR/coga-usable/#summary) .
 
-**Ways to reduce cognitive load**
+#### Ways to reduce cognitive load
 
 - Include confirm steps, especially for riskier commands
 - Include headers to help set context for output
@@ -143,7 +143,7 @@ Use [this template](https://docs.google.com/document/d/1JIRErIUuJ6fTgabiFYfCH3x9
 1. Choose a light text color
 1. Choose a monospace font
 
-**Tips**
+#### Tips
 
 - Mix it up since people’s setups change so much. Not everyone uses dark background!
 - Make use of the document outline and headers to help communicate your ideas

--- a/content/native/cli/getting-started.mdx
+++ b/content/native/cli/getting-started.mdx
@@ -1,0 +1,161 @@
+---
+title: Getting started
+---
+
+import {DoDontContainer, Do, Dont, Caption} from '@primer/gatsby-theme-doctocat'
+
+These guidelines are a collection of principles, foundations and usage guidelines for designing GitHub command line products.
+
+## Principles
+
+### Reasonable defaults, easy overrides
+
+Optimize for what most people will need to do most of the time, but make it easy for people to adjust it to their needs. Often this means considering the default behavior of each command, and how it might need to be adjusted with flags.
+
+### Make it feel like GitHub
+
+Using this tool, it should be obvious that it’s GitHub and not anything else. Use details that are specific to GitHub, such as language or color. When designing output, reflect the GitHub.com interface as much as possible and appropriate.
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497434-62e03bc6-8b64-4f08-8d0d-c931def35c03.png"
+      width="100%"
+    />
+    <Caption>Use language accurate to GitHub.com</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497426-4c1d30df-91df-4e42-a293-ad590768f20d.png"
+      width="100%"
+    />
+    <Caption>Don't use language that GitHub.com doesn't use</Caption>
+  </Dont>
+</DoDontContainer>
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497433-e050966e-a102-4d50-93c3-bfa6d7251560.png"
+      width="100%"
+    />
+    <Caption>Use sentence case</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://user-images.githubusercontent.com/980622/215497423-4eeea07a-7a2e-4af7-a486-c9a773c29454.png"
+      width="100%"
+    />
+    <Caption>Don't use title case</Caption>
+  </Dont>
+</DoDontContainer>
+
+**Resources**
+
+- [GitHub Brand Content Guide](https://brand.github.com/content/)
+
+### Reduce cognitive load
+
+Command line interfaces are not as visually intuitive as graphical interfaces. They have very few affordances (indicators of use), rely on memory, and are often unforgiving of mistakes. We do our best to design our commands to mitigate this.
+
+Reducing cognitive load is necessary for [making an accessible product](https://www.w3.org/TR/coga-usable/#summary) .
+
+**Ways to reduce cognitive load**
+
+- Include confirm steps, especially for riskier commands
+- Include headers to help set context for output
+- Ensure consistent command language to make memorizing easier
+- Ensure similar commands are visually and behaviorally parallel. \* For example, any create command should behave the same
+- Anticipate what people might want to do next. \* For example, we ask if you want to delete your branch after you merge.
+- Anticipate what mistakes people might make
+
+### Bias towards terminal, but make it easy to get to the browser
+
+We want to help people stay in the terminal wherever they might want to maintain focus and reduce context switching, but when it’s necessary to jump to GitHub.com make it obvious, fast, and easy. Certain actions are probably better to do in a visual interface.
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497436-cccc800d-4f68-4a40-8a93-3f6b5ae741b2.png"
+  alt="A prompt asking 'What's next?' with the choice 'Preview in browser' selected."
+/>
+<Caption>A preview in browser step helps users create issues and pull requests more smoothly.</Caption>
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497438-3b664837-0182-4d94-9433-f9a59ad642ff.png"
+  alt="The gh pr create command with title and body flags outputting a pull request URL."
+/>
+<Caption>Many commands output the relevant URL at the end.</Caption>
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497440-5d1f2ebb-b8b8-4dc6-8104-68c125dd85d0.png"
+  alt="The gh issue view command with the --web flag. The output is opening a URL in the browser."
+/>
+<Caption>Web flags help users jump to the browser quickly</Caption>
+
+## Process
+
+When designing for the command line, consider:
+
+### 1. What the command does
+
+- What makes sense to do from a terminal? What doesn’t?
+- What might people want to automate?
+- What is the default behavior? What flags might you need to change that behavior?
+- What might people try and fail to do and how can you anticipate that?
+
+### 2. What the command is called
+
+- What should the [command language system](/foundations/language) be?
+- What should be a command vs a flag?
+- How can you align the language of the new command with the existing commands?
+
+### 3. What the command outputs
+
+- What can you do to make the CLI version [feel like the GitHub.com version](/principles#make-it-feel-like-github), using [color](/foundations/color), [language](/foundations/language), [spacing](/foundations/spacing), info shown, etc?
+- How should the [machine output](/foundations/scriptability) differ from the interactive behavior?
+
+### 4. How you explain your command
+
+- You will need to provide a short and long description of the command for the [help pages](/components/help).
+
+### 5. How people discover your command
+
+- Are there ways to integrate CLI into the feature where it exists on other platforms?
+
+## Prototyping
+
+When designing for GitHub CLI, there are several ways you can go about prototyping your ideas.
+
+### Google Docs
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497389-fc902fb0-e0c0-40f7-a745-d6469af09936.png"
+  alt="A screenshot of the Google Docs template"
+/>
+
+Best for simple quick illustrations of most ideas
+
+Use [this template](https://docs.google.com/document/d/1JIRErIUuJ6fTgabiFYfCH3x91pyHuytbfa0QLnTfXKM/edit?usp=sharing), or format your document with these steps:
+
+1. Choose a dark background (File > Page Setup > Page Color)
+1. Choose a light text color
+1. Choose a monospace font
+
+**Tips**
+
+- Mix it up since people’s setups change so much. Not everyone uses dark background!
+- Make use of the document outline and headers to help communicate your ideas
+
+### Figma
+
+<img
+  src="https://user-images.githubusercontent.com/980622/215497367-3d6febe7-3565-4ff1-9725-fc7b6eaa25a3.png"
+  alt="A screenshot of the Figma library"
+/>
+
+If you need to show a process unfolding over time, or need to show a prototype that feels more real to users, Figma or code prototypes are best.
+
+[**Figma library**](https://www.figma.com/file/zYsBk5KFoMlovE4g2f4Wkg/Primer-Command-Line) (accessible to GitHub staff only)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "gatsby develop",
+    "clean": "gatsby clean",
     "build": "gatsby build --prefix-paths",
     "build:preview": "gatsby build",
     "now-build": "yarn build",

--- a/src/@primer/gatsby-theme-doctocat/mdx-components.js
+++ b/src/@primer/gatsby-theme-doctocat/mdx-components.js
@@ -1,5 +1,4 @@
 import CustomVideoPlayer from '../../CustomVideoPlayer'
 import ImageBox from './components/ImageBox'
 
-
 export default {CustomVideoPlayer, ImageBox}

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -9,10 +9,10 @@
     - title: Figma
       url: /guides/figma
       children:
-      - title: Introduction
-        url: /guides/figma
-      - title: How to contribute
-        url: /guides/figma/contribute
+        - title: Introduction
+          url: /guides/figma
+        - title: How to contribute
+          url: /guides/figma/contribute
     - title: Component lifecycle
       url: /guides/component-lifecycle
     - title: Accessibility
@@ -128,3 +128,13 @@
       url: /components/tokens
     - title: Tree view
       url: /components/tree-view
+- title: Native
+  children:
+    - title: CLI
+      children:
+        - title: Getting started
+          url: /native/cli/getting-started
+        - title: Foundations
+          url: /native/cli/foundations
+        - title: Components
+          url: /native/cli/components


### PR DESCRIPTION
As part of: https://github.com/github/primer/issues/1607
We're moving all the CLI docs over and introducing a new Native section in the menu.

- Added bash to code scripts
- Unified in 3 main pages
- Changed links to be not absolute

<img width="1125" alt="Screenshot 2023-01-30 at 16 54 37" src="https://user-images.githubusercontent.com/980622/215542445-4d35289e-b5a2-4df7-aed7-aea4d1547aa0.png">

