### PR TITLE
Modify globals regarding the framework

### DIFF
--- a/src/@primer/gatsby-theme-doctocat/components/storyBookEmbed.js
+++ b/src/@primer/gatsby-theme-doctocat/components/storyBookEmbed.js
@@ -15,7 +15,7 @@ export function StorybookEmbed({framework = 'react', componentId, stories, heigh
     shortcuts: false,
     singleStory: Object.entries(stories).length <= 1,
     panel: false,
-    globals: `theme:${colorScheme}`,
+    globals: framework === 'css' ? `{"theme":"${colorScheme}"}` : `{"colorScheme":"${colorScheme}"}`,
     viewMode: 'story',
   }
 


### PR DESCRIPTION
Temporary fix to adapt global properties in the `embedStorybook` component depending on the framework used. 

Ideally we could align and use the same color global setting in both `CSS` and `React` stories.

cc @simurai 