### PR TITLE
Fix Figma layout missing Rails tabs 

### DIFF
--- a/content/components/relative-time.mdx
+++ b/content/components/relative-time.mdx
@@ -2,10 +2,13 @@
 title: Relative time
 description: Relative time displays time in a way that is clear, concise, and accessible.
 reactId: relative_time
+railsId: Primer::Beta::RelativeTime
 componentId: relative_time
 ---
 
 import {Box} from '@primer/react'
+import ComponentLayout from '~/src/layouts/component-layout'
+export default ComponentLayout
 
 ## Overview
 

--- a/src/layouts/figma-component-layout.tsx
+++ b/src/layouts/figma-component-layout.tsx
@@ -23,7 +23,7 @@ export const query = graphql`
           description
           reactId
           figmaId
-          railsUrl: rails
+          railsId
         }
       }
     }
@@ -91,7 +91,7 @@ export default function FigmaComponentLayout({data}) {
           <ComponentPageNav
             basePath={data.sitePage.path}
             includeReact={data.sitePage.context.frontmatter.reactId}
-            includeRails={data.sitePage.context.frontmatter.railsUrl}
+            includeRails={data.sitePage.context.frontmatter.railsId}
             includeFigma={data.sitePage.context.frontmatter.figmaId}
             current="figma"
           />


### PR DESCRIPTION
- Fix Figma layout to use RailsId instead of RailsURL
- Update `RelativeTime` component to use the new layout