### PR TITLE
Add all remaining Rails components

### DIFF
--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -1,0 +1,14 @@
+---
+title: Banner
+description: Use Banner to highlight important information.
+railsId: Primer::Alpha::Banner
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/border-box.mdx
+++ b/content/components/border-box.mdx
@@ -1,0 +1,14 @@
+---
+title: BorderBox
+description: BorderBox is a Box component with a border.
+railsId: Primer::Beta::BorderBox
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/button-marketing.mdx
+++ b/content/components/button-marketing.mdx
@@ -1,0 +1,14 @@
+---
+title: ButtonMarketing
+description: Use ButtonMarketing for actions (e.g. in forms).
+railsId: Primer::Alpha::ButtonMarketing
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/close-button.mdx
+++ b/content/components/close-button.mdx
@@ -1,0 +1,14 @@
+---
+title: CloseButton
+description: Use CloseButton to render an `×` without default button styles.
+railsId: Primer::Beta::CloseButton
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/hidden-text-expander.mdx
+++ b/content/components/hidden-text-expander.mdx
@@ -1,0 +1,14 @@
+---
+title: HiddenTextExpander
+description: Use HiddenTextExpander to indicate and toggle hidden text.
+railsId: Primer::Alpha::HiddenTextExpander
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/icon-button.mdx
+++ b/content/components/icon-button.mdx
@@ -2,7 +2,7 @@
 title: Icon button
 description: Icon button is used for buttons that show an icon in place of a text label.
 reactId: icon_button
-rails: https://primer.style/view-components/components/beta/iconbutton
+railsId: Primer::Beta::IconButton
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=14919%3A49961&t=aWZ6bMYEtFusbdzZ-1
 ---
 

--- a/content/components/menu.mdx
+++ b/content/components/menu.mdx
@@ -1,0 +1,14 @@
+---
+title: Menu
+description: Use Menu to create vertical lists of navigational links.
+railsId: Primer::Alpha::Menu
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/octicon-symbols.mdx
+++ b/content/components/octicon-symbols.mdx
@@ -1,0 +1,14 @@
+---
+title: OcticonSymbols
+description: OcticonSymbols renders a symbol dictionary using a list of Octicons.
+railsId: Primer::Alpha::OcticonSymbols
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -1,0 +1,14 @@
+---
+title: Overlay
+description: Overlay components codify design patterns related to floating surfaces such as dialogs and menus.
+railsId: Primer::Alpha::Overlay
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/spinner.mdx
+++ b/content/components/spinner.mdx
@@ -1,0 +1,14 @@
+---
+title: Spinner
+description: Use Spinner to let users know that content is being loaded.
+railsId: Primer::Beta::Spinner
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/text.mdx
+++ b/content/components/text.mdx
@@ -2,8 +2,12 @@
 title: Text
 description: Text styles a string.
 reactId: text
+railsId: Primer::Beta::Text
 componentId: text
 ---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+export default ComponentLayout
 
 ## Usage
 

--- a/content/components/timeline-item.mdx
+++ b/content/components/timeline-item.mdx
@@ -1,0 +1,14 @@
+---
+title: TimelineItem
+description: Use TimelineItem to display items on a vertical timeline, connected by badge elements.
+railsId: Primer::Beta::TimelineItem
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/tooltip.mdx
+++ b/content/components/tooltip.mdx
@@ -1,0 +1,14 @@
+---
+title: Tooltip
+description: Tooltips add additional context to other UI elements and appear on mouse hover or keyboard focus.
+railsId: Primer::Alpha::Tooltip
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -3,8 +3,8 @@ title: Underline nav
 description: The UnderlineNav is used to display navigation.
 componentId: underline_nav
 reactId: underline_nav
+railsId: Primer::Alpha::UnderlineNav
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=18843-67449&t=XqqSolC6AzRO9nae-11
-rails: https://primer.style/view-components/components/alpha/underlinenav/
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -1,0 +1,14 @@
+---
+title: UnderlinePanels
+description: Use UnderlinePanels to style tabs with an associated panel and an underlined selected state.
+railsId: Primer::Alpha::UnderlinePanels
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Text} from '@primer/react'
+export default ComponentLayout
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  We are currently working on general guidance for this component.
+</Note>

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -146,8 +146,12 @@
       url: /components/avatar-pair
     - title: Avatar stack
       url: /components/avatar-stack
+    - title: Banner
+      url: /components/banner
     - title: Blankslate
       url: /components/blankslate
+    - title: Border box
+      url: /components/border-box
     - title: Box
       url: /components/box
     - title: Branch name
@@ -158,12 +162,16 @@
       url: /components/button
     - title: Button group
       url: /components/button-group
+    - title: Button marketing
+      url: /components/button-marketing
     - title: Checkbox
       url: /components/checkbox
     - title: Checkbox group
       url: /components/checkbox-group
     - title: Clipboard copy
       url: /components/clipboard-copy
+    - title: Close button
+      url: /components/close-button
     - title: Comment box
       url: /components/comment-box
     - title: Counter label
@@ -182,14 +190,16 @@
       url: /components/form-control
     - title: Heading
       url: /components/heading
+    - title: Hidden text expander
+      url: /components/hidden-text-expander
+    - title: Icon button
+      url: /components/icon-button
     - title: Label
       url: /components/label
     - title: Layout
       url: /components/layout
     - title: Icon
       url: /components/icon
-    - title: Icon button
-      url: /components/icon-button
     - title: Image
       url: /components/image
     - title: Image crop
@@ -198,8 +208,14 @@
       url: /components/link
     - title: Markdown
       url: /components/markdown
+    - title: Menu
+      url: /components/menu
     - title: Nav list
       url: /components/nav-list
+    - title: Octicon symbols
+      url: /components/octicon-symbols
+    - title: Overlay
+      url: /components/overlay
     - title: Page header
       url: /components/page-header
     - title: Pagination
@@ -220,6 +236,8 @@
       url: /components/select
     - title: Select panel
       url: /components/selectpanel
+    - title: Spinner
+      url: /components/spinner
     - title: State label
       url: /components/state-label
     - title: Subhead
@@ -238,16 +256,22 @@
       url: /components/text-input-with-tokens
     - title: Textarea
       url: /components/textarea
+    - title: Timeline item
+      url: /components/timeline-item
     - title: Toggle switch
       url: /components/toggle-switch
     - title: Token
       url: /components/token
+    - title: Tooltip
+      url: /components/tooltip
     - title: Tree view
       url: /components/tree-view
     - title: Truncate
       url: /components/truncate
     - title: Underline nav
       url: /components/underline-nav
+    - title: Underline panels
+      url: /components/underline-panels
 - title: Native
   url: /native
   children:


### PR DESCRIPTION
This PR adds documentation for all remaining Rails components, including:

* `Banner`
* `BorderBox`
* `ButtonMarketing`
* `CloseButton`
* `HiddenTextExpander`
* `IconButton`
* `Menu`
* `OcticonSymbols`
* `Overlay`
* `Spinner`
* `Text`
* `TimelineItem`
* `Tooltip`
* `UnderlineNav`
* `UnderlinePanels`