### PR TITLE
Add guidance about what to do with new patterns

### DIFF
--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -1,0 +1,87 @@
+---
+title: Underline nav
+description: The UnderlineNav is used to display navigation.
+componentId: underline_nav
+reactId: underline_nav
+figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=18843-67449&t=XqqSolC6AzRO9nae-11
+rails: https://primer.style/view-components/components/alpha/underlinenav/
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+export default ComponentLayout
+
+## Usage
+
+The underline nav is used to provide navigation links to related views for the user's current context. It is typically used as primary navigation at the top of the page or as secondary or tertiary navigation when nested in views with a [nav list](/components/nav-list).
+
+## Anatomy
+
+![Anatomy of the UnderlineNav component](https://user-images.githubusercontent.com/175638/186432408-c2479dd2-31fe-4261-9f9a-e67d49b28e72.png)
+
+- **Item**: A navigation link.
+- **Current item**: The item currently selected is highlighted with an underline.
+- **Label**: Describes the navigation item.
+- **Leading icon (optional)**: An icon that identifies the navigation item.
+- **Counter (optional)**: Displays a count next to the label.
+- **Overflow menu**: A disclosure menu that displays additional items when there are too many to fit in the available space.
+
+## Options
+
+### Item
+
+The underline nav is composed of a list of items. Each item is a link that can be selected to navigate to a different page in the current context.
+
+#### Label text
+
+The title of the view associated with that tab. Keep labels clear, short, and concise.
+
+#### Leading icons
+
+Use an [Octicon](/foundations/icons) to improve the scannability of common items, but only when relevant. When adding leading icons, all items in the navigation should have one.
+
+Make sure that icons used are consistent across views, and that they are not repeated for different navigations across the product.
+
+#### Counters
+
+You may include a counter to indicate the number of related resources contained in the desitination page, such as the number of open issues.
+
+When loading multiple counters asynchronously, wait for all the data to be ready before displaying the counters, so you can avoid multiple layout shifts. Use the counter loading state while waiting for the data.
+
+## Layout
+
+### Placement
+
+The underline nav has two possible main placements depending on its intended usage:
+
+- As primary navigation: place it at the top of the page. Ensure any secondary and tertiary navigation is nested under the underline nav.
+- As secondary or tertiary navigation: place it above the main content of the page.
+
+In either scenarios, avoid stacking multiple uderline navs to display multiple levels of navigation.
+
+### Alignment
+
+Align the the underline nav to the left and, when possible, make the component span the available width.
+
+### Responsive design
+
+![The underline nav without overflowing items and the component on a smaller viewport showing the overflow menu](https://user-images.githubusercontent.com/175638/229456836-bfa1ddbb-5cef-4dbc-a0db-da77814c63a2.png)
+
+Underline nav handles overflowing items automatically by collapsing them into a disclosure menu. When some of the items don't fit the available space, the component will first hide leading icons to economize space and then move items to the overflow menu one by one.
+
+## Accessibility
+
+Set `aria-current` to `"page"` to indicate that the item represents the current page. Set `aria-current` to `"location"` to indicate that the item represents the current location on a page.
+
+### Keyboard navigation
+
+Items can be activated using a cursor or keyboard
+
+| Key(s)                                                                                                                                                    | Description                   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <Box as="kbd" backgroundColor="canvas.subtle" borderRadius={1} borderColor="border.default" borderWidth={1} borderStyle="solid" py={1} px={2}>Enter</Box> | Activates the focused item.   |
+| <Box as="kbd" backgroundColor="canvas.subtle" borderRadius={1} borderColor="border.default" borderWidth={1} borderStyle="solid" py={1} px={2}>Tab</Box>   | Moves focus to the next item. |
+
+## Related links
+
+- [Nav list](/components/nav-list)
+- [Tab nav](/components/tab-nav)

--- a/content/guides/contribute/adding-new-components.mdx
+++ b/content/guides/contribute/adding-new-components.mdx
@@ -19,9 +19,7 @@ Your component should have:
 
 This is the least refined phase of a new component: it just needs to exist. If you've already decided that this is a component worth sharing with other teams, it just needs to be discoverable and pass basic accessibility checks.
 
-{/* TODO: uncomment this once we add this documentation
-
-For guidance on what makes a pattern worth sharing, check out the documentation: [Handling new patterns](/guides/contribute/handling-new-patterns). */}
+For guidance on what makes a pattern worth sharing, check out the documentation: [Handling new patterns](/guides/contribute/handling-new-patterns).
 
 ### 2. Meets basic design quality checks
 

--- a/content/guides/contribute/handling-new-patterns.mdx
+++ b/content/guides/contribute/handling-new-patterns.mdx
@@ -34,9 +34,7 @@ Signs that your component is a good candidate for sharing:
 
 Your team is responsible for maintaining the new pattern (unless it gets upstreamed to Primer), but you can always come to Primer for feedback.
 
-{/* TODO: uncomment this after the "Adding new components" page has been added
-
-For more information about piloting new components outside of Primer, read the guidance about the [on-ramp from product to Primer](/guides/contribute/adding-new-components#on-ramp-from-product-to-primer). */}
+For more information about piloting new components outside of Primer, read the guidance about the [on-ramp from product to Primer](/guides/contribute/adding-new-components#on-ramp-from-product-to-primer).
 
 ## Adding new components directly to Primer
 
@@ -54,7 +52,5 @@ Signs that you should add directly to Primer:
 If you know your project is going to need support from Primer maintainers, it's best to come to us as early as possible. We can't design or build quality design patterns to unblock you at the last minute.
 
 
-{/* TODO: uncomment this after the "Adding new components" page has been added
-
-For more information about introducing new components to Primer, read the guidance about [upstreaming components](/guides/contribute/adding-new-components#upstreaming-to-primer) and [adding components directly to Primer](/guides/contribute/adding-new-components#adding-components-directly-to-primer) */}
+For more information about introducing new components to Primer, read the guidance about [upstreaming components](/guides/contribute/adding-new-components#upstreaming-to-primer) and [adding components directly to Primer](/guides/contribute/adding-new-components#adding-components-directly-to-primer).
 

--- a/content/guides/contribute/handling-new-patterns.mdx
+++ b/content/guides/contribute/handling-new-patterns.mdx
@@ -1,0 +1,60 @@
+---
+title: Handling new patterns
+description: Guidance to help Primer consumers decide what to do when discovering a new design pattern. This primary audience for this guidance is GitHub staff.
+---
+
+We know that Primer isn't going to always have exactly what you want when designing a new feature. Explorations done by our product designers are what help us innovate and create components to solve problems that the Primer maintainers haven't considered yet. The Primer maintainers may incorporate those ideas by balancing that work with our bigger strategic initiatives to mature Primer.
+
+## Exploring new components that aren't ready for sharing
+
+We strongly prefer design patterns that are consistent and can be reused for other features, but there is room for patterns that aren't meant to be reused. Our goal isn't to only build a UI from existing components, it's to help all users complete tasks in the most efficient and pleasant way possible. As long as what you ship is accessible, visually consistent, and high-quality: go for it.
+
+Signs that your new component isn't ready to be shared outside of your app:
+
+- The component was rushed and has known issues that need to be addressed after launch
+- It solves a very specific design problem my team encountered, but is unlikely to be useful for other use-cases
+- It's a very complex component that applies to a use-case other apps don't often deal with
+
+## Sharing new components before they land in Primer
+
+GitHub's designers come up with innovative ways to solve difficult problems. Our teams and our products will be stronger if we make our good work available for others, even if it's not through Primer.
+
+There's a long process to vet something into Primer, and we understand how that doesn't always work with your team's deadlines to ship features. Instead of trying to add your new pattern directly into Primer you can start by focusing on how it works for the use-cases your team identified and share it for other designers to try out in their work.
+
+Signs that your component is a good candidate for sharing:
+
+- It's very likely to be used in more than one app
+- It's codifying a pattern that already exists but hasn't been distilled into one or more components for designers and engineers to use
+- The side effects of adding this component will help us move Primer forward. For example, adding form components forced us to consider the interaction patterns for saving or submitting data
+- I can clearly explain what the component is and how it should be used
+- It does not require app data to function properly
+- It's a new pattern that can be used to replace multiple different components that do the same thing but are slightly different
+- It solves my design problem much better than any existing components, and it's likely to be useful for other teams
+
+Your team is responsible for maintaining the new pattern (unless it gets upstreamed to Primer), but you can always come to Primer for feedback.
+
+<!--
+TODO: uncomment this after the "Adding new components" page has been added
+
+For more information about piloting new components outside of Primer, read the guidance about the [on-ramp from product to Primer](/guides/contribute/adding-new-components#on-ramp-from-product-to-primer).
+-->
+
+## Adding new components directly to Primer
+
+Primer intentionally has a high barrier to entry. We want our consumers to be confident that anything they use from Primer is ready to be used in production. Of course, we want to mature Primer as long as it's the right time to make the investment required to add a new component.
+
+Signs that you should add directly to Primer:
+
+- It meets all of the criteria that make it a good candidate for sharing (listed in the previous section)
+- Taking the time to add this component to Primer won't block more impactful work
+- Somebody from my team can add the component to Primer with minimal help from a Primer maintainer
+- Primer maintainers have agreed that this component belongs in Primer and it can be added it in time to launch with my feature
+- It already exists outside of Primer and Primer maintainers agree it should upstreamed
+
+If you know your project is going to need support from Primer maintainers, it's best to come to us as early as possible. We can't design or build quality design patterns to unblock you at the last minute.
+
+<!--
+TODO: uncomment this after the "Adding new components" page has been added
+
+For more information about introducing new components to Primer, read the guidance about [upstreaming components](/guides/contribute/adding-new-components#upstreaming-to-primer) and [adding components directly to Primer](/guides/contribute/adding-new-components#adding-components-directly-to-primer)
+-->

--- a/content/guides/contribute/handling-new-patterns.mdx
+++ b/content/guides/contribute/handling-new-patterns.mdx
@@ -27,17 +27,16 @@ Signs that your component is a good candidate for sharing:
 - It's codifying a pattern that already exists but hasn't been distilled into one or more components for designers and engineers to use
 - The side effects of adding this component will help us move Primer forward. For example, adding form components forced us to consider the interaction patterns for saving or submitting data
 - I can clearly explain what the component is and how it should be used
-- It does not require app data to function properly
+- It does not request data (like an API call) or have any other side effects that aren't available to all apps in the monolith
+- It does not require specific code dependencies that aren't available to all apps in the monolith
 - It's a new pattern that can be used to replace multiple different components that do the same thing but are slightly different
 - It solves my design problem much better than any existing components, and it's likely to be useful for other teams
 
 Your team is responsible for maintaining the new pattern (unless it gets upstreamed to Primer), but you can always come to Primer for feedback.
 
-<!--
-TODO: uncomment this after the "Adding new components" page has been added
+{/* TODO: uncomment this after the "Adding new components" page has been added
 
-For more information about piloting new components outside of Primer, read the guidance about the [on-ramp from product to Primer](/guides/contribute/adding-new-components#on-ramp-from-product-to-primer).
--->
+For more information about piloting new components outside of Primer, read the guidance about the [on-ramp from product to Primer](/guides/contribute/adding-new-components#on-ramp-from-product-to-primer). */}
 
 ## Adding new components directly to Primer
 
@@ -46,6 +45,7 @@ Primer intentionally has a high barrier to entry. We want our consumers to be co
 Signs that you should add directly to Primer:
 
 - It meets all of the criteria that make it a good candidate for sharing (listed in the previous section)
+- It does not require specific code dependencies that only live within the monolith
 - Taking the time to add this component to Primer won't block more impactful work
 - Somebody from my team can add the component to Primer with minimal help from a Primer maintainer
 - Primer maintainers have agreed that this component belongs in Primer and it can be added it in time to launch with my feature
@@ -53,8 +53,8 @@ Signs that you should add directly to Primer:
 
 If you know your project is going to need support from Primer maintainers, it's best to come to us as early as possible. We can't design or build quality design patterns to unblock you at the last minute.
 
-<!--
-TODO: uncomment this after the "Adding new components" page has been added
 
-For more information about introducing new components to Primer, read the guidance about [upstreaming components](/guides/contribute/adding-new-components#upstreaming-to-primer) and [adding components directly to Primer](/guides/contribute/adding-new-components#adding-components-directly-to-primer)
--->
+{/* TODO: uncomment this after the "Adding new components" page has been added
+
+For more information about introducing new components to Primer, read the guidance about [upstreaming components](/guides/contribute/adding-new-components#upstreaming-to-primer) and [adding components directly to Primer](/guides/contribute/adding-new-components#adding-components-directly-to-primer) */}
+

--- a/content/guides/contribute/how-to-contribute.mdx
+++ b/content/guides/contribute/how-to-contribute.mdx
@@ -16,7 +16,10 @@ All contributions to Primer need to follow our [code of conduct](https://github.
 
 If at any time you get stuck or need help, head to #primer on Slack or start a discussion in github/primer with your question.
 
-<Note>Please note that at this time, we are not looking for external contributions from non-GitHub staff. Some of the links included in these documents are only available to GitHub staff.</Note>
+<Note>
+  Please note that at this time, we are not looking for external contributions from non-GitHub staff. Some of the links
+  included in these documents are only available to GitHub staff.
+</Note>
 
 ## Participate in discussions
 
@@ -41,6 +44,8 @@ Read the Primer guidelines for [writing documentation](https://primer.style/cont
 You can contribute to new patterns either by design, prototype and build proofs of concept, test in dotcom, or directly to our Primer open source repos.
 
 Please read the [guidelines on designing Primer patterns](https://primer.style/contribute/design).
+
+Please read the guidelines on how to [handle new patterns](/guides/contribute/handling-new-patterns)<!-- TODO: uncomment this once this page exists [adding new components](/guides/contribute/adding-new-components)--> and [designing Primer patterns](/guides/contribute/design).
 
 From the [Primer project board](https://github.com/orgs/github/projects/2759) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -212,6 +212,8 @@
       url: /components/token
     - title: Tree view
       url: /components/tree-view
+    - title: Underline nav
+      url: /components/underline-nav
 - title: Native
   url: /native
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -60,6 +60,8 @@
           url: /guides/contribute/content
         - title: Documentation
           url: /guides/contribute/documentation
+        - title: Handling new patterns
+          url: /guides/contribute/handling-new-patterns
 - title: Foundations
   children:
     - title: Color


### PR DESCRIPTION
These changes add a new page to help designers and engineers decide how to proceed with new patterns they come up with. It focuses on whether or not a component should be added to Primer and what should be done if the component isn't a good fit for Primer yet.