### PR TITLE
Fix links to other components in Rails docs

### DIFF
--- a/src/components/rails-markdown.tsx
+++ b/src/components/rails-markdown.tsx
@@ -81,10 +81,10 @@ export default function RailsMarkdown({text, parentRailsId}) {
   }
 
   const mustacheViewContext = {
-    link_to_system_arguments_docs: "[System arguments](/foundations/system-arguments)",
-    link_to_typography_docs: "[Typography](/foundations/typography)",
-    link_to_accessibility: "[Accessibility](/guides/accessibility/accessibility-at-github)",
-    link_to_octicons: "[Octicons](/foundations/icons)",
+    link_to_system_arguments_docs: `[System arguments](${withPrefix('/foundations/system-arguments')})`,
+    link_to_typography_docs: `[Typography](${withPrefix('/foundations/typography')})`,
+    link_to_accessibility: `[Accessibility](${withPrefix('/guides/accessibility/accessibility-at-github')})`,
+    link_to_octicons: `[Octicons](${withPrefix('/foundations/icons')})`,
 
     link_to_component: () => {
       return (railsId, _render) => {

--- a/src/components/rails-markdown.tsx
+++ b/src/components/rails-markdown.tsx
@@ -1,8 +1,8 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import { Link } from '@primer/react'
 import Code from '@primer/gatsby-theme-doctocat/src/components/code'
 import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
-import { graphql, useStaticQuery } from "gatsby"
+import { graphql, useStaticQuery, withPrefix } from "gatsby"
 import ReactMarkdown from 'react-markdown'
 import Mustache from 'mustache'
 import GithubSlugger from 'github-slugger'
@@ -68,7 +68,7 @@ export default function RailsMarkdown({text, parentRailsId}) {
     const parentPage = findPageForRailsId(parentComponent.railsId)
     if (!parentPage) return null
 
-    return `[${parentComponent.name}](${parentPage.path}/rails)`
+    return `[${parentComponent.name}](${withPrefix(parentPage.path)}/rails)`
   }
 
   const linkToChild = (childComponent, parentComponent) => {
@@ -77,7 +77,7 @@ export default function RailsMarkdown({text, parentRailsId}) {
     const parentPage = findPageForRailsId(parentComponent.railsId)
     if (!parentPage) return null
 
-    return `[${childComponent.name}](${parentPage.path}/rails#${slugger.slug(childComponent.name)})`
+    return `[${childComponent.name}](${withPrefix(parentPage.path)}/rails#${slugger.slug(childComponent.name, false)})`
   }
 
   const mustacheViewContext = {
@@ -118,6 +118,7 @@ export default function RailsMarkdown({text, parentRailsId}) {
     }
   }
 
+  /* @ts-ignore */
   const markdown = Mustache.render(text || "", mustacheViewContext)
 
   /* @ts-ignore */
@@ -131,5 +132,6 @@ function CodeWrapper({node, inline, className, children, ...props}) {
     return <InlineCode {...props}>{children}</InlineCode>
   }
 
+  /* @ts-ignore */
   return <Code {...{className, ...props}}>{children[0]}</Code>
 }


### PR DESCRIPTION
Unfortunately the fact that the site is available at / in development and /design in production has tripped me up a few times. This case is even more subtle because we use Mustache tags to generate markdown for Rails doc strings. I tried importing and passing the `Link` component to `ReactMarkdown`, but that didn't work. Instead it looks like we have to use the `withPrefix` helper 🤷 