### PR TITLE
Fixed path to css-utilities

### DIFF
--- a/content/foundations/index.mdx
+++ b/content/foundations/index.mdx
@@ -10,7 +10,7 @@ How to work with color modes and themes, and how to apply color to GitHub interf
 
 How to create responsive interfaces for GitHub.
 
-#### [CSS Utilities](/foundations/css-utilitiesw)
+#### [CSS Utilities](/foundations/css-utilities)
 
 How to use Primer CSS utilities to build interfaces.
 


### PR DESCRIPTION
Firstly great work, found a bug and here is the fix.


Go to publick page : https://primer.style/design/foundations
click 👉  **CSS Utilities**

**Actual**  : Pointing to ❌  https://primer.style/design/foundations/css-utilities/  [index]
**Expected**  :  Should point to  ✅  https://primer.style/design/foundations/css-utilities/


No more `404` due to a incorrect path ( typo) now fixed :octocat:

