### PR TITLE
Add a page to explain 'shared components' and where to find them

### DIFF
--- a/content/components/github-shared-components.mdx
+++ b/content/components/github-shared-components.mdx
@@ -21,4 +21,4 @@ For more information on the upstreaming process and how existing components can 
 
 GitHub shared components are documented in a private Storybook instance: [ui/packages/ Storybook](https://gh.io/storybook) (only available to GitHub staff).
 
-Please note that these components will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1) (only available to GitHub staff), until they have been successfully upstreamed into Primer.
+Please note that these components will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1), until they have been successfully upstreamed into Primer.

--- a/content/components/github-shared-components.mdx
+++ b/content/components/github-shared-components.mdx
@@ -5,7 +5,7 @@ description: Components that are shared by GitHub feature teams, but are not pub
 
 <Note>This information is only relevant to GitHub staff.</Note>
 
-These components support new design patterns that have been piloted by feature teams outside of Primer. While we encourage relying only on Primer components, we also value exploring new ideas without exhaustive the vetting process required for inclusion in Primer.
+These components support new design patterns that have been piloted by feature teams outside of Primer. While we encourage relying only on Primer components, we also value exploring new ideas without the exhaustive vetting process required for inclusion in Primer.
 
 To ensure consistency and seamless collaboration, we recommend sharing these components with other teams by developing them as React components within the `ui/packages/` monorepo. This monorepo, along with the larger monolith, provides a solid foundation with baseline configurations for linting, accessibility scanning using Axe, and Storybook previews.
 

--- a/content/components/github-shared-components.mdx
+++ b/content/components/github-shared-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Privately shared components
+title: GitHub shared components
 description: Components that are shared by GitHub feature teams, but are not publicly available in Primer yet.
 ---
 
@@ -19,6 +19,6 @@ For more information on the upstreaming process and how existing components can 
 
 ## Finding these components
 
-Privately shared components are documented in a private Storybook instance: [ui/packages/ Storybook](https://gh.io/storybook) (only available to GitHub staff).
+GitHub shared components are documented in a private Storybook instance: [ui/packages/ Storybook](https://gh.io/storybook) (only available to GitHub staff).
 
 Please note that these components will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1) (only available to GitHub staff), until they have been successfully upstreamed into Primer.

--- a/content/components/github-shared-components.mdx
+++ b/content/components/github-shared-components.mdx
@@ -15,7 +15,7 @@ Engineers building UI components should refer to the guidance on The Hub: [Build
 
 GitHub shared components are documented in a private Storybook instance: [ui/packages/ Storybook](https://gh.io/storybook) (only available to GitHub staff).
 
-Please note that these components will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1), until they have been successfully upstreamed into Primer.
+Please note that these components are **owned by the feature teams**, and will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1), unless they have been upstreamed into Primer.
 
 ## Related reading
 

--- a/content/components/github-shared-components.mdx
+++ b/content/components/github-shared-components.mdx
@@ -5,7 +5,8 @@ description: Components that are shared by GitHub feature teams, but are not pub
 
 <Note>This information is only relevant to GitHub staff.</Note>
 
-These components support new design patterns that have been piloted by feature teams outside of Primer. While we encourage relying only on Primer components, we also value exploring new ideas without the exhaustive vetting process required for inclusion in Primer.
+These components are shared design patterns by GitHub feature teams developing application-specific components. We encourage relying only on Primer components where possible, and not all patterns will be upstreamed to Primer. 
+
 
 To ensure consistency and seamless collaboration, we recommend sharing these components with other teams by developing them as React components within the `ui/packages/` monorepo. This monorepo, along with the larger monolith, provides a solid foundation with baseline configurations for linting, accessibility scanning using Axe, and Storybook previews.
 

--- a/content/components/github-shared-components.mdx
+++ b/content/components/github-shared-components.mdx
@@ -1,25 +1,23 @@
 ---
 title: GitHub shared components
-description: Components that are shared by GitHub feature teams, but are not publicly available in Primer yet.
+description: Application-specific components that are shared by GitHub feature teams but are not in Primer.
 ---
 
 <Note>This information is only relevant to GitHub staff.</Note>
 
 These components are shared design patterns by GitHub feature teams developing application-specific components. We encourage relying only on Primer components where possible, and not all patterns will be upstreamed to Primer. 
 
+They're shared with other teams by developing them as React components within the `ui/packages/` monorepo. This monorepo, along with the larger monolith, provides a solid foundation with baseline configurations for linting, accessibility scanning using Axe, and Storybook previews.
 
-To ensure consistency and seamless collaboration, we recommend sharing these components with other teams by developing them as React components within the `ui/packages/` monorepo. This monorepo, along with the larger monolith, provides a solid foundation with baseline configurations for linting, accessibility scanning using Axe, and Storybook previews.
-
-For more information about introducing new design patterns, refer to our documentation on [handling new patterns](/guides/contribute/handling-new-patterns).
-
-## Upstreaming to Primer
-
-Should a design pattern from the `ui/packages/` monorepo gain widespread adoption, it becomes a strong candidate for upstreaming into Primer. If your component is data-dependent or feature-specific, our Primer maintainers can help evolve it into a more versatile pattern suitable for multiple use-cases.
-
-For more information on the upstreaming process and how existing components can be included in Primer, refer to our documentation on [upstreaming existing components](/guides/contribute/adding-new-components#upstreaming-to-primer).
+Engineers building UI components should refer to the guidance on The Hub: [Building reusable UI Components](https://thehub.github.com/epd/engineering/dev-practicals/frontend/common-components/) (only available to GitHub staff).
 
 ## Finding these components
 
 GitHub shared components are documented in a private Storybook instance: [ui/packages/ Storybook](https://gh.io/storybook) (only available to GitHub staff).
 
 Please note that these components will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1), until they have been successfully upstreamed into Primer.
+
+## Related reading
+
+- [Handling new patterns](/guides/contribute/handling-new-patterns)
+- [Upstreaming to Primer](/guides/contribute/adding-new-components#upstreaming-to-primer)

--- a/content/components/privately-shared-components.mdx
+++ b/content/components/privately-shared-components.mdx
@@ -9,16 +9,16 @@ These components support new design patterns that have been piloted by feature t
 
 To ensure consistency and seamless collaboration, we recommend sharing these components with other teams by developing them as React components within the `ui/packages/` monorepo. This monorepo, along with the larger monolith, provides a solid foundation with baseline configurations for linting, accessibility scanning using Axe, and Storybook previews.
 
-For more information about introducing new design patterns, refer to our documentation on [handling new patterns](https://primer.style/design/guides/contribute/handling-new-patterns).
+For more information about introducing new design patterns, refer to our documentation on [handling new patterns](/guides/contribute/handling-new-patterns).
 
 ## Upstreaming to Primer
 
 Should a design pattern from the `ui/packages/` monorepo gain widespread adoption, it becomes a strong candidate for upstreaming into Primer. If your component is data-dependent or feature-specific, our Primer maintainers can help evolve it into a more versatile pattern suitable for multiple use-cases.
 
-For more information on the upstreaming process and how existing components can be included in Primer, refer to our documentation on [upstreaming existing components](https://primer.style/design/guides/contribute/adding-new-components#upstreaming-to-primer).
+For more information on the upstreaming process and how existing components can be included in Primer, refer to our documentation on [upstreaming existing components](/guides/contribute/adding-new-components#upstreaming-to-primer).
 
 ## Finding these components
 
-Privately shared components are documented in a private Storybook instance: [ui/packages/ Storybook]().
+Privately shared components are documented in a private Storybook instance: [ui/packages/ Storybook](https://gh.io/storybook) (only available to GitHub staff).
 
-Please note that these components will not exist in our Figma component library, [Primer Web](), until they have been successfully upstreamed into Primer.
+Please note that these components will not exist in our Figma component library, [Primer Web](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?type=design&node-id=1406%3A0&mode=design&t=Qi8hXoRhKLLrDhgf-1) (only available to GitHub staff), until they have been successfully upstreamed into Primer.

--- a/content/components/privately-shared-components.mdx
+++ b/content/components/privately-shared-components.mdx
@@ -1,0 +1,24 @@
+---
+title: Privately shared components
+description: Components that are shared by GitHub feature teams, but are not publicly available in Primer yet.
+---
+
+<Note>This information is only relevant to GitHub staff.</Note>
+
+These components support new design patterns that have been piloted by feature teams outside of Primer. While we encourage relying only on Primer components, we also value exploring new ideas without exhaustive the vetting process required for inclusion in Primer.
+
+To ensure consistency and seamless collaboration, we recommend sharing these components with other teams by developing them as React components within the `ui/packages/` monorepo. This monorepo, along with the larger monolith, provides a solid foundation with baseline configurations for linting, accessibility scanning using Axe, and Storybook previews.
+
+For more information about introducing new design patterns, refer to our documentation on [handling new patterns](https://primer.style/design/guides/contribute/handling-new-patterns).
+
+## Upstreaming to Primer
+
+Should a design pattern from the `ui/packages/` monorepo gain widespread adoption, it becomes a strong candidate for upstreaming into Primer. If your component is data-dependent or feature-specific, our Primer maintainers can help evolve it into a more versatile pattern suitable for multiple use-cases.
+
+For more information on the upstreaming process and how existing components can be included in Primer, refer to our documentation on [upstreaming existing components](https://primer.style/design/guides/contribute/adding-new-components#upstreaming-to-primer).
+
+## Finding these components
+
+Privately shared components are documented in a private Storybook instance: [ui/packages/ Storybook]().
+
+Please note that these components will not exist in our Figma component library, [Primer Web](), until they have been successfully upstreamed into Primer.

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -240,6 +240,8 @@
       url: /components/tree-view
     - title: Underline nav
       url: /components/underline-nav
+    - title: Privately shared components
+      url: /components/privately-shared-components
 - title: Native
   url: /native
   children:

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -240,8 +240,10 @@
       url: /components/tree-view
     - title: Underline nav
       url: /components/underline-nav
-    - title: Privately shared components
-      url: /components/privately-shared-components
+- title: GitHub staff
+  children:
+    - title: GitHub shared components
+      url: /components/github-shared-components
 - title: Native
   url: /native
   children:


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/1915

Unfortunately the `ui/packages/` component metadata has been de-prioritized. However, we can still point Hubbers towards components that are meant to shared but aren't in Primer yet.