### PR TITLE
Add a status menu to Rails components

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -1,7 +1,8 @@
 ---
 title: Action list
 reactId: action_list
-railsId: Primer::Alpha::ActionList
+railsIds:
+- Primer::Alpha::ActionList
 figmaId: action_list
 description:
   Action list is a vertical list of interactive actions or options. It's composed of items presented in a consistent.

--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -1,7 +1,8 @@
 ---
 title: Action menu
 reactId: action_menu
-railsId: Primer::Alpha::ActionMenu
+railsIds:
+- Primer::Alpha::ActionMenu
 description: Action menu is composed of action list and overlay patterns used for quick actions and selections.
 ---
 

--- a/content/components/autocomplete.mdx
+++ b/content/components/autocomplete.mdx
@@ -2,7 +2,9 @@
 title: Autocomplete
 description: Autocomplete allows users to quickly filter through a list of options and pick one or more values for a field.
 reactId: autocomplete
-railsId: Primer::Beta::AutoComplete
+railsIds:
+- Primer::Beta::AutoComplete
+- Primer::Alpha::AutoComplete
 figmaId: autocomplete
 rails: https://primer.style/view-components/components/beta/autocomplete
 ---

--- a/content/components/avatar-stack.mdx
+++ b/content/components/avatar-stack.mdx
@@ -2,7 +2,8 @@
 title: Avatar stack
 description: Avatar stack displays two or more avatars in an inline stack.
 reactId: avatar_stack
-railsId: Primer::Beta::AvatarStack
+railsIds:
+- Primer::Beta::AvatarStack
 figmaId: avatar_stack
 ---
 

--- a/content/components/avatar.mdx
+++ b/content/components/avatar.mdx
@@ -2,7 +2,8 @@
 title: Avatar
 description: Avatar is an image that represents a user or organization.
 reactId: avatar
-railsId: Primer::Beta::Avatar
+railsIds:
+- Primer::Beta::Avatar
 figmaId: avatar
 ---
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -1,7 +1,8 @@
 ---
 title: Banner
 description: Use Banner to highlight important information.
-railsId: Primer::Alpha::Banner
+railsIds:
+- Primer::Alpha::Banner
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/blankslate.mdx
+++ b/content/components/blankslate.mdx
@@ -1,7 +1,9 @@
 ---
 title: Blankslate
 description: Use Blankslate as placeholder to tell users why content is missing.
-railsId: Primer::Beta::Blankslate
+railsIds:
+- Primer::Beta::Blankslate
+- Primer::BlankslateComponent
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/border-box.mdx
+++ b/content/components/border-box.mdx
@@ -1,7 +1,8 @@
 ---
 title: BorderBox
 description: BorderBox is a Box component with a border.
-railsId: Primer::Beta::BorderBox
+railsIds:
+- Primer::Beta::BorderBox
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/box.mdx
+++ b/content/components/box.mdx
@@ -2,7 +2,8 @@
 title: Box
 description: Box is a basic wrapper component for most layout related needs.
 reactId: box
-railsId: Primer::Box
+railsIds:
+- Primer::Box
 rails: https://primer.style/view-components/components/box
 ---
 

--- a/content/components/breadcrumbs.mdx
+++ b/content/components/breadcrumbs.mdx
@@ -2,7 +2,8 @@
 title: Breadcrumbs
 description: Breadcrumbs display the current page or context within the site, allowing them to navigate different levels of the hierarchy.
 reactId: breadcrumbs
-railsId: Primer::Beta::Breadcrumbs
+railsIds:
+- Primer::Beta::Breadcrumbs
 figmaId: breadcrumbs
 rails: https://primer.style/view-components/components/beta/breadcrumbs
 ---

--- a/content/components/button-group.mdx
+++ b/content/components/button-group.mdx
@@ -2,7 +2,8 @@
 title: Button group
 description: Button group renders a series of buttons.
 reactId: button_group
-railsId: Primer::Beta::ButtonGroup
+railsIds:
+- Primer::Beta::ButtonGroup
 figmaId: button_group
 rails: https://primer.style/view-components/components/beta/buttongroup
 ---

