### PR TITLE
Clarify footer divider behaviour

### DIFF
--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -120,7 +120,7 @@ The body region is the main content of the Dialog. It can contain any content th
 
 The footer region may be used to show confirmation actions, navigation links, or specialized actions. Primary actions should be aligned to the right of the footer, and grouped by additional related actions. Secondary actions may be shown aligned to the left side.
 
-If the content area has overflow scrolling, a divider will be shown between the footer and content area. Otherwise, showing a divider is optional.
+If the content area has overflow scrolling, a divider should be added between the footer and content area. Otherwise, showing a divider is optional.
 
 <img
   src="https://user-images.githubusercontent.com/293280/175850630-9f3df284-c69b-4d16-9e57-ea04a0202d04.png"


### PR DESCRIPTION
The divider is not added automatically based on the content of the dialog body. Rather, it needs to be set manually and proactively.

Please land this for me upon approval as I don't have write access. 🙏🏻 