### PR TITLE
docs: fix link to to Link component

### DIFF
--- a/content/components/link.mdx
+++ b/content/components/link.mdx
@@ -214,7 +214,7 @@ Some examples of this are:
 ### For engineers
 
 - Use Primer link components:
-  - [Link in Primer ViewComponents](https://primer.style/view-components/components/link)
+  - [Link in Primer ViewComponents](https://primer.style/view-components/components/beta/link)
   - [Link in Primer React](https://primer.style/react/Link)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard (reference: [Focus management](/guides/accessibility/focus-management))

--- a/content/guides/accessibility/links.mdx
+++ b/content/guides/accessibility/links.mdx
@@ -179,7 +179,7 @@ Some examples of this are:
 ### For engineers
 
 - Use Primer link components:
-  - [Link in Primer ViewComponents](https://primer.style/view-components/components/link)
+  - [Link in Primer ViewComponents](https://primer.style/view-components/components/beta/link)
   - [Link in Primer React](https://primer.style/react/Link)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard (reference: [Focus management](/guides/accessibility/focus-management))


### PR DESCRIPTION
Replace https://primer.style/view-components/components/link with https://primer.style/view-components/components/beta/link