### PR TITLE
Clarify chevron direction state meaning

### DIFF
--- a/content/ui-patterns/progressive-disclosure.mdx
+++ b/content/ui-patterns/progressive-disclosure.mdx
@@ -40,7 +40,7 @@ The following table outlines common progressive disclosure solutions in use at G
 
 ### Chevron icon
 
-The chevron icon is used when elements of content are collapsed and can be toggled open. Typically this icon is positioned vertically, and alternates between “up” and “down” states. This icon is quite flexible, and can stand alone, or be paired with text.
+The chevron icon is used when elements of content are collapsed and can be toggled open. Typically this icon is positioned vertically, and alternates between the “up” state when expanded and the “down” state when collapsed. This icon is quite flexible, and can stand alone, or be paired with text.
 
 <Box display="flex" alignItems="center" flexDirection="column" my={5}>
   <Box


### PR DESCRIPTION
I was having a brain fart about chevron directions for toggles and came looking for the obvious answer. It’s not made plain here, only inferred in screenshots.