--- a/content/components/button-marketing.mdx
+++ b/content/components/button-marketing.mdx
@@ -1,7 +1,8 @@
 ---
 title: ButtonMarketing
 description: Use ButtonMarketing for actions (e.g. in forms).
-railsId: Primer::Alpha::ButtonMarketing
+railsIds:
+- Primer::Alpha::ButtonMarketing
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/button.mdx
+++ b/content/components/button.mdx
@@ -2,7 +2,9 @@
 title: Button
 description: Button is used to initiate actions on a page or form.
 reactId: button
-railsId: Primer::Beta::Button
+railsIds:
+- Primer::Beta::Button
+- Primer::ButtonComponent
 figmaId: button
 rails: https://primer.style/view-components/components/beta/button
 ---

--- a/content/components/checkbox-group.mdx
+++ b/content/components/checkbox-group.mdx
@@ -2,7 +2,8 @@
 title: Checkbox group
 description: Checkbox group renders a set of checkboxes.
 reactId: checkbox_group
-railsId: Primer::Alpha::CheckBoxGroup
+railsIds:
+- Primer::Alpha::CheckBoxGroup
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/checkbox.mdx
+++ b/content/components/checkbox.mdx
@@ -2,7 +2,8 @@
 title: Checkbox
 description: Checkbox is a form control for single and multiple selections.
 reactId: checkbox
-railsId: Primer::Alpha::CheckBox
+railsIds:
+- Primer::Alpha::CheckBox
 figmaId: checkbox
 ---
 

--- a/content/components/clipboard-copy.mdx
+++ b/content/components/clipboard-copy.mdx
@@ -1,7 +1,8 @@
 ---
 title: Clipboard copy
 description: Copies element text content or input values to the clipboard.
-railsId: Primer::Beta::ClipboardCopy
+railsIds:
+- Primer::Beta::ClipboardCopy
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/close-button.mdx
+++ b/content/components/close-button.mdx
@@ -1,7 +1,8 @@
 ---
 title: CloseButton
 description: Use CloseButton to render an `×` without default button styles.
-railsId: Primer::Beta::CloseButton
+railsIds:
+- Primer::Beta::CloseButton
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/counter-label.mdx
+++ b/content/components/counter-label.mdx
@@ -2,7 +2,8 @@
 title: Counter label
 description: Counter label is a button with a numbered label accompanied by text.
 reactId: counter_label
-railsId: Primer::Beta::Counter
+railsIds:
+- Primer::Beta::Counter
 figmaId: counter_label
 rails: https://primer.style/view-components/components/beta/counter
 ---

--- a/content/components/details.mdx
+++ b/content/components/details.mdx
@@ -2,7 +2,8 @@
 title: Details
 description: Details is a styled component to enhance the native behaviors of the <details> element.
 reactId: details
-railsId: Primer::Beta::Details
+railsIds:
+- Primer::Beta::Details
 rails: https://primer.style/view-components/components/beta/details
 ---
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -4,7 +4,8 @@ description:
   Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and
   more.
 reactId: dialog
-railsId: Primer::Alpha::Dialog
+railsIds:
+- Primer::Alpha::Dialog
 figmaId: dialog
 rails: https://primer.style/view-components/components/alpha/dialog
 ---

--- a/content/components/dropdown.mdx
+++ b/content/components/dropdown.mdx
@@ -1,8 +1,8 @@
 ---
-title: HiddenTextExpander
-description: Use HiddenTextExpander to indicate and toggle hidden text.
+title: Dropdown
+description: Use dropdown for a lightweight context menu for housing navigation and actions.
 railsIds:
-- Primer::Alpha::HiddenTextExpander
+- Primer::Alpha::Dropdown
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/flash.mdx
+++ b/content/components/flash.mdx
@@ -2,7 +2,8 @@
 title: Flash
 description: Flash alert informs users of successful or pending actions.
 reactId: flash
