### PR TITLE
Update tooltip-alternatives.mdx

### DIFF
--- a/content/guides/accessibility/tooltip-alternatives.mdx
+++ b/content/guides/accessibility/tooltip-alternatives.mdx
@@ -170,4 +170,4 @@ If you are unsure which alternative is more suited to your scenario and need hel
 ## Additional resources
 
 - [Your tooltips are bogus](https://heydonworks.com/article/your-tooltips-are-bogus/)
-- [erb lint rule: NoAriaLabelMisuseCounter](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/no-aria-label-misuse-counter.md#no-aria-label-misuse-counter)
+- [erb lint rule: NoAriaLabelMisuse](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/no-aria-label-misuse.md#no-aria-label-misuse)


### PR DESCRIPTION
One of the links (https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/no-aria-label-misuse-counter.md) on the additional resources is broken. Updating the readme with the correct link (https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/no-aria-label-misuse.md) and name of the doc