### PR TITLE
Missing link on Form Control

### DIFF
--- a/content/components/form-control.mdx
+++ b/content/components/form-control.mdx
@@ -19,11 +19,11 @@ This component is a helper component to keep layouts consistent and ensure the c
 
 Form controls allow users to provide data. At a minimum, they include an input and label. They may also include a caption and required field indicator.
 
-To learn more about anatomy, input methods, forms structure, validation, and more, please refer to our [Forms guidance](/ui-patterns/forms).
+To learn more about anatomy, input methods, forms structure, validation, and more, please refer to our [Forms guidance](/ui-patterns/forms/overview).
 
 ## Related links
 
-- [Forms](/ui-patterns/forms)
+- [Forms](/ui-patterns/forms/overview)
 - [Checkbox](/components/checkbox)
 - [Checkbox group](/components/checkbox-group)
 - [Radio](/components/radio)


### PR DESCRIPTION
On the page, [Form Contro](https://primer.style/design/components/form-control)l, the link under the `Forms guidance` and `Forms` return 404. I believe the correct one should have `/overview` appended on the URL?

Which is this one https://primer.style/design/ui-patterns/forms/overview