-railsId: Primer::Beta::Flash
+railsIds:
+- Primer::Beta::Flash
 figmaId: banner
 rails: https://primer.style/view-components/components/beta/flash
 ---

--- a/content/components/heading.mdx
+++ b/content/components/heading.mdx
@@ -2,7 +2,8 @@
 title: Heading
 description: Heading defines the hierarchical structure and importance of the content they contain.
 reactId: heading
-railsId: Primer::Beta::Heading
+railsIds:
+- Primer::Beta::Heading
 figmaId: heading
 rails: https://primer.style/view-components/components/beta/heading
 ---

--- a/content/components/icon-button.mdx
+++ b/content/components/icon-button.mdx
@@ -2,7 +2,9 @@
 title: Icon button
 description: Icon button is used for buttons that show an icon in place of a text label.
 reactId: icon_button
-railsId: Primer::Beta::IconButton
+railsIds:
+- Primer::Beta::IconButton
+- Primer::IconButton
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=14919%3A49961&t=aWZ6bMYEtFusbdzZ-1
 ---
 

--- a/content/components/icon.mdx
+++ b/content/components/icon.mdx
@@ -1,6 +1,7 @@
 ---
 title: Icon
-railsId: Primer::Beta::Octicon
+railsIds:
+- Primer::Beta::Octicon
 figmaId: icon
 description: Icons at GitHub are called Octicons, which are available in various implementations including React, Figma, Rails, and Styled System.
 ---

--- a/content/components/image-crop.mdx
+++ b/content/components/image-crop.mdx
@@ -1,7 +1,8 @@
 ---
 title: Image crop
 description: Use image crop as a client-side mechanism to crop images.
-railsId: Primer::Alpha::ImageCrop
+railsIds:
+- Primer::Alpha::ImageCrop
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/image.mdx
+++ b/content/components/image.mdx
@@ -1,7 +1,8 @@
 ---
 title: Image
 description: Use image to render images.
-railsId: Primer::Alpha::Image
+railsIds:
+- Primer::Alpha::Image
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/label.mdx
+++ b/content/components/label.mdx
@@ -1,7 +1,8 @@
 ---
 title: Label
 description: Use the label component to add contextual metadata to a design.
-railsId: Primer::Beta::Label
+railsIds:
+- Primer::Beta::Label
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/layout.mdx
+++ b/content/components/layout.mdx
@@ -1,7 +1,9 @@
 ---
 title: Layout
 description: Layout provides foundational patterns for responsive pages.
-railsId: Primer::Alpha::Layout
+railsIds:
+- Primer::Alpha::Layout
+- Primer::LayoutComponent
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/link.mdx
+++ b/content/components/link.mdx
@@ -2,7 +2,8 @@
 title: Link
 description: Links are used to apply styles to hyperlink text.
 reactId: link
-railsId: Primer::Beta::Link
+railsIds:
+- Primer::Beta::Link
 figmaId: link
 ---
 

--- a/content/components/markdown.mdx
+++ b/content/components/markdown.mdx
@@ -1,7 +1,8 @@
 ---
 title: Markdown
 description: Use markdown to wrap markdown content.
-railsId: Primer::Beta::Markdown
+railsIds:
+- Primer::Beta::Markdown
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/menu.mdx
+++ b/content/components/menu.mdx
@@ -1,7 +1,8 @@
 ---
 title: Menu
 description: Use Menu to create vertical lists of navigational links.
-railsId: Primer::Alpha::Menu
+railsIds:
+- Primer::Alpha::Menu
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/nav-list.mdx
+++ b/content/components/nav-list.mdx
@@ -2,7 +2,8 @@
 title: Nav list
 description: Nav list renders a vertical list of navigation links.
 reactId: nav_list
-railsId: Primer::Alpha::NavList
+railsIds:
+- Primer::Alpha::NavList
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/octicon-symbols.mdx
+++ b/content/components/octicon-symbols.mdx
@@ -1,7 +1,8 @@
 ---
 title: OcticonSymbols
 description: OcticonSymbols renders a symbol dictionary using a list of Octicons.
