### PR TITLE
Fix table overflow on component guideline pages

### DIFF
--- a/src/@primer/gatsby-theme-doctocat/mdx-components.js
+++ b/src/@primer/gatsby-theme-doctocat/mdx-components.js
@@ -1,5 +1,16 @@
+import React from 'react'
 import CustomVideoPlayer from '../../CustomVideoPlayer'
 import ImageBox from './components/ImageBox'
 import StorybookEmbed from '../../components/storybook-embed'
+import DoctocatTable from '@primer/gatsby-theme-doctocat/src/components/table'
+import {Box} from '@primer/react'
 
-export default {CustomVideoPlayer, ImageBox, StorybookEmbed}
+// Override the default table component with a custom one that supports overflow
+// TODO: Upsream this to @primer/gatsby-theme-doctocat
+const Table = props => (
+  <Box sx={{overflow: 'auto'}}>
+    <DoctocatTable {...props} />
+  </Box>
+)
+
+export default {table: Table, CustomVideoPlayer, ImageBox, StorybookEmbed}

--- a/src/layouts/component-layout.tsx
+++ b/src/layouts/component-layout.tsx
@@ -53,7 +53,7 @@ export default function ComponentLayout({pageContext, children, path}) {
               </>
             ) : null}
           </Box>
-          <Box>
+          <Box sx={{minWidth: 0}}>
             {/* Narrow table of contents */}
             {pageContext.tableOfContents.items ? (
               <Box


### PR DESCRIPTION
### Before

<img width="1138" alt="CleanShot 2023-03-17 at 15 13 10@2x" src="https://user-images.githubusercontent.com/4608155/226051950-4b03761c-56ee-405a-880f-e7decbebf956.png">


### After

<img width="1139" alt="CleanShot 2023-03-17 at 15 12 39@2x" src="https://user-images.githubusercontent.com/4608155/226051765-abedadbf-95b2-4f35-a7bc-a17ecfc9347d.png">

Closes https://github.com/primer/react/issues/3013
