### PR TITLE
Expose Rails version of ActionMenu in docs

### DIFF
--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -1,6 +1,7 @@
 ---
 title: Action menu
 reactId: action_menu
+railsId: Primer::Alpha::ActionMenu
 description: Action menu is composed of action list and overlay patterns used for quick actions and selections.
 ---
 


### PR DESCRIPTION
We recently landed the Rails version of `ActionMenu` and would like to expose it in the new docsite.