-railsId: Primer::Alpha::OcticonSymbols
+railsIds:
+- Primer::Alpha::OcticonSymbols
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -1,7 +1,8 @@
 ---
 title: Overlay
 description: Overlay components codify design patterns related to floating surfaces such as dialogs and menus.
-railsId: Primer::Alpha::Overlay
+railsIds:
+- Primer::Alpha::Overlay
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/popover.mdx
+++ b/content/components/popover.mdx
@@ -2,7 +2,8 @@
 title: Popover
 description: Popover is used to bring attention to specific user interface elements.
 reactId: popover
-railsId: Primer::Beta::Popover
+railsIds:
+- Primer::Beta::Popover
 figmaId: popover
 rails: https://primer.style/view-components/components/beta/popover
 ---

--- a/content/components/progress-bar.mdx
+++ b/content/components/progress-bar.mdx
@@ -2,7 +2,8 @@
 title: Progress bar
 description: Progress bar visualizes one or more parts of a whole.
 reactId: progress_bar
-railsId: Primer::Beta::ProgressBar
+railsIds:
+- Primer::Beta::ProgressBar
 figmaId: progress_bar
 ---
 

--- a/content/components/radio-group.mdx
+++ b/content/components/radio-group.mdx
@@ -2,7 +2,8 @@
 title: Radio group
 description: Radio group is used to render a short list of mutually exclusive options.
 reactId: radio_group
-railsId: Primer::Alpha::RadioButtonGroup
+railsIds:
+- Primer::Alpha::RadioButtonGroup
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/radio.mdx
+++ b/content/components/radio.mdx
@@ -2,7 +2,8 @@
 title: Radio
 description: Radio button is a form control for making a single selection from a short list of options.
 reactId: radio
-railsId: Primer::Alpha::RadioButton
+railsIds:
+- Primer::Alpha::RadioButton
 figmaId: radio
 ---
 

--- a/content/components/relative-time.mdx
+++ b/content/components/relative-time.mdx
@@ -2,7 +2,8 @@
 title: Relative time
 description: Relative time displays time in a way that is clear, concise, and accessible.
 reactId: relative_time
-railsId: Primer::Beta::RelativeTime
+railsIds:
+- Primer::Beta::RelativeTime
 componentId: relative_time
 ---
 

--- a/content/components/segmented-control.mdx
+++ b/content/components/segmented-control.mdx
@@ -4,7 +4,8 @@ description:
   Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply
   that selection.
 reactId: segmented_control
-railsId: Primer::Alpha::SegmentedControl
+railsIds:
+- Primer::Alpha::SegmentedControl
 figmaId: segmented_control
 rails: https://primer.style/view-components/components/alpha/segmentedcontrol
 ---

--- a/content/components/select.mdx
+++ b/content/components/select.mdx
@@ -2,7 +2,8 @@
 title: Select
 description: Select is an input for selecting a single option from a menu.
 reactId: select
-railsId: Primer::Alpha::Select
+railsIds:
+- Primer::Alpha::Select
 figmaId: select
 ---
 

--- a/content/components/spinner.mdx
+++ b/content/components/spinner.mdx
@@ -1,7 +1,8 @@
 ---
 title: Spinner
 description: Use Spinner to let users know that content is being loaded.
-railsId: Primer::Beta::Spinner
+railsIds:
+- Primer::Beta::Spinner
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/state-label.mdx
+++ b/content/components/state-label.mdx
@@ -2,7 +2,8 @@
 title: State
 description: Use state for rendering the status of an item.
 reactId: state_label
-railsId: Primer::Beta::State
+railsIds:
+- Primer::Beta::State
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/subhead.mdx
+++ b/content/components/subhead.mdx
@@ -1,7 +1,8 @@
 ---
 title: Subhead
 description: Use subhead as the start of a section.
-railsId: Primer::Beta::Subhead
+railsIds:
+- Primer::Beta::Subhead
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/tab-container.mdx
+++ b/content/components/tab-container.mdx
@@ -1,7 +1,8 @@
 ---
 title: Tab container
 description: Use tab container to create tabbed content with keyboard support.
