### PR TITLE
Figma install & getting started

### DIFF
--- a/content/guides/figma/getting-started.mdx
+++ b/content/guides/figma/getting-started.mdx
@@ -28,7 +28,7 @@ You can also directly open the *team library* view via the command palette or wi
 
 
 ## Understanding styles
-Figma libraries like `Primer Primitives` install styles for you to use. In contrast to *local styles* they don;t show up in the sidebar.
+Figma libraries like `Primer Primitives` install styles for you to use. In contrast to *local styles* they don't show up in the sidebar.
 However once you open a selection to choose a color style, text style, etc. you will see the styles from team libraries as well.
 
 To quickly find a style you can use the search box. E.g. use `accent` to bring up all accent colors.

--- a/content/guides/figma/getting-started.mdx
+++ b/content/guides/figma/getting-started.mdx
@@ -49,7 +49,7 @@ At GitHub, we have created a [set of guidelines](https://github.com/primer/figma
 Components in our libraries have been built to be easy to understand for consumers. When possible try to keep components small and simple. Avoid advanced methods/tricks if possible. 
 
 ### Variants and component properties
-To make component dynamics we favour [component properties <LinkExternalIcon />](https://help.figma.com/hc/en-us/articles/5579474826519-Explore-component-properties) over nesting and expecting users to manual overwrite parts of a component. 
+To make components dynamic, we favor [component properties <LinkExternalIcon />](https://help.figma.com/hc/en-us/articles/5579474826519-Explore-component-properties) over nesting, so users don't have to override parts of a component manually. 
 
 Whenever possible use components as they are without *detaching*.
 

--- a/content/guides/figma/getting-started.mdx
+++ b/content/guides/figma/getting-started.mdx
@@ -1,0 +1,65 @@
+---
+title: Getting started
+---
+
+import createBranchImg from '../../../src/images/figma/create-branch.png'
+import createBranchDialogImg from '../../../src/images/figma/create-branch-dialog.png'
+import requestReviewImg from '../../../src/images/figma/request-review.png'
+import mergeDialogImg from '../../../src/images/figma/merge-dialog.png'
+import requestDialogImg from '../../../src/images/figma/request-dialog.png'
+
+
+## What are Figma libraries
+## Installation
+## Understanding styles
+## Understanding components
+
+Currently only **GitHub employees** can contribute to **Primer Web**, due to how Figma handles open source files. 
+To make changes you first need to [create a branch](https://www.youtube.com/watch?v=tbNCGEC2G1E) from Primer Web and name it `@username/changes-being-made`. 
+For example: `@lukasoppermann/update-button-radius`.
+
+When you are satisfied with the changes you made, request a review from the [direct responsible individual](https://github.com/primer/figma/blob/main/CONTRIBUTION.md#contribute-new-components-or-updates) (DRI) of the file. If you are not sure who that is, reach out in the #primer-figma slack channel.
+
+Once your branch is approved, a maintainer will take care of merging and publishing the changes to the library.
+
+We use this process to make sure no accidental changes get added to the library. It also allows us to better track changes added by a branch. Think of it as a repo that does not allow direct pushes to the main branch.
+
+<ImageBox caption="Select “Create branch...” from the dropdown or via the command palette">
+  <img
+    width="410"
+    alt="Screenshot showing how to create a branch in figma"
+    src={createBranchImg}
+  />
+</ImageBox>
+
+<ImageBox caption="Name your branch “@username/changes-being-made”" paddingX>
+  <img
+    width="293"
+    alt="Screenshot showing the create branch dialog in figma"
+    src={createBranchDialogImg}
+  />
+</ImageBox>
+
+<ImageBox caption="When you are done request a review to get your changes merged.">
+  <img
+    width="730"
+    alt="Screenshot showing the request review option in figma"
+    src={requestReviewImg}
+  />
+</ImageBox>
+
+<ImageBox caption="Select the DRI for the file to review. Reach out in the internal #primer-figma channel if you are not sure who to add." paddingX>
+  <img
+    width="568"
+    alt="Screenshot showing the merge dialog in figma"
+    src={mergeDialogImg}
+  />
+</ImageBox>
+
+<ImageBox caption="Add a detailed message describe what you changed and why." paddingX>
+  <img
+    width="506"
+    alt="Screenshot showing the request review text dialog in figma"
+    src={requestDialogImg}
+  />
+</ImageBox>

--- a/content/guides/figma/getting-started.mdx
+++ b/content/guides/figma/getting-started.mdx
@@ -4,7 +4,7 @@ title: Getting started
 import {LinkExternalIcon} from '@primer/octicons-react'
 
 ## What are Primer Figma libraries?
-The Primer Figma libraries contain UI components & design tokens (styles) that our team’s at GitHub use to design GitHub. The components contained within Primer match what is available for developers in Primer React Components, Primer ViewComponents, and Primer CSS.
+The Primer Figma libraries contain UI components and design tokens (styles) that our teams at GitHub use to design GitHub. The components contained within Primer match what is available for developers in Primer React Components, Primer ViewComponents, and Primer CSS.
 
 ## Installation
 To use a library in Figma enable (install) it from the **assets** tab (`option` + `2`).

--- a/content/guides/figma/getting-started.mdx
+++ b/content/guides/figma/getting-started.mdx
@@ -1,65 +1,56 @@
 ---
 title: Getting started
 ---
+import {LinkExternalIcon} from '@primer/octicons-react'
 
-import createBranchImg from '../../../src/images/figma/create-branch.png'
-import createBranchDialogImg from '../../../src/images/figma/create-branch-dialog.png'
-import requestReviewImg from '../../../src/images/figma/request-review.png'
-import mergeDialogImg from '../../../src/images/figma/merge-dialog.png'
-import requestDialogImg from '../../../src/images/figma/request-dialog.png'
+## What are Primer Figma libraries?
+The Primer Figma libraries contain UI components & design tokens (styles) that our team’s at GitHub use to design GitHub. The components contained within Primer match what is available for developers in Primer React Components, Primer ViewComponents, and Primer CSS.
 
-
-## What are Figma libraries
 ## Installation
+To use a library in Figma enable (install) it from the **assets** tab (`option` + `2`).
+You can also directly open the *team library* view via the command palette or with the shortcut `option` + `cmd` + `o`.
+
+<ImageBox caption="Navigate to the assets tab in the left sidebar and press the book icon to open the libraries overview.">
+  <img
+    width="490"
+    alt="Screenshot showing the assets tab in figma"
+    src="https://user-images.githubusercontent.com/813754/221525999-d0278cec-d79c-40fc-8150-532f97549dc8.png"
+  />
+</ImageBox>
+
+<ImageBox caption="Enable all libraries you need in your file.">
+  <img
+    width="443"
+    alt="Screenshot showing the library overview in figma"
+    src="https://user-images.githubusercontent.com/813754/221527802-76638b6b-be81-4c87-b3e8-63d543537a9c.png"
+  />
+</ImageBox>
+
+
 ## Understanding styles
+Figma libraries like `Primer Primitives` install styles for you to use. In contrast to *local styles* they don;t show up in the sidebar.
+However once you open a selection to choose a color style, text style, etc. you will see the styles from team libraries as well.
+
+To quickly find a style you can use the search box. E.g. use `accent` to bring up all accent colors.
+
+<ImageBox caption="Color style selector and color style selector with search for 'accent'">
+  <img
+    width="443"
+    alt="Screenshot showing the style selector in figma"
+    src="https://user-images.githubusercontent.com/813754/221531315-605cba02-de29-4834-a01b-ef8dc391fe21.png"
+  />
+</ImageBox>
+
+<a href="https://help.figma.com/hc/en-us/articles/360039238753-Styles-in-Figma">Learn more about Figma styles <LinkExternalIcon /></a>
+
 ## Understanding components
+At GitHub, we have created a [set of guidelines](https://github.com/primer/figma/blob/main/docs/authoring-components.md) that contributors and maintainers can reference when creating and updating components.
 
-Currently only **GitHub employees** can contribute to **Primer Web**, due to how Figma handles open source files. 
-To make changes you first need to [create a branch](https://www.youtube.com/watch?v=tbNCGEC2G1E) from Primer Web and name it `@username/changes-being-made`. 
-For example: `@lukasoppermann/update-button-radius`.
+Components in our libraries have been built to be easy to understand for consumers. When possible try to keep components small and simple. Avoid advanced methods/tricks if possible. 
 
-When you are satisfied with the changes you made, request a review from the [direct responsible individual](https://github.com/primer/figma/blob/main/CONTRIBUTION.md#contribute-new-components-or-updates) (DRI) of the file. If you are not sure who that is, reach out in the #primer-figma slack channel.
+### Variants and component properties
+To make component dynamics we favour [component properties <LinkExternalIcon />](https://help.figma.com/hc/en-us/articles/5579474826519-Explore-component-properties) over nesting and expecting users to manual overwrite parts of a component. 
 
-Once your branch is approved, a maintainer will take care of merging and publishing the changes to the library.
+Whenever possible use components as they are without *detaching*.
 
-We use this process to make sure no accidental changes get added to the library. It also allows us to better track changes added by a branch. Think of it as a repo that does not allow direct pushes to the main branch.
-
-<ImageBox caption="Select “Create branch...” from the dropdown or via the command palette">
-  <img
-    width="410"
-    alt="Screenshot showing how to create a branch in figma"
-    src={createBranchImg}
-  />
-</ImageBox>
-
-<ImageBox caption="Name your branch “@username/changes-being-made”" paddingX>
-  <img
-    width="293"
-    alt="Screenshot showing the create branch dialog in figma"
-    src={createBranchDialogImg}
-  />
-</ImageBox>
-
-<ImageBox caption="When you are done request a review to get your changes merged.">
-  <img
-    width="730"
-    alt="Screenshot showing the request review option in figma"
-    src={requestReviewImg}
-  />
-</ImageBox>
-
-<ImageBox caption="Select the DRI for the file to review. Reach out in the internal #primer-figma channel if you are not sure who to add." paddingX>
-  <img
-    width="568"
-    alt="Screenshot showing the merge dialog in figma"
-    src={mergeDialogImg}
-  />
-</ImageBox>
-
-<ImageBox caption="Add a detailed message describe what you changed and why." paddingX>
-  <img
-    width="506"
-    alt="Screenshot showing the request review text dialog in figma"
-    src={requestDialogImg}
-  />
-</ImageBox>
+<a href="https://help.figma.com/hc/en-us/articles/360038662654-Guide-to-components-in-Figma">Learn more about Figma components <LinkExternalIcon /></a>

--- a/content/guides/figma/index.mdx
+++ b/content/guides/figma/index.mdx
@@ -16,7 +16,7 @@ Design teams at GitHub use Figma as the single source of truth, collaboration, a
 
 ## Team libraries
 
-GitHub uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
+GitHub's uses Figma to distribute Primer through team libraries. Each library covers a different part of the system, allowing a designer to only use what's needed. Any team within GitHub's Figma organization can create and distribute their own team/project specific libraries, but all of the core asset libraries for Primer can be found in the Primer team's "[Core libraries (internal)](https://www.figma.com/files/797266083973274396/project/8172024/Core-libraries)" project or the [primer community page](https://www.figma.com/@primer). They include the following:
 
 - Primer Primitives ([internal](https://www.figma.com/file/B5XPE8IwGPIZDAvN7jqWqx/Primer-Primitives) | [community](https://www.figma.com/community/file/854766928300977832)): All of the color, type, and spacing styles used within Primer.
 - Primer Web ([internal](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=1406%3A0&t=kY6ZvRffnaGOaUib-1) | [community](https://www.figma.com/community/file/854767373644076713)): UI components used to design for GitHub's web interfaces.
@@ -38,20 +38,8 @@ In addition to asset libraries for components and styles, you can also use templ
 - [Primer Interfaces](https://www.figma.com/file/Y2xJLFBrU7yyiDLlEkQXcF/Primer-Interfaces): Templates for common views and UI patterns found within GitHub's web product.
 - [Primer Email](https://www.figma.com/file/MZM32u6Q80DOvOGlDCNIyc/Primer-Email): Templates used to design product emails for GitHub.
 
-## Collaboration
-
-<ImageBox caption="Example communicating in Figma using comments">
-  <img
-    width="656"
-    alt="Screenshot demonstrating collaboration in Figma using Figma comments"
-    src="https://user-images.githubusercontent.com/10384315/93832938-0f14bf80-fc2c-11ea-9e8b-e72bee3b4fdd.png"
-  />
-</ImageBox>
-
-All GitHub members have read-only access to all GitHub design files and edit access to files within their team. You can leave [Figma comments](https://help.figma.com/article/44-comments) to provide feedback and use [issues](https://help.github.com/en/articles/about-issues) to document design exploration, track decisions and progress. The design team values [incremental correctness](https://github.com/github/product-design/blob/master/principles-and-practices.md#incremental-correctness), so share early and share often.
-
 ## Support
 
-GitHub's Figma organization is currently maintained by GitHub's Design Infrastructure team. For any questions or comments please reach out to us either in our Slack [#primer](https://github.slack.com/archives/CSGAVNZ19) channel or by submitting an issue in the [github/design-infrastructure repo](https://github.com/github/design-infrastructure/issues/new/choose). The Design Infrastructure team also offers weekly Figma office hours on Tuesdays, which are hosted by [@ashygee](https://github.com/ashygee). Please reach out to them for the calendar invite.
+GitHub's Figma organization is currently maintained by GitHub's Design Infrastructure team. For any questions or comments please reach out to us either in our Slack [#primer-figma](https://github.slack.com/archives/C049REXSRBQ) channel or by submitting an issue in the [github/primer repo](https://github.com/github/primer/issues/new/choose).
 
 For additional support specific to Figma, please reference the [Figma Help Center](https://help.figma.com/hc/en-us).

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -13,6 +13,8 @@
       children:
         - title: Introduction
           url: /guides/figma
+        - title: Getting started
+          url: /guides/figma/getting-started
         - title: How to contribute
           url: /guides/figma/contribute
     - title: Component lifecycle


### PR DESCRIPTION
This PR adds a new `getting started` page to the figma section.

Once merged it replaces the page in Figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=14841%3A47461&t=qomBKdMWPKZxBH5o-1

## In the Figma files

- We should just add a link to the libraries to this documentation.

- I would suggest to rename the cover page in Figma to `Getting Started` and add the links there after the cover on a small slide with infos about the slack, etc.