### PR TITLE
docs(Accessibility): the contact from is no more

### DIFF
--- a/content/guides/accessibility/accessibility-at-github.mdx
+++ b/content/guides/accessibility/accessibility-at-github.mdx
@@ -55,6 +55,6 @@ If you're GitHub staff and need help with accessibility:
 
 ## Support
 
-Accessibility is a priority for GitHub. If you ever encounter accessibility related issues when using github.com, please don’t hesitate to get in touch via [the contact page](https://support.github.com/contact) or email [support@github.com](mailto:support@github.com) with your concerns.
+Accessibility is a priority for GitHub. If you ever encounter accessibility related issues when using github.com, please don’t hesitate to get in touch via email [support@github.com](mailto:support@github.com) with your concerns.
 
 For information about the accessibility compliance of GitHub products, please refer to the [VPAT report, outlining §508 accessibility information for GitHub.com, GitHub Enterprise, and GitHub Desktop](https://government.github.com/accessibility/).


### PR DESCRIPTION
We could link to https://github.com/orgs/community/discussions/categories/accessibility as an addition to the email contact, I'm not sure if that's what you want though