-railsId: Primer::Alpha::TabContainer
+railsIds:
+- Primer::Alpha::TabContainer
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/tab-nav.mdx
+++ b/content/components/tab-nav.mdx
@@ -2,7 +2,8 @@
 title: Tab nav
 description: Tab nav contains a set of links that let users navigate between different views in the same context.
 reactId: tab_nav
-railsId: Primer::Alpha::TabNav
+railsIds:
+- Primer::Alpha::TabNav
 componentId: tab_nav
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=20366-72067&t=kKGC85STU5bcL0zg-4
 ---

--- a/content/components/tab-panels.mdx
+++ b/content/components/tab-panels.mdx
@@ -1,7 +1,8 @@
 ---
 title: Tab panels
 description: Tab panels let users switch between views in the same context.
-railsId: Primer::Alpha::TabPanels
+railsIds:
+- Primer::Alpha::TabPanels
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/text-input.mdx
+++ b/content/components/text-input.mdx
@@ -2,7 +2,8 @@
 title: Text input
 description: Text input is used to set a value that is a single line of text.
 reactId: text_input
-railsId: Primer::Alpha::TextField
+railsIds:
+- Primer::Alpha::TextField
 figmaId: text_input
 ---
 

--- a/content/components/text.mdx
+++ b/content/components/text.mdx
@@ -2,7 +2,8 @@
 title: Text
 description: Text styles a string.
 reactId: text
-railsId: Primer::Beta::Text
+railsIds:
+- Primer::Beta::Text
 componentId: text
 ---
 

--- a/content/components/textarea.mdx
+++ b/content/components/textarea.mdx
@@ -2,7 +2,8 @@
 title: Textarea
 description: Textarea is used to set a value that is multiple lines of text.
 reactId: textarea
-railsId: Primer::Alpha::TextArea
+railsIds:
+- Primer::Alpha::TextArea
 figmaId: textarea
 ---
 

--- a/content/components/timeline-item.mdx
+++ b/content/components/timeline-item.mdx
@@ -1,7 +1,8 @@
 ---
 title: TimelineItem
 description: Use TimelineItem to display items on a vertical timeline, connected by badge elements.
-railsId: Primer::Beta::TimelineItem
+railsIds:
+- Primer::Beta::TimelineItem
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/toggle-switch.mdx
+++ b/content/components/toggle-switch.mdx
@@ -2,7 +2,8 @@
 title: Toggle switch
 description: Toggle switch is used to immediately toggle a setting on or off.
 reactId: toggle_switch
-railsId: Primer::Alpha::ToggleSwitch
+railsIds:
+- Primer::Alpha::ToggleSwitch
 figmaId: toggle_switch
 rails: https://primer.style/view-components/components/alpha/toggleswitch
 ---

--- a/content/components/tooltip.mdx
+++ b/content/components/tooltip.mdx
@@ -1,7 +1,9 @@
 ---
 title: Tooltip
 description: Tooltips add additional context to other UI elements and appear on mouse hover or keyboard focus.
-railsId: Primer::Alpha::Tooltip
+railsIds:
+- Primer::Alpha::Tooltip
+- Primer::Tooltip
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/truncate.mdx
+++ b/content/components/truncate.mdx
@@ -1,7 +1,9 @@
 ---
 title: Truncate
 description: Use Truncate to shorten overflowing text with an ellipsis.
-railsId: Primer::Beta::Truncate
+railsIds:
+- Primer::Beta::Truncate
+- Primer::Truncate
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -3,7 +3,8 @@ title: Underline nav
 description: The UnderlineNav is used to display navigation.
 componentId: underline_nav
 reactId: underline_nav
-railsId: Primer::Alpha::UnderlineNav
+railsIds:
+- Primer::Alpha::UnderlineNav
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=18843-67449&t=XqqSolC6AzRO9nae-11
 ---
 

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -1,7 +1,8 @@
 ---
 title: UnderlinePanels
 description: Use UnderlinePanels to style tabs with an associated panel and an underlined selected state.
-railsId: Primer::Alpha::UnderlinePanels
+railsIds:
+- Primer::Alpha::UnderlinePanels
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/guides/contribute/how-to-contribute.mdx
+++ b/content/guides/contribute/how-to-contribute.mdx
@@ -59,5 +59,5 @@ When contributing to Primer open source repos, please follow the repo's contribu
 
 - [Primer CSS](https://github.com/primer/css/blob/main/CONTRIBUTING.md)
 - [Primer React](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md)
-- [Primer ViewComponents](https://primer.style/view-components/contributing)
+- [Primer ViewComponents](https://github.com/primer/view_components/blob/main/docs/contributors/README.md)
 - [Octicons](https://github.com/primer/octicons/blob/main/CONTRIBUTING.md)

--- a/content/ui-patterns/forms/rails.mdx
+++ b/content/ui-patterns/forms/rails.mdx
@@ -4,7 +4,8 @@ description: Primer contains a framework for declaratively building Rails forms.
 current_page: rails
 ---
 
-import {Heading, Link} from '@primer/react'
+import {Heading} from '@primer/react'
+import {Link} from 'gatsby'
 import {LinkExternalIcon} from '@primer/octicons-react'
 import FormsLayout from '~/src/layouts/forms-layout'
 export default FormsLayout

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,8 @@ const path = require('path')
 const defines = require('./babel-defines')
 const fetch = require('node-fetch')
 const fs = require('fs')
+const railsHelpers = require('./src/rails-helpers')
+
 
 exports.onCreateWebpackConfig = ({actions, plugins, getConfig}) => {
   const config = getConfig()

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -303,8 +303,14 @@ async function createComponentPages({actions, graphql}) {
           frontmatter {
             reactId
             figmaId
-            railsId
+            railsIds
           }
+        }
+      }
+      allRailsComponent {
+        nodes {
+          railsId: fully_qualified_name
+          status
         }
       }
     }
@@ -326,14 +332,36 @@ async function createComponentPages({actions, graphql}) {
       })
     }
 
-    if (frontmatter.railsId) {
-      actions.createPage({
-        path: `/${slug}/rails`,
-        component: railsComponentLayout,
-        context: {
-          componentId: frontmatter.railsId,
-          parentPath: `/${slug}`,
-        },
+    if (frontmatter.railsIds) {
+      const statuses = []
+
+      frontmatter.railsIds.forEach((railsId) => {
+        let status
+
+        for (const railsComponent of data.allRailsComponent.nodes) {
+          if (railsComponent.railsId === railsId) {
+            status = railsComponent.status
+            break
+          }
+        }
+
+        statuses.push(status)
+
+        actions.createPage({
+          path: `/${slug}/rails/${status}`,
+          component: railsComponentLayout,
+          context: {
+            componentId: railsId,
+            parentPath: `/${slug}`,
+          },
+        })
+      })
+
+      actions.createRedirect({
+        fromPath: `/${slug}/rails/latest`,
+        toPath: `/${slug}/rails/${railsHelpers.latestStatusFrom(statuses)}`,
+        redirectInBrowser: true,
+        force: true
       })
     }
 

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -182,6 +182,8 @@
       url: /components/details
     - title: Dialog
       url: /components/dialog
+    - title: Dropdown
+      url: /components/dropdown
     - title: Filter input
       url: /components/filter-input
     - title: Flash

--- a/src/components/component-page-nav.tsx
+++ b/src/components/component-page-nav.tsx
@@ -26,7 +26,7 @@ export function ComponentPageNav({
         </UnderlineNav.Link>
       ) : null}
       {includeRails ? (
-        <UnderlineNav.Link as={GatsbyLink} to={`${basePath}/rails`} selected={current === 'rails'}>
+        <UnderlineNav.Link as={GatsbyLink} to={`${basePath}/rails/latest`} selected={current === 'rails'}>
           Rails
         </UnderlineNav.Link>
       ) : null}

--- a/src/components/rails-markdown.tsx
+++ b/src/components/rails-markdown.tsx
@@ -18,7 +18,7 @@ export default function RailsMarkdown({text, parentRailsId}) {
           path
           context {
             frontmatter {
-              railsId
+              railsIds
             }
           }
         }
@@ -39,7 +39,7 @@ export default function RailsMarkdown({text, parentRailsId}) {
 
   const findPageForRailsId = (railsId) => {
     for (const page of data.allSitePage.nodes) {
-      if (page.context?.frontmatter?.railsId === railsId) {
+      if (page.context?.frontmatter?.railsIds?.indexOf(railsId) !== -1) {
         return page
       }
     }

--- a/src/layouts/component-layout.tsx
+++ b/src/layouts/component-layout.tsx
@@ -9,7 +9,7 @@ import {BaseLayout} from '../components/base-layout'
 import {ComponentPageNav} from '../components/component-page-nav'
 
 export default function ComponentLayout({pageContext, children, path}) {
-  const {title, description, reactId, railsId, figmaId} = pageContext.frontmatter
+  const {title, description, reactId, railsIds, figmaId} = pageContext.frontmatter
 
   return (
     <BaseLayout title={title} description={description}>
@@ -24,7 +24,7 @@ export default function ComponentLayout({pageContext, children, path}) {
           <ComponentPageNav
             basePath={path}
             includeReact={reactId}
-            includeRails={railsId}
+            includeRails={railsIds}
             includeFigma={figmaId}
             current="overview"
           />

--- a/src/layouts/figma-component-layout.tsx
+++ b/src/layouts/figma-component-layout.tsx
@@ -23,7 +23,7 @@ export const query = graphql`
           description
           reactId
           figmaId
-          railsId
+          railsIds
         }
       }
     }
@@ -91,7 +91,7 @@ export default function FigmaComponentLayout({data}) {
           <ComponentPageNav
             basePath={data.sitePage.path}
             includeReact={data.sitePage.context.frontmatter.reactId}
-            includeRails={data.sitePage.context.frontmatter.railsId}
+            includeRails={data.sitePage.context.frontmatter.railsIds}
             includeFigma={data.sitePage.context.frontmatter.figmaId}
             current="figma"
           />

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -28,7 +28,7 @@ export const query = graphql`
           title
           description
           reactId
-          railsId
+          railsIds
           figmaId
         }
       }
@@ -92,7 +92,7 @@ export default function ReactComponentLayout({data}) {
           <ComponentPageNav
             basePath={data.sitePage.path}
             includeReact={data.sitePage.context.frontmatter.reactId}
-            includeRails={data.sitePage.context.frontmatter.railsId}
+            includeRails={data.sitePage.context.frontmatter.railsIds}
             includeFigma={data.sitePage.context.frontmatter.figmaId}
             current="react"
           />

--- a/src/rails-helpers.js
+++ b/src/rails-helpers.js
@@ -1,0 +1,25 @@
+const statusOrder = [
+  'deprecated',
+  'experimental',
+  'alpha',
+  'beta',
+  'stable'
+]
+
+const latestStatusFrom = (statuses) => {
+  let highestRank = -1
+  let latestStatus = null
+
+  for (const status of statuses) {
+    const rank = statusOrder.indexOf(status)
+
+    if (rank > highestRank) {
+      highestRank = rank
+      latestStatus = status
+    }
+  }
+
+  return latestStatus
+}
+
+module.exports.latestStatusFrom = latestStatusFrom


### PR DESCRIPTION
This PR adds a status menu to Rails component pages that allows a user to view documentation for previous versions of a component. Documentation for older versions of components is helpful during migrations.

![A screenshot of the Rails documentation page for the Autocomplete component. On the right-hand side of the header, a new button labeled "Status: Beta" is visible. A dropdown menu attached to the button is open and lists two items, "Deprecated" and "Beta." The "Beta" item is checked.](https://github.com/primer/design/assets/575280/072b3b45-62bd-4179-a0fb-15677957bef1)