### PR TITLE
Make `CommentBox` placeholder text optional

### DIFF
--- a/content/components/comment-box.mdx
+++ b/content/components/comment-box.mdx
@@ -65,9 +65,9 @@ It's recommended to _always_ show a heading to give users a permanent descriptio
   </Dont>
 </DoDontContainer>
 
-### Placeholder text (recommended)
+### Placeholder text (optional)
 
-The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. A placeholder text is not required, but can help suggest CommentBox features specific to a component implementation, such as slash commands. Having a placeholder text also helps with improving usablity and making sure users know where to start typing. The default placeholder text is "Type your comment here...".
+The placeholder text is meant to give users addtional hints. Keep in mind that it will disappear as soon as users start typing. By default a comment box has no placeholder text, but can help suggest features specific to an implementation, such as slash commands. Having a placeholder text can also help with improving usablity and making sure users know where to start typing. For example by adding a placeholder text like "Add your comment here...".
 
 <DoDontContainer>
   <Do>


### PR DESCRIPTION
This updates the `CommentBox` component with:

- [x] Make the placeholder text optional (no default)
    - 👉 Addresses https://github.com/github/primer/pull/2303#discussion_r1210634103
- [x] Change example to "Add your comment here..."
    - 👉  Addresses https://github.com/github/primer/pull/2303#discussion_r1210635678