### PR TITLE
Make `flex-nowrap` the default

### DIFF
--- a/content/foundations/css-utilities/flexbox.mdx
+++ b/content/foundations/css-utilities/flexbox.mdx
@@ -106,25 +106,16 @@ This example uses the responsive variant `.flex-sm-row-reverse` to override `.fl
 You can choose whether flex items are forced into a single line or wrapped onto multiple lines.
 
 ```css
-.flex-wrap           { flex-wrap: wrap; }
 .flex-nowrap         { flex-wrap: nowrap; }
+.flex-wrap           { flex-wrap: wrap; }
 .flex-wrap-reverse   { flex-wrap: wrap-reverse; }
 ```
 
 | Class | Description |
 | --- | --- |
-| `.flex-wrap` | Flex items will break onto multiple lines (default) |
-| `.flex-nowrap` | Flex items are laid out in a single line, even if they overflow |
+| `.flex-nowrap` | Flex items are laid out in a single line, even if they overflow (default) |
+| `.flex-wrap` | Flex items will break onto multiple lines |
 | `.flex-wrap-reverse` | Behaves the same as wrap but cross-start and cross-end are permuted. |
-
-### `flex-wrap` example
-
-<StorybookEmbed
-  framework="css"
-  componentId="utilities-flexbox"
-  stories={{'wrap': {name: 'wrap'}}}
-  height="220"
-/>
 
 ### `flex-nowrap` example
 
@@ -133,6 +124,15 @@ You can choose whether flex items are forced into a single line or wrapped onto 
   componentId="utilities-flexbox"
   stories={{'nowrap': {name: 'nowrap'}}}
   height="125"
+/>
+
+### `flex-wrap` example
+
+<StorybookEmbed
+  framework="css"
+  componentId="utilities-flexbox"
+  stories={{'wrap': {name: 'wrap'}}}
+  height="220"
 />
 
 ### `flex-wrap-reverse` example


### PR DESCRIPTION
This is an upstream from https://github.com/primer/css/pull/2388 and makes the `flex-nowrap` utility the default. Also, switches position to show the default first.

/cc @arelia