### PR TITLE
Add additional guidance for required input fields

### DIFF
--- a/content/ui-patterns/forms.mdx
+++ b/content/ui-patterns/forms.mdx
@@ -23,7 +23,16 @@ Placeholder text is never an acceptable substitute for a label because:
 
 ### Required field indicator
 
-When a field is required to have a value, it should be visibly marked as required. An individual checkbox or radio button cannot be marked as required.
+When a field is required to have a value, it should be visibly marked as required. 
+
+This guidance applies to sitations where all fields are required. The exception to this are common interaction patterns such as login forms, where there is the expectation that:
+
+- All items are required, and that 
+- Input validation will help communicate the input being required if left out on submission.
+
+Fields visually marked as required should also be set as required in code. This creates a parity in experience for all users.
+
+An individual checkbox or radio button cannot be marked as required.
 
 ### Input (required)
 


### PR DESCRIPTION
This PR addresses these two conversations in Slack:

1. [Thread on required fields in #accessibility](https://github.slack.com/archives/C0FSWLQ0Y/p1681910695074239)
1. Private channel (linked internally to this PR on Slack)

It adds additional language about when all fields in a form are required, as well as indicating that programmatically marking a field as required is also necessary for maintaining equivalency in experience. 