### PR TITLE
Update documentation header/title to 'Primer Design System'

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -5,8 +5,7 @@ title: Interface guidelines
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
 export default HeroLayout
 
-Primer's interface guidelines are a collection of principles, standards, and usage guidelines for designing GitHub
-interfaces.
+Primer is a set of guidelines, principles, and patterns for designing and building UI at GitHub. It provides a shared language and standardized approach to delivering cohesive experiences.
 
 #### [Guides](/guides)
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,11 @@ const path = require('path')
 module.exports = {
   siteMetadata: {
     title: 'Primer',
+    header: {
+      title: 'Primer Design System',
+      url: 'https://primer.style',
+      logoUrl: 'https://primer.style',
+    },
     // Remove short name from site header
     shortName: '',
     description: 'Principles, standards, and usage guidelines for designing GitHub interfaces.',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,9 +4,7 @@ module.exports = {
   siteMetadata: {
     title: 'Primer',
     header: {
-      title: 'Primer Design System',
-      url: 'https://primer.style',
-      logoUrl: 'https://primer.style',
+      title: 'Primer Design System'
     },
     // Remove short name from site header
     shortName: '',


### PR DESCRIPTION
Updates to header (`Primer Design System`, instead of just `Primer`)
Removed reference to Interface guidelines