### PR TITLE
Fix ToC in system arguments docs

### DIFF
--- a/src/layouts/system-arguments-layout.tsx
+++ b/src/layouts/system-arguments-layout.tsx
@@ -33,7 +33,7 @@ export default function SystemArgumentsLayout({data}) {
     if (child.type == 'heading' && child.depth == 2) {
       const title = (child.children[0] as MDText).value
       tableOfContents.items.push({
-        url: `/foundations/system-arguments#${slugger.slug(title)}`,
+        url: `#${slugger.slug(title)}`,
         title: title
       })
     }


### PR DESCRIPTION
Fixes: https://github.com/github/primer/issues/2320

I made the mistake of including the URL path in ToC links in the system arguments docs. This PR removes the path so the links are all just anchors.