### PR TITLE
Update header navigation

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,8 +2,8 @@ const path = require('path')
 
 module.exports = {
   siteMetadata: {
-    title: 'Interface guidelines',
-    shortName: 'Interface guidelines',
+    title: 'Primer',
+    shortName: '',
     description: 'Principles, standards, and usage guidelines for designing GitHub interfaces.',
   },
   pathPrefix: '/design',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,7 @@ const path = require('path')
 module.exports = {
   siteMetadata: {
     title: 'Primer',
+    // Remove short name from site header
     shortName: '',
     description: 'Principles, standards, and usage guidelines for designing GitHub interfaces.',
   },

--- a/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -9,9 +9,9 @@ export default function Hero() {
       <Box bg="canvas.default" py={6}>
         <Container>
           <Heading sx={{color: 'accent.fg', fontSize: 7, lineHeight: 'condensed', pb: 3, m: 0}}>
-            Interface guidelines
+            Primer Design System
           </Heading>
-          <img src={heroIllustration} alt="Interface Guidelines hero" width="100%" />
+          <img src={heroIllustration} alt="Primer Design System" width="100%" />
         </Container>
       </Box>
     </ThemeProvider>

--- a/src/@primer/gatsby-theme-doctocat/primer-nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/primer-nav.yml
@@ -1,0 +1,6 @@
+- title: Brand
+  url: https://primer.style/brand
+- title: View Components
+  url: https://primer.style/view-components
+- title: React Components
+  url: https://primer.style/react


### PR DESCRIPTION
- Removes `/ Interface guidelines` from header
- Updates top-level nav links as described in https://github.com/github/primer/issues/2323
- Updates header to say "Primer Design System" instead of "Interfaces Guidelines"

## Before

![Before screenshot](https://github.com/primer/design/assets/4608155/70e5a8c6-1eee-4871-9ff4-6d43de66e2db)


## After

![After screenshot](https://github.com/primer/design/assets/4608155/8a49c089-a0e8-4f99-ae79-f318519752d7)


Closes https://github.com/github/primer/issues/2323

## Open question

Do we want the top-level nav links to change for all primer.style sites or just primer.style/design? cc @emilybrick 