### PR TITLE
Add more deploy triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,12 @@
 name: Deploy
 
 on:
+  # Manual deploy
+  workflow_dispatch:
+  # Scheduled deploy
+  schedule: 
+    - cron: '0 0 * * *' # Every day at midnight UTC time
+  # Deploy on change to main
   push:
     branches:
       - main


### PR DESCRIPTION
Adds the following deploy triggers:
- Manual deploy
- Scheduled deploy (Deploy the site every day so we get the latest version of Primer packages)