### PR TITLE
Add guidance for getting new components introduced to Primer

### DIFF
--- a/content/guides/contribute/adding-new-components.mdx
+++ b/content/guides/contribute/adding-new-components.mdx
@@ -11,7 +11,7 @@ This guidance is intended for GitHub staff members who are introducing design pa
 
 ### 1. Exists and is discoverable
 
-**Qualities**
+#### Qualities
 
 - Name
 - Description
@@ -28,7 +28,7 @@ For guidance on what makes a pattern worth sharing, check out the documentation:
 
 ### 2. Meets basic design quality checks
 
-**Qualities**
+#### Qualities
 
 - Meets the criteria in the [pattern design checklist](https://primer.style/design/guides/contribute/design#design-checklist)
 
@@ -36,7 +36,7 @@ The criteria in the pattern design checklist ensure your pattern is sturdy enoug
 
 ### 3. Has documentation
 
-**Qualities**
+#### Qualities
 
 - Storybook stories demonstrate all of the pattern's features and options
 - At least meets the [MVP component documentation criteria](https://github.com/primer/design/blob/main/content/components/component-documentation-guidelines/component-MVP-documentation-guidelines.md)
@@ -50,7 +50,7 @@ Resources for writing documentation:
 
 ### 4. Is accessible
 
-**Qualities**
+#### Qualities
 
 - Passes a11y design review focused on the component
 - Passes a11y engineering review focused on the component

--- a/content/guides/contribute/adding-new-components.mdx
+++ b/content/guides/contribute/adding-new-components.mdx
@@ -11,7 +11,7 @@ This guidance is intended for GitHub staff members who are introducing design pa
 
 ### 1. Exists and is discoverable
 
-#### Qualities
+Your component should have:
 
 - Name
 - Description
@@ -28,15 +28,13 @@ For guidance on what makes a pattern worth sharing, check out the documentation:
 
 ### 2. Meets basic design quality checks
 
-#### Qualities
-
-- Meets the criteria in the [pattern design checklist](https://primer.style/design/guides/contribute/design#design-checklist)
+Check the design against the criteria in the [pattern design checklist](https://primer.style/design/guides/contribute/design#design-checklist).
 
 The criteria in the pattern design checklist ensure your pattern is sturdy enough to be used in production and easily picked up by other designers or engineers. For a more detailed quality check, you can refer to the [product design checklist](https://github.com/github/product-design/blob/main/resources/design-checklist.md) (GitHub staff only).
 
 ### 3. Has documentation
 
-#### Qualities
+The most basic documentation your component should have:
 
 - Storybook stories demonstrate all of the pattern's features and options
 - At least meets the [MVP component documentation criteria](https://github.com/primer/design/blob/main/content/components/component-documentation-guidelines/component-MVP-documentation-guidelines.md)
@@ -50,10 +48,10 @@ Resources for writing documentation:
 
 ### 4. Is accessible
 
-#### Qualities
+Your component is considered to be accessible once it passes the following reviews from GitHub's a11y team:
 
-- Passes a11y design review focused on the component
-- Passes a11y engineering review focused on the component
+- a11y design review focused on the component
+- a11y engineering review focused on the component
 
 New features already undergo accessibility reviews, but reviews for shared patterns zoom in on smaller and more specific pieces of UI. Every new component we add to Primer goes through rigorous testing by the accessibility team, so your component will be better prepared for adopting and releasing in Primer.
 

--- a/content/guides/contribute/adding-new-components.mdx
+++ b/content/guides/contribute/adding-new-components.mdx
@@ -21,7 +21,7 @@ This is the least refined phase of a new component: it just needs to exist. If y
 
 {/* TODO: uncomment this once we add this documentation
 
-For guidance on what makes a pattern worth sharing, check out the documentation: [Deciding if something is a new pattern](). */}
+For guidance on what makes a pattern worth sharing, check out the documentation: [Handling new patterns](/guides/contribute/handling-new-patterns). */}
 
 ### 2. Meets basic design quality checks
 

--- a/content/guides/contribute/adding-new-components.mdx
+++ b/content/guides/contribute/adding-new-components.mdx
@@ -13,18 +13,15 @@ This guidance is intended for GitHub staff members who are introducing design pa
 
 Your component should have:
 
-- Name
-- Description
+- A name
+- A description
 - At least 1 Storybook story
-- No aXe violations
 
 This is the least refined phase of a new component: it just needs to exist. If you've already decided that this is a component worth sharing with other teams, it just needs to be discoverable and pass basic accessibility checks.
 
-<!--
-TODO: uncomment this once we add this documentation
+{/* TODO: uncomment this once we add this documentation
 
-For guidance on what makes a pattern worth sharing, check out the documentation: [Deciding if something is a new pattern]().
--->
+For guidance on what makes a pattern worth sharing, check out the documentation: [Deciding if something is a new pattern](). */}
 
 ### 2. Meets basic design quality checks
 
@@ -48,16 +45,13 @@ Resources for writing documentation:
 
 ### 4. Is accessible
 
-Your component is considered to be accessible once it passes the following reviews from GitHub's a11y team:
+Your component likely meets basic accessibility requirements if it passes axe checks and follows the guidance in the [Product Accessibility Checkpoints](https://github.com/github/accessibility-playbook/blob/main/content/product-lifecycle-checkpoints.mdx) (GitHub staff only) in our accessibility playbook.
 
-- a11y design review focused on the component
-- a11y engineering review focused on the component
-
-New features already undergo accessibility reviews, but reviews for shared patterns zoom in on smaller and more specific pieces of UI. Every new component we add to Primer goes through rigorous testing by the accessibility team, so your component will be better prepared for adopting and releasing in Primer.
+It would be even better if your component has gone through an a11y design review and a a11y engineering review. Every new component we add to Primer goes through rigorous testing by the accessibility team, so your component will be better prepared for adopting and releasing in Primer.
 
 ### 5. Ready to upstream
 
-Now your component has satisfied enough criteria that it's already halfway to being at the “Alpha” maturity status! From here, your team or the Primer maintainers will be in a good position to adopt your component and iterate on it until it reaches the “Alpha” maturity status.
+Now your component has satisfied enough criteria that it's well on it's way to being at the “Alpha” maturity status! From here, your team or the Primer maintainers will be in a good position to adopt your component and iterate on it until it reaches the “Alpha” maturity status.
 
 ## Upstreaming to Primer
 

--- a/content/guides/contribute/adding-new-components.mdx
+++ b/content/guides/contribute/adding-new-components.mdx
@@ -1,0 +1,98 @@
+---
+title: Adding new components
+description: Guidance to help you get your components added to Primer. This primary audience for this guidance is GitHub staff.
+---
+
+## On-ramp from product to Primer
+
+The process starts with a new component being introduced as a custom component in a feature team's app and becoming a Primer component once it matures and gets more usage.
+
+This guidance is intended for GitHub staff members who are introducing design patterns that are not yet supported by Primer components. Contributions from Primer consumers who don't work at GitHub are welcome and encouraged, but these steps assume the reader is working on a feature team at GitHub.
+
+### 1. Exists and is discoverable
+
+**Qualities**
+
+- Name
+- Description
+- At least 1 Storybook story
+- No aXe violations
+
+This is the least refined phase of a new component: it just needs to exist. If you've already decided that this is a component worth sharing with other teams, it just needs to be discoverable and pass basic accessibility checks.
+
+<!--
+TODO: uncomment this once we add this documentation
+
+For guidance on what makes a pattern worth sharing, check out the documentation: [Deciding if something is a new pattern]().
+-->
+
+### 2. Meets basic design quality checks
+
+**Qualities**
+
+- Meets the criteria in the [pattern design checklist](https://primer.style/design/guides/contribute/design#design-checklist)
+
+The criteria in the pattern design checklist ensure your pattern is sturdy enough to be used in production and easily picked up by other designers or engineers. For a more detailed quality check, you can refer to the [product design checklist](https://github.com/github/product-design/blob/main/resources/design-checklist.md) (GitHub staff only).
+
+### 3. Has documentation
+
+**Qualities**
+
+- Storybook stories demonstrate all of the pattern's features and options
+- At least meets the [MVP component documentation criteria](https://github.com/primer/design/blob/main/content/components/component-documentation-guidelines/component-MVP-documentation-guidelines.md)
+
+Documentation makes your pattern easier for others to use, and helps the team understand how your pattern could be adopted into Primer.
+
+Resources for writing documentation:
+
+- [Component documentation criteria](https://github.com/primer/design/blob/main/content/components/component-documentation-guidelines/component-documentation-guidelines.md)
+- [Primer documentation guidelines](https://primer.style/design/guides/contribute/documentation)
+
+### 4. Is accessible
+
+**Qualities**
+
+- Passes a11y design review focused on the component
+- Passes a11y engineering review focused on the component
+
+New features already undergo accessibility reviews, but reviews for shared patterns zoom in on smaller and more specific pieces of UI. Every new component we add to Primer goes through rigorous testing by the accessibility team, so your component will be better prepared for adopting and releasing in Primer.
+
+### 5. Ready to upstream
+
+Now your component has satisfied enough criteria that it's already halfway to being at the “Alpha” maturity status! From here, your team or the Primer maintainers will be in a good position to adopt your component and iterate on it until it reaches the “Alpha” maturity status.
+
+## Upstreaming to Primer
+
+Primer has a strict process for adding new components to ensure they meet certain quality criteria and are accessible.
+
+**Initiated by Primer:** If a component gains enough traction that it's being regularly used by multiple feature teams, the Primer maintainers will create and prioritize an issue to upstream it.
+
+**Initiated by a feature team:** If a feature team feels that the component is ready to be upstreamed to Primer, anybody is welcome to create an issue to review the component with Primer maintainers. During that review, the Primer will decide whether or not the component is a good candidate for upstreaming. Use the [Primer pattern proposal issue template](https://github.com/github/primer/issues/new?assignees=&labels=proposal%2C+needs+triage&template=01-pattern-proposal.md&title=%5BProposal%5D+).
+
+### How do Primer maintainers arrive at a decision to upstream?
+
+- Is the pattern frequently used by multiple feature teams?
+- Is this a pattern we want to encourage because it does a good job solving a particular design, engineering, or accessibility problem?
+- Will there be any negative consequences from adding this new component? For example, a negative impact on performance
+- Does it fit in with a “theme” of any existing Primer components? For example, a new data input component would fit in nicely with our existing form components and other patterns for data input
+- Is the time we'd have to invest in owning and maintaining the component worth it?
+
+### Who are the decision makers and stakeholders involved?
+
+The Primer maintainers (designers and engineers) will decide if a component should be upstreamed using input from feature teams and the criteria described above.
+
+### How do Primer maintainers vet components once they're upstreamed?
+
+Once a component is upstreamed, it goes through a [component lifecycle maturity](/guides/component-lifecycle) process until it reaches the stable level.
+
+Once a component meets “Alpha” criteria it's considered safe to be use in production, but consumers can expect breaking changes as it matures to “Beta”. We aim to get all or most components to the “Stable” level of maturity criteria.
+
+## Adding components directly to Primer
+
+Although Primer has a high barrier of entry for introducing new components, contributions from everyone are welcome and encouraged. The contribution documentation and the Primer team members are available to guide new component contributions.
+
+Primer maintainers often lack the bandwidth to do the work for you, but will do our best to answer your questions and help get your contribution to the “Alpha” maturity level.
+
+## Adding more general patterns
+
+If you're pitching design patterns that are lower-level than a component (for example, [data saving patterns](https://primer.style/design/ui-patterns/saving), [focus management utility](https://github.com/primer/behaviors/blob/main/docs/focus-zone.md)), you can create an issue or pull request, share your idea at the Primer patterns weekly working session (only available to GitHub staff), or post to one of Primer's Slack channels (only available to GitHub staff).

--- a/content/guides/contribute/how-to-contribute.mdx
+++ b/content/guides/contribute/how-to-contribute.mdx
@@ -16,7 +16,10 @@ All contributions to Primer need to follow our [code of conduct](https://github.
 
 If at any time you get stuck or need help, head to #primer on Slack or start a discussion in github/primer with your question.
 
-<Note>Please note that at this time, we are not looking for external contributions from non-GitHub staff. Some of the links included in these documents are only available to GitHub staff.</Note>
+<Note>
+  Please note that at this time, we are not looking for external contributions from non-GitHub staff. Some of the links
+  included in these documents are only available to GitHub staff.
+</Note>
 
 ## Participate in discussions
 
@@ -28,19 +31,19 @@ Primer office hours are held once a week and anyone at GitHub can join, ask ques
 
 If you'd like to propose a new Primer pattern, big or small, let's talk! The best way to get started, especially if your proposal is in its early stages, is to start a new [discussion](https://github.com/github/primer/discussions) (GitHub staff only).
 
-If you're more certain about what you need, please open a [pattern request issue](https://github.com/github/primer/issues/new?assignees=&labels=type%3A+request&template=0-request.md&title=%5BRequest%5D+) (GitHub staff only). We will get back to you after our weekly backlog triaging session.
+If you're more certain about what you need, please open a [pattern request issue](https://github.com/github/primer/issues/new?assignees=&labels=proposal%2C+needs+triage&template=01-pattern-proposal.md&title=%5BProposal%5D+) (GitHub staff only). We will get back to you after our weekly backlog triaging session.
 
 ## Improve the documentation
 
 Documentation is a core part of Primer, and, just as design and code, we’re always trying to make it better and more useful. If you notice something missing, a typo, or have an idea of how the docs can be improved, please start a new [discussion](https://github.com/github/primer/discussions), or submit a pull request with a fix (you can do this directly via the “Edit this page on GitHub” link on the footer of docs pages).
 
-Read the Primer guidelines for [writing documentation](https://primer.style/contribute/documentation).
+Read the Primer guidelines for [writing documentation](/guides/contribute/documentation).
 
 ## Design or build new patterns
 
 You can contribute to new patterns either by design, prototype and build proofs of concept, test in dotcom, or directly to our Primer open source repos.
 
-Please read the [guidelines on designing Primer patterns](https://primer.style/contribute/design).
+Please read the guidelines on [adding new components](/guides/contribute/adding-new-components) and [designing Primer patterns](/guides/contribute/design).
 
 From the [Primer project board](https://github.com/orgs/github/projects/2759) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -60,6 +60,8 @@
           url: /guides/contribute/content
         - title: Documentation
           url: /guides/contribute/documentation
+        - title: Adding new components
+          url: /guides/contribute/adding-new-components
 - title: Foundations
   children:
     - title: Color


### PR DESCRIPTION
These changes add a new page with information about how a component can be "on-ramped" into Primer from dotcom, or how a new component can be added directly to Primer.