### PR TITLE
Output a JSON file with component metadata

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -259,20 +259,22 @@ exports.onPostBuild = async ({graphql}) => {
     }
   `)
 
-  const components = data.allMdx.nodes.map(node => {
-    const reactComponent = data.allReactComponent.nodes.find(
-      component => component.componentId === node.frontmatter.reactId,
-    )
+  const components = data.allMdx.nodes
+    .filter(node => Boolean(node.frontmatter.title))
+    .map(node => {
+      const reactComponent = data.allReactComponent.nodes.find(
+        component => component.componentId === node.frontmatter.reactId,
+      )
 
-    return {
-      id: node.slug.replace(/^components\//, ''),
-      displayName: node.frontmatter.title,
-      description: node.frontmatter.description,
-      implementations: {
-        react: reactComponent ? {status: reactComponent.status, a11yReviewed: reactComponent.a11yReviewed} : null,
-      },
-    }
-  })
+      return {
+        id: node.slug.replace(/^components\//, ''),
+        displayName: node.frontmatter.title,
+        description: node.frontmatter.description,
+        implementations: {
+          react: reactComponent ? {status: reactComponent.status, a11yReviewed: reactComponent.a11yReviewed} : null,
+        },
+      }
+    })
 
   fs.writeFileSync(
     path.resolve(process.cwd(), 'public/components.json'),

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -255,7 +255,13 @@ exports.onPostBuild = async ({graphql}) => {
         displayName: node.frontmatter.title,
         description: node.frontmatter.description,
         implementations: {
-          react: reactComponent ? {status: reactComponent.status, a11yReviewed: reactComponent.a11yReviewed} : null,
+          react: reactComponent
+            ? {
+                id: reactComponent.componentId,
+                status: reactComponent.status,
+                a11yReviewed: reactComponent.a11yReviewed,
+              }
+            : null,
         },
       }
     })


### PR DESCRIPTION
Adds a public `components.json` to the /design site that will allow us to access Primer component metadata outside the docs site. This unlocks exciting extension possibilities like a Primer Docs Figma plugin or Raycast extension.