### PR TITLE
Update form guidance to emphasize live region attributes are unnecessary for form validation

### DIFF
--- a/content/ui-patterns/forms/overview.mdx
+++ b/content/ui-patterns/forms/overview.mdx
@@ -327,6 +327,9 @@ When the form fails validation, guide the user to the invalid inputs:
 
 - If the form has 3 or more errors, you may show an [interactive summary of errors](#interactive-summary-of-errors)
 - If an interactive summary of errors is not shown, the first invalid input should be focused and scrolled into the viewport
+- The inline error message should be tied to each invalid input using `aria-describedby`
+
+Live regions should not be used for form validation. Always use focus management (e.g. moving focus to the first link in the interactive summary, or the first invalid field), and appropriate markup to connect the error message to the field.
 
 After a form has been submitted and failed validation, you may switch to inline validation to provide quicker feedback.
 


### PR DESCRIPTION
Relates to: https://github.com/github/accessibility/issues/3822
[Related Staff-only thread](https://github.slack.com/archives/C0FSWLQ0Y/p1687170248400479)

This PR updates the form guidance to emphasize that using live region attributes is not necessary for form validation. Live regions tend to be overused and mistakenly used in form validation scenarios where it is unnecessary. Focus management is perfectly sufficient for communicating errors in form validation.