### PR TITLE
Remove placeholder image on Octovisuals page

### DIFF
--- a/content/foundations/icons/octovisuals.mdx
+++ b/content/foundations/icons/octovisuals.mdx
@@ -25,10 +25,6 @@ GitHub's brand is visually expressed in a multitude of ways depending on the pro
 
 <br />
 
-<Box as="img" src={OctovisualsBanner} sx={{width: '100%'}} alt="Octovisuals" />
-
-<hr />
-
 ### Permitted GitHub logos
 
 <br />

--- a/content/foundations/icons/octovisuals.mdx
+++ b/content/foundations/icons/octovisuals.mdx
@@ -32,7 +32,7 @@ GitHub's brand is visually expressed in a multitude of ways depending on the pro
 <Box className="octovisual_assets">
   <Box
     sx={{
-      margin: '0px 24px 32px 24px',
+      margin: '0px 24px 32px 0px',
       border: '1px solid #d0d7de',
       borderTopRightRadius: '3px',
       borderTopLeftRadius: '3px',


### PR DESCRIPTION
There's a placeholder image showing Octicons on the Octovisuals page. Removing this until we have an image reflecting Octovisuals.

I also fixed the alignment of the 'Permitted logos' boxes as there was a left-margin that was causing them to be misaligned.

### Before
<img width="1601" alt="Screenshot 2023-06-02 at 11 25 25 AM" src="https://github.com/primer/design/assets/586552/bba781d9-fa3a-4319-81dc-1b896d43ff8e">


### After
<img width="1609" alt="Screenshot 2023-06-02 at 11 25 14 AM" src="https://github.com/primer/design/assets/586552/2d5a6727-edc2-4693-9287-0f0a245452cf">
