### PR TITLE
Add Rails migration guides + a few missing components

### DIFF
--- a/content/components/blankslate.mdx
+++ b/content/components/blankslate.mdx
@@ -1,0 +1,14 @@
+---
+title: Blankslate
+description: Use Blankslate as placeholder to tell users why content is missing.
+railsId: Primer::Beta::Blankslate
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/layout.mdx
+++ b/content/components/layout.mdx
@@ -1,0 +1,14 @@
+---
+title: Layout
+description: Layout provides foundational patterns for responsive pages.
+railsId: Primer::Alpha::Layout
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/truncate.mdx
+++ b/content/components/truncate.mdx
@@ -1,0 +1,14 @@
+---
+title: Truncate
+description: Use Truncate to shorten overflowing text with an ellipsis.
+railsId: Primer::Beta::Truncate
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/guides/development/rails/index.mdx
+++ b/content/guides/development/rails/index.mdx
@@ -1,0 +1,93 @@
+---
+title: Rails
+description: Get started using Primer ViewComponents in your Rails application.
+source: https://github.com/primer/view_components
+---
+
+Primer ViewComponents is an implementation of the Primer Design System, using [ViewComponent](https://github.com/github/view_component).
+
+<Note variant="warning">This library is under active pre-1.0 development. Breaking changes are likely in patch releases.</Note>
+
+## Getting started
+
+In your `Gemfile`, add:
+
+```ruby
+gem "primer_view_components"
+```
+
+In `config/application.rb`, add **after the application definition**:
+
+```ruby
+require "view_component"
+require "primer/view_components/engine"
+```
+
+Optionally, to add the JavaScript behaviours, in your `application.html.erb` in the `<head>` tag add:
+
+```erb
+<%= javascript_include_tag("primer_view_components") %>
+```
+
+Or alternatively, you can install the `@primer/view-components` npm package and in your JavaScript code add:
+
+```js
+import '@primer/view-components'
+```
+
+You can also import only the components you need:
+
+```js
+import '@primer/view-components/tab_container'
+```
+
+## Usage
+
+Render Primer ViewComponents in Rails templates:
+
+```erb
+<%= render(Primer::Beta::Counter.new(count: 25)) %>
+```
+
+## Dependencies
+
+In addition to the dependencies declared in the `gemspec`, Primer ViewComponents assumes the presence of [Primer CSS](https://primer.style/css/getting-started).
+
+## Migration and upgrade guides
+
+Primer ViewComponents are routinely deprecated as they mature. The following guides detail performing component upgrades.
+
+### Migrating from Primer CSS
+
+Many Primer CSS use cases are supported by Primer ViewComponents.
+
+When migrating from Primer CSS classes to ViewComponents, use this mapping to
+help guide your implementation. This list includes components currently in
+stable status.
+
+| Primer CSS Class | ViewComponent |
+|------------------|---------------|
+| [`State`](https://primer.style/css/components/labels#states)             | [`Primer::Beta::State`](/components/state-label/rails)              |
+| [`breadcrumb-item`](https://primer.style/css/components/breadcrumb)      | [`Primer::Beta::Breadcrumbs`](/components/breadcrumbs/rails)    |
+| [`Counter`](https://primer.style/css/stickersheet/labels#counters)       | [`Primer::Beta::Counter`](/components/counter-label/rails)          |
+| [`Subhead`](https://primer.style/css/components/subhead)                 | [`Primer::Beta::Subhead`](/components/subhead/rails)          |
+| [`blankslate`](https://primer.style/css/components/blankslate)           | [`Primer::Beta::Blankslate`](/components/blankslate/rails)    |
+
+### Upgrading deprecated components
+
+As Primer ViewComponents are updated, there are often breaking changes and
+deprecations that require changes which cannot be auto-corrected with Rubocop or
+other tools. These guides will walk you through the upgrade process for specific
+components.
+
+| Deprecated Component | Replacement Component | Guide |
+|----------------------|-----------------------|-------|
+| `Primer::ButtonComponent` | [`Primer::Beta::Button`](/components/button/rails) | [Upgrade to Primer::Beta::Button](/guides/development/rails/migration-guides/primer-button-component) |
+| `Primer::LayoutComponent` | [`Primer::Alpha::Layout`](/components/layout/rails) | [Upgrade to Primer::Alpha::Layout](/guides/development/rails/migration-guides/primer-layout-component) |
+| `Primer::LocalTime` | [`Primer::Beta::RelativeTime`](/components/relative-time/rails) | [Upgrade to Primer::Beta::RelativeTime](/guides/development/rails/migration-guides/primer-local-time) |
+| `Primer::TimeAgoComponent` | [`Primer::Beta::RelativeTime`](/components/relative-time/rails) | [Upgrade to Primer::Beta::RelativeTime](/guides/development/rails/migration-guides/primer-time-ago) |
+| `Primer::Truncate` | [`Primer::Beta::Truncate`](/components/truncate/rails) | [Upgrade to Primer::Beta::Truncate](/guides/development/rails/migration-guides/primer-truncate) |
+
+## More information
+
+See the [primer/view_components repository](https://github.com/primer/view_components) for more information about how to use and contribute to Primer ViewComponents. For component-specific documentation, check out the Rails section of component guidelines (example: [ActionList](/components/action-list/rails)).

--- a/content/guides/development/rails/migration-guides/primer-button-component.mdx
+++ b/content/guides/development/rails/migration-guides/primer-button-component.mdx
@@ -1,0 +1,41 @@
+---
+title: Moving Away From Primer::ButtonComponent
+---
+
+This guide will show you how to upgrade from the now deprecated
+`Primer::ButtonComponent` to the latest [`Primer::Beta::Button`](/components/button/rails)
+component.
+
+## Arguments
+
+The following arguments for the component initializer have changed between the deprecated and newer versions
+of the Primer Button.
+
+| From `Primer::ButtonComponent` | To `Primer::Beta::Button` | Notes |
+|--------------------------------|---------------------------|-------|
+| `dropdown`   | n/a      | removed in `Primer::Beta::Button`                  |
+| `group_item` | n/a      | removed in `Primer::Beta::Button`                  |
+| `scheme`     | `scheme` | removed `:outline` value. use `:invisible` instead |
+| `variant`    | `size`   | renamed; values remain the same                    |
+
+The remaining arguments have stayed the same.
+
+`Primer::Beta::Button` no longer supports the boolean settings for being part of
+a group, nor the dropdown caret via initializer argument. See the following for examples of how to replace
+this functionality.
+
+* Button groups: [`Primer::Beta::ButtonGroup`](/components/beta/buttongroup)
+* Trailing counter: [`trailing_visual` slot](https://primer.style/view-components/lookbook/inspect/primer/beta/button/trailing_visual)
+* Trailing caret: [`trailing_action` slot](https://primer.style/view-components/lookbook/inspect/primer/beta/button/trailing_action)
+
+## Slot Names
+
+The following slots have changed with the newer Primer Button.
+
+| From `Primer::ButtonComponent` | To `Primer::Beta::Button` | Notes |
+|--------------------------------|---------------------------|-------|
+| n/a | `trailing_action` | appears to the right of the `trailing_visual` slot |
+
+The remaining slot names have stayed the same.
+
+[&larr; Back to development docs](/guides/development/rails#upgrading-deprecated-components)

--- a/content/guides/development/rails/migration-guides/primer-layout-component.mdx
+++ b/content/guides/development/rails/migration-guides/primer-layout-component.mdx
@@ -1,0 +1,148 @@
+---
+title: Moving Away From Primer::LayoutComponent
+---
+
+This guide will show you how to upgrade from the now-deprecated
+`Primer::LayoutComponent` to the latest
+[`Primer::Alpha::Layout`](/components/layout/rails)
+component.
+
+## Features and Examples
+
+`Primer::Alpha::Layout` deprecates some arguments and also provides a few new
+capabilities.
+
+### Sidebar width
+
+The deprecated `Primer::LayoutComponent` configures sidebar width as an integer
+number of columns. With `Primer::Alpha::Layout` we set the sidebar width to one
+of `:default`, `:narrow`, or `:wide`. Those correspond to numbers that vary
+according to the layout's breakpoint; see the [the component's
+documentation](/components/layout/rails#sidebar-widths)
+for specific breakpoint widths.
+
+For example, to create a narrower sidebar:
+
+```erb
+<%= render(Primer::Alpha::Layout.new) do |component| %>
+  <% component.with_main { "Main" } %>
+  <% component.with_sidebar(width: :narrow) { "Sidebar" } %>
+<% end %>
+```
+
+### Sidebar placement
+
+Sidebar placement was previously limited to either `:left` or `:right`. We can
+still configure those, but we can also now configure whether the sidebar should
+be above or below the main content when breaking into row mode.
+
+For example, suppose we previously had a sidebar on the left, and would like it
+to be above the main content when the page breaks into row mode.
+
+With `Primer::LayoutComponent` we'd probably have something like this:
+
+```erb
+<%= render(Primer::LayoutComponent.new(side: :left)) do |component| %>
+  <% component.with_sidebar { "Sidebar" } %>
+  <% component.with_main { "Main" } %>
+<% end %>
+```
+
+When migrating to `Primer::Alpha::Layout` we might try:
+
+```erb
+<%= render(Primer::Alpha::Layout.new) do |component| %>
+  <% component.with_main { "Main" } %>
+  <% component.with_sidebar(col_placement: :start, row_placement: :start) { "Sidebar" } %>
+<% end %>
+```
+
+To keep the sidebar *below* the main content, though, we could've set
+`row_placement: :end`, or hidden it entirely with `row_placement: :none`.
+
+### Reordering keyboard order
+
+We might want to manually set the focus order for keyboard navigation for
+accessibility reasons. Under `Primer::LayoutComponent` we might reorder the
+components in the source, but `Primer::Alpha::LayoutComponent` can override that
+with the `first_in_source` argument, which can be either `:main` or `:sidebar`.
+
+For example, to ensure that keyboard focus always visits the sidebar before the
+main content:
+
+```erb
+<%= render(Primer::Alpha::Layout.new(first_in_source: :sidebar)) do |component| %>
+  <% component.with_main { "Main" } %>
+  <% component.with_sidebar { "Sidebar" } %>
+<% end %>
+```
+
+### Specific breakpoints to control responsiveness
+
+Where previously `Primer::LayoutComponent` only offered `responsiveness: true`
+to enable a breakpoint, we can now be more specific by setting the
+`stacking_breakpoint` argument to one of `:sm`, `:med`, or `:lg`. Setting a
+larger breakpoint will cause the layout to shift into row mode on a wider
+screen.
+
+For example, to retain columns on a smaller screen:
+
+```erb
+<%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :sm)) do |component| %>
+  <% component.with_main { "Main" } %>
+  <% component.with_sidebar { "Sidebar" } %>
+<% end %>
+```
+
+### Configurable gutter width
+
+`Primer::Alpha::Layout` includes a new `gutter` argument to configure the width
+of the gutter between the sidebar and main content, which can be one of `:none`,
+`:condensed`, `:default`, or `:spacious`.
+
+For example, to create an especially roomy gutter:
+
+```erb
+<%= render(Primer::Alpha::Layout.new(gutter: :spacious)) do |component| %>
+  <% component.with_main { "Main" } %>
+  <% component.with_sidebar { "Sidebar" } %>
+<% end %>
+```
+
+## Arguments
+
+The following arguments are different between `Primer::LayoutComponent` and
+`Primer::Alpha::Layout`:
+
+| From `Primer::LayoutComponent` | To `Primer::Alpha::Layout` | Notes                                                                                                                                                    |
+|--------------------------------|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `responsive`                   | `stacking_breakpoint`      | When to collapse from columns to rows. Previously a Boolean, now one of `:lg`, `:med`, or `:sm`.                                                         |
+| n/a                            | `first_in_source`          | Which element to render first in HTML, determining keyboard navigation order. Either `:main` or `:sidebar`.                                              |
+| n/a                            | `gutter`                   | Amount of space between the sidebar and main section. One of `:none`, `:condensed`, `:default`, or `:spacious`.                                          |
+| `side`                         | n/a                        | Which side should the sidebar be on? Previously either `:right` or `:left`, now handled by the `col_placement` and `row_placement` slots on the sidebar. |
+| `sidebar_col`                  | n/a                        | Width of the sidebar in columns. Now handled by the `width` slot on the sidebar.                                                                         |
+
+The main and sidebar components also have some new, additional slots.
+
+New on the `main` component:
+
+* `width`: One of `:full`, `:xl`, `:lg`, or `:med`. A `:full` width will stretch
+  the main column to cover all available space.
+
+New on the `sidebar` component:
+
+* `width`: One of `:default`, `:narrow`, or `:wide`. Replaces the deprecated
+  `Primer::LayoutComponent#sidebar_col` argument.
+* `col_placement`: Sidebar placement in column mode. One of `:start` or `:end`.
+  Use this in combination with `row_placement` to duplicate the functionality of
+  the deprecated `Primer::LayoutComponent#side` argument.
+* `row_placement`: Sidebar placement in row mode. One of `:start`, `:end`, or `:none`.
+
+Please see the following documentation for complete descriptions and examples.
+
+* [`Primer::Alpha::Layout` component](/components/layout/rails)
+* [`Primer::Alpha::Layout` Lookbook examples](https://primer.style/view-components/lookbook/inspect/primer/alpha/layout/default)
+
+<p>&nbsp;</p>
+
+[&larr; Back to development docs](/guides/development/rails#upgrading-deprecated-components)

--- a/content/guides/development/rails/migration-guides/primer-local-time.mdx
+++ b/content/guides/development/rails/migration-guides/primer-local-time.mdx
@@ -1,0 +1,62 @@
+---
+title: Moving Away From Primer::LocalTime
+---
+
+This guide will show you how to upgrade from the now deprecated
+`Primer::LocalTime` component to the latest [`Primer::Beta::RelativeTime`](/components/relative-time/rails)
+component.
+
+## A Migration Example
+
+The most common use case of the `LocalTime` component can be migrated with only
+a few minor changes.
+
+For example, if the `LocalTime` was set up in this way:
+
+```erb
+<%= Primer::LocalTime(datetime: Time.now, initial_text: Time.now.iso8601) %>
+```
+
+It can be migrated by removing `initial_text`, setting an empty `prefix`, and
+adding `threshold: "PT0S"`.
+
+```erb
+<%= Primer::Beta::RelativeTime(datetime: Time.now, prefix: "", threshold: "PT0S") %>
+```
+
+The `RelativeTime` component defaults to the `iso8601` format and does not need
+to be specified directly.
+
+The `threshold` value is an [ISO-8601 "duration"](https://en.wikipedia.org/wiki/ISO_8601#Durations) that tells the `RelativeTime`
+component to display the absolute date/time, instead of relative time
+description. The example of `PT0S` says to switch to absolute time display
+starting zero (0) seconds ago. In practice, this means it will always display
+the absolute time. With the `LocalTime` component, `PT0S` was the default
+threshold. The `RelativeTime` component defaults to `P30D`, however, and
+it will need to be zeroed out to always display a datetime.
+
+## Arguments
+
+The following arguments are different between `LocalTime` and `RelativeTime`.
+
+| From `Primer::LocalTime` | To `Primer::Beta::RelativeTime` | Notes |
+|--------------------------|---------------------------------|-------|
+| `initial_text` | n/a         | No longer used.                                                                                                     |
+| n/a            | `tense`     | Which tense to use. One of `:auto`, `:future`, or `:past`.                                                          |
+| n/a            | `prefix`    | What to prefix the relative ime display with.                                                                       |
+| n/a            | `threshold` | The threshold, in ISO-8601 'durations' format, at which relative time displays become absolute.                                                      |
+| n/a            | `precision` | The precision elapsed time should display. One of nil, `:day`, `:hour`, `:minute`, `:month`, `:second`, or `:year`. |
+| n/a            | `format`    | The format the display should take. One of `:auto`, `:elapsed`, or `:micro`.                                        |
+| n/a            | `lang`      | The language to use.                                                                                                |
+| n/a            | `title`     | Provide a custom title to the element.                                                                              |
+
+The remaining arguments stayed the same.
+
+Please see the following documentation for complete descriptions and examples.
+
+* [`Primer::Beta::RelativeTime` component](/components/relative-time/rails)
+* [`Primer::Beta::RelativeTime` Lookbook examples](https://primer.style/view-components/lookbook/inspect/primer/beta/relativetime/default)
+
+<p>&nbsp;</p>
+
+[&larr; Back to development docs](/guides/development/rails#upgrading-deprecated-components)

--- a/content/guides/development/rails/migration-guides/primer-time-ago.mdx
+++ b/content/guides/development/rails/migration-guides/primer-time-ago.mdx
@@ -1,0 +1,48 @@
+---
+title: Moving Away From Primer::TimeAgoComponent
+---
+
+This guide will show you how to upgrade from the now deprecated
+`Primer::TimeAgoComponent` to the latest [`Primer::Beta::RelativeTime`](/components/relative-time/rails)
+component.
+
+## A Migration Example
+
+Use of the `TimeAgoComponent` component can be migrated with only a few minor changes.
+
+For example, if the `TimeAgoComponent` was set up in this way:
+
+```rb
+<%= render(Primer::TimeAgoComponent.new(time: Time.at(628232400))) %>
+```
+
+It can be migrated by renaming `time` to `datetime`, and adding the `tense:
+:past` setting.
+
+```rb
+<%= render(Primer::Beta::RelativeTime.new(datetime: Time.at(628232400), tense: :past)) %>
+```
+
+## Arguments
+
+The majority of options available in `RelativeTime` are not relevant when
+using it as a replacement for `TimeAgo`. There are a few changes that need to be
+noted, however.
+
+| From `Primer::TimeAgoComponent` | To `Primer::Beta::RelativeTime` | Notes |
+|---------------------------------|---------------------------------|-------|
+| `time`  | `datetime`       | Renamed argument, but the semantics remain the same                                                                     |
+| `micro` | `format: :micro` | Instead of a boolean flag, set the `format` argument to the value of `:micro`                                           |
+| n/a     | `tense: :past`   | Required for displaying how long ago the set time was. This argument tells `RelativeTime` to behave like `TimeAgo` did. |
+
+The remaining arguments for `RelativeTime` can be found in the documentation for
+that component.
+
+Please see the following for complete descriptions and examples.
+
+* [`Primer::Beta::RelativeTime` component](/components/relative-time/rails)
+* [`Primer::Beta::RelativeTime` Lookbook examples](https://primer.style/view-components/lookbook/inspect/primer/beta/relative_time_preview/default)
+
+<p>&nbsp;</p>
+
+[&larr; Back to development docs](/guides/development/rails#upgrading-deprecated-components)

--- a/content/guides/development/rails/migration-guides/primer-truncate.mdx
+++ b/content/guides/development/rails/migration-guides/primer-truncate.mdx
@@ -1,0 +1,64 @@
+---
+title: Moving Away From `Primer::Truncate`
+---
+
+This guide will show you how to upgrade from the now-deprecated
+Primer::Truncate component to the latest [`Primer::Beta::Truncate`](/components/truncate/rails)
+component.
+
+The new `Truncate` component additionally now includes a text slot used for the
+truncated text.
+
+## Some Migration Examples
+
+Migrating the most common use cases of the `Truncate` component simply requires
+changing the name.
+
+Previously we might have something like:
+
+```erb
+<%= render(Primer::Truncate.new(tag: :p)) { "Some really, really verbose content" } %>
+```
+
+That's now:
+
+```erb
+<%= render(Primer::Beta::Truncate.new(tag: :p)) { "Some really, really verbose content" } %>
+```
+
+The `tag` argument now defaults to `:span` instead of `:div`, so if we want to
+continue wrapping content in `<div>` tags we'll need to explicitly set that. So,
+if we'd been using:
+
+```erb
+<%= render(Primer::Truncate.new) { "Some more very very long text" } %>
+```
+
+We can now equivalently write:
+
+```erb
+<%= render(Primer::Beta::Truncate.new(tag: :div)) { "Some more very very long text" } %>
+```
+
+## Arguments
+
+The following arguments for the component initializer have changed between the deprecated and newer versions
+of the `Truncate` component.
+
+| From `Primer::Truncate` | To `Primer::Beta::Truncate` | Notes                                                                    |
+|-------------------------|-----------------------------|--------------------------------------------------------------------------|
+| `tag`                   | `tag`                       | Previously defaulted to `:div`, now `:span`.                             |
+| `inline`                | n/a                         | Removed in `Primer::Beta::Truncate`.                                     |
+| n/a                     | `priority`                  | If `true`, the text will be given priority (by increasing `flex-basis`). |
+
+The remaining arguments for `Truncate` can be found in the documentation for
+that component.
+
+Please see the following for complete descriptions and examples.
+
+* [`Primer::Beta::Truncate` component](/components/truncate/rails)
+* [`Primer::Beta::Truncate` Lookbook examples](https://primer.style/view-components/lookbook/inspect/primer/beta/truncate/default)
+
+<p>&nbsp;</p>
+
+[&larr; Back to development docs](/guides/development/rails#upgrading-deprecated-components)

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -18,6 +18,8 @@
       children:
         - title: React
           url: /guides/development/react
+        - title: Rails
+          url: /guides/development/rails
     - title: Component lifecycle
       url: /guides/component-lifecycle
     - title: Component status
@@ -144,6 +146,8 @@
       url: /components/avatar-pair
     - title: Avatar stack
       url: /components/avatar-stack
+    - title: Blankslate
+      url: /components/blankslate
     - title: Box
       url: /components/box
     - title: Branch name
@@ -180,6 +184,8 @@
       url: /components/heading
     - title: Label
       url: /components/label
+    - title: Layout
+      url: /components/layout
     - title: Icon
       url: /components/icon
     - title: Icon button
@@ -238,6 +244,8 @@
       url: /components/token
     - title: Tree view
       url: /components/tree-view
+    - title: Truncate
+      url: /components/truncate
     - title: Underline nav
       url: /components/underline-nav
 - title: Native

--- a/src/layouts/rails-component-layout.tsx
+++ b/src/layouts/rails-component-layout.tsx
@@ -307,7 +307,7 @@ export default function RailsComponentLayout({data}) {
             </Text>
             <TableOfContents aria-labelledby="toc-heading" items={tableOfContents.items} />
           </Box>
-          <Box>
+          <Box sx={{'flexGrow': 1}}>
             <Box sx={{display: 'flex', gap: 2, mb: 4}}>
               <Label size="large">v{data.primerRailsVersion.version}</Label>
               <StatusLabel status={sentenceCase(status)} />
@@ -320,11 +320,6 @@ export default function RailsComponentLayout({data}) {
               The <InlineCode>{name}</InlineCode> component is part of the <Link as={GatsbyLink} to="/ui-patterns/forms/rails">Primer forms framework</Link>.
               If you're building a form, please consider using the framework instead of this standalone component.
             </Note>}
-
-            {is_published && <p>
-              <strong>NOTE: </strong>
-              These docs are being migrated. The originals are available <Link href={railsUrl}><LinkExternalIcon /> here</Link>.
-            </p>}
 
             <H2>Description</H2>
             <RailsMarkdown text={data.railsComponent.description} parentRailsId={railsId} />


### PR DESCRIPTION
This PR copies over the existing Rails migration guides [here](https://primer.style/view-components/migration). A couple of additional components mentioned in the guide haven't been brought over yet, so I also added them.