### PR TITLE
Fix theme menu

### DIFF
--- a/src/@primer/gatsby-theme-doctocat/components/storyBookEmbed.js
+++ b/src/@primer/gatsby-theme-doctocat/components/storyBookEmbed.js
@@ -15,7 +15,7 @@ export function StorybookEmbed({framework = 'react', componentId, stories, heigh
     shortcuts: false,
     singleStory: Object.entries(stories).length <= 1,
     panel: false,
-    globals: `colorScheme:${colorScheme}`,
+    globals: `theme:${colorScheme}`,
     viewMode: 'story'
   }
 
@@ -57,7 +57,6 @@ export function StorybookEmbed({framework = 'react', componentId, stories, heigh
 
         <ActionMenu>
           <ActionMenu.Button>Theme: {colorScheme}</ActionMenu.Button>
-
           <ActionMenu.Overlay>
             <ActionList selectionVariant="single">
               <ActionList.Item selected={colorScheme === 'light'} onSelect={() => setColorScheme('light')}>
@@ -96,6 +95,7 @@ export function StorybookEmbed({framework = 'react', componentId, stories, heigh
             </ActionList>
           </ActionMenu.Overlay>
         </ActionMenu>
+
         <Link
           href={`${base}?path=/story/${componentId}--${story}&${new URLSearchParams({globals: options.globals})}`}
           target="_blank"


### PR DESCRIPTION
This fixes the theme menu currently used for the CSS utilities. E.g. https://primer.style/design/foundations/css-utilities/colors#text

![Screen Shot 2023-02-03 at 10 42 31](https://user-images.githubusercontent.com/378023/216491636-e3ad3810-cfa9-433d-beb5-54863066d3da.png)

It might also fix the console error that @josepmartins saw:

<img width="654" alt="Screenshot 2023-02-02 at 16 49 22" src="https://user-images.githubusercontent.com/378023/216492369-ac0cf4fb-578e-49d0-b40b-80ab8b4db586.png">
