### PR TITLE
Move remaining React components over, update messaging and missing/outdated information

### DIFF
--- a/content/components/anchored-overlay.mdx
+++ b/content/components/anchored-overlay.mdx
@@ -12,11 +12,9 @@ export default ComponentLayout
 
 Anchored overlay provides an anchor that will open a floating overlay positioned relative to the anchor. The overlay can be opened and navigated using a keyboard or mouse.
 
-See also [Overlay positioning](https://primer.style/react/Overlay#positioning)
-
 ## Related components
 
-- [Overlay](https://primer.style/react/Overlay)
+- [Overlay](/components/overlay)
 
 ## Accessibility
 

--- a/content/components/avatar-pair.mdx
+++ b/content/components/avatar-pair.mdx
@@ -9,13 +9,13 @@ import {Box, Text} from '@primer/react'
 import ComponentLayout from '~/src/layouts/component-layout'
 export default ComponentLayout
 
-## Usage
-
 <img
   width="960"
   alt="An image showing two different avatars, one larger and one smaller, to represent a parent-child combination."
   src="https://user-images.githubusercontent.com/586552/203213337-c7d0f683-4971-4ef3-b480-c4743b929634.png"
 />
+
+## Usage
 
 Use AvatarPair to display two avatars when one is secondary to the other.
 

--- a/content/components/avatar-pair.mdx
+++ b/content/components/avatar-pair.mdx
@@ -17,7 +17,7 @@ export default ComponentLayout
 
 ## Usage
 
-Use AvatarPair to display two avatars when one is secondary to the other.
+Use avatar pair to display two avatars when one is secondary to the other.
 
 ## Options
 

--- a/content/components/avatar-stack.mdx
+++ b/content/components/avatar-stack.mdx
@@ -34,7 +34,7 @@ Only the 20px avatar size is currently used in the avatar stack.
 
 ### Alignment
 
-The default AvatarStack is left-aligned. You can [right-align](https://primer.style/react/AvatarStack#right-aligned) the component for layouts that are better suited for it.
+The default AvatarStack is left-aligned. You can right-align the component for layouts that are better suited for it.
 
 ## Related components
 

--- a/content/components/avatar-stack.mdx
+++ b/content/components/avatar-stack.mdx
@@ -35,7 +35,7 @@ Only the 20px avatar size is currently used in the avatar stack.
 
 ### Alignment
 
-The default AvatarStack is left-aligned. You can right-align the component for layouts that are better suited for it.
+The default avatar stack is left-aligned. You can right-align the component for layouts that are better suited for it.
 
 ## Related components
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -1,6 +1,6 @@
 ---
 title: Banner
-description: Use Banner to highlight important information.
+description: Banner is used to highlight important information.
 componentId: banner
 railsIds: 
 - Primer::Alpha::Banner

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -2,7 +2,7 @@
 title: Banner
 description: Use Banner to highlight important information.
 componentId: banner
-Primer::Alpha::Banner
+railsId: Primer::Alpha::Banner
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -11,7 +11,4 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
-</Note>
+For general design and usage guidelines of banners, see the [flash component](/components/flash).

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -6,9 +6,11 @@ railsId: Primer::Alpha::Banner
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -2,7 +2,8 @@
 title: Banner
 description: Use Banner to highlight important information.
 componentId: banner
-railsId: Primer::Alpha::Banner
+railsIds: 
+- Primer::Alpha::Banner
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/blankslate.mdx
+++ b/content/components/blankslate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blankslate
-description: Use Blankslate as placeholder to tell users why content is missing.
+description: Blankslate is used as placeholder to tell users why content is missing.
 componentId: blankslate
 railsIds:
 - Primer::Beta::Blankslate
@@ -12,7 +12,60 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
-</Note>
+## Anatomy
+
+The blankslate component is made up of several elements that work together to inform the user about a feature and how to proceed forward. Below are the different elements of the component and how to modify them.
+
+![Blankslate anatomy](https://user-images.githubusercontent.com/6846673/62806713-78795380-baa8-11e9-9cbd-1a56fef3247b.png)
+
+### Graphic
+
+The graphic can bring delight, preview an interface element, or represent the goal of the feature. Graphics should be placed intentionally and with thought about the intention of the content. Graphics also differ in meaning and appeal to the user, which is why the Blankslate component has multiple variations. These variations are outlined later on this page.
+
+### Primary Text
+
+Use primary text to explain the purpose of the empty state, help users feel comfortable to engage with the content, or begin a feature flow. Primary text should sound welcoming, human, and convey the intention of the feature.
+
+### Secondary text
+
+This optional text is used to inform the user about the feature in more detail. Secondary text should be brief and non-redundant if possible. From the text, users should be able to understand the general purpose of the feature and how it may help them accomplish a goal.
+
+### Primary action
+
+Blankslates can and are encouraged to use one primary action. This button should lead to a feature or component creation flow. Button copy should be kept brief and descriptive. If a button requires further specification, consider adding an Octicon.
+
+### Secondary action
+
+Secondary actions are optional and are represented by a text link located below the primary action button. A secondary action is used to direct a user to additional content about the feature. This might look like `Learn more about X` or "`Check out the guide on X`.
+
+### Border
+
+The border is invisible by default, but can be added to help define the structure of the Blankslate component when needed. This can be particularly helpful in page layouts where the Blankslate is not the only content on the screen. For implementation, check out the [Primer CSS Blankslate component](https://primer.style/css/components/blankslate#add-border).
+
+## Variations
+
+Empty states have multiple variations that can be used in different contexts.
+
+### GitHub marketing icons
+
+[GitHub marketing icons](https://ghicons.github.com/) can be used to represent the feature where the Blankslate is found. Blankslates should default to using a GitHub marketing icon for graphic elements.
+
+![GH Icon Blankslate](https://user-images.githubusercontent.com/6846673/62806619-39e39900-baa8-11e9-9de0-5b2f511d63da.png)
+
+### Code block
+
+Blankslates that use a list of steps or offer instructions in the format of code to get started with a feature can insert a `code` block. This is the case for getting started with packages in GitHub:
+
+![Code block Blankslate](https://user-images.githubusercontent.com/589285/64209577-b83c1c80-ce55-11e9-8b61-8d82713b56a6.png)
+
+## Content and copy
+
+Empty states should explain features _in addition_ to conveying intention. In the example below, the primary text is used to provide a welcome invitation to creating a positive community while the secondary text supports this intent by informing the user on how to do this by providing a code of conduct.
+
+![code of conduct illustration Blankslate](https://user-images.githubusercontent.com/6846673/62806616-394b0280-baa8-11e9-8a5e-45f0c51aaa22.png)
+
+## First time user experiences
+
+For first time user experiences, use illustration Blankslates to playfully engage the user and introduce the Octocat as a symbol of GitHub. Primary text should welcome the user to the platform and feature. Secondary text should seek to educate the user, but at a simpler, less-technical level.
+
+![first time user Blankslate](https://user-images.githubusercontent.com/6846673/62813307-efb9e200-babe-11e9-93e7-a6fd45d7f942.png)

--- a/content/components/blankslate.mdx
+++ b/content/components/blankslate.mdx
@@ -1,16 +1,16 @@
 ---
 title: Blankslate
 description: Use Blankslate as placeholder to tell users why content is missing.
+componentId: blankslate
 railsId: Primer::Beta::Blankslate
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
 import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>

--- a/content/components/blankslate.mdx
+++ b/content/components/blankslate.mdx
@@ -3,8 +3,8 @@ title: Blankslate
 description: Use Blankslate as placeholder to tell users why content is missing.
 componentId: blankslate
 railsIds:
-Primer::Beta::Blankslate
-Primer::BlankslateComponent
+- Primer::Beta::Blankslate
+- Primer::BlankslateComponent
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/blankslate.mdx
+++ b/content/components/blankslate.mdx
@@ -6,9 +6,11 @@ railsId: Primer::Beta::Blankslate
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>

--- a/content/components/border-box.mdx
+++ b/content/components/border-box.mdx
@@ -6,9 +6,11 @@ railsId: Primer::Beta::BorderBox
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>

--- a/content/components/border-box.mdx
+++ b/content/components/border-box.mdx
@@ -6,7 +6,6 @@ railsIds:
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
 import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout

--- a/content/components/border-box.mdx
+++ b/content/components/border-box.mdx
@@ -1,6 +1,6 @@
 ---
-title: BorderBox
-description: BorderBox is a Box component with a border.
+title: Border box
+description: Border box is a box component with a border.
 railsIds:
 - Primer::Beta::BorderBox
 ---
@@ -11,6 +11,7 @@ import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+

--- a/content/components/button-marketing.mdx
+++ b/content/components/button-marketing.mdx
@@ -1,6 +1,6 @@
 ---
-title: ButtonMarketing
-description: Use ButtonMarketing for actions (e.g. in forms).
+title: Button marketing
+description: Use Button marketing for actions in marketing experiences, such as forms.
 railsIds:
 - Primer::Alpha::ButtonMarketing
 ---
@@ -10,7 +10,11 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
-</Note>
+For general design and usage guidelines of this component, see the [button component](https://primer.style/brand/components/Button#usage) in our Brand documentation.
+
+<img
+  src="https://github.com/primer/design/assets/586552/1abfae09-27e7-419d-8c69-abb3122f5928"
+  role="presentation"
+  width="960"
+  alt="A marketing button Rails component"
+/>

--- a/content/components/button-marketing.mdx
+++ b/content/components/button-marketing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Button marketing
-description: Use Button marketing for actions in marketing experiences, such as forms.
+description: Button marketing is used for actions in marketing experiences, such as forms.
 railsIds:
 - Primer::Alpha::ButtonMarketing
 ---

--- a/content/components/button-marketing.mdx
+++ b/content/components/button-marketing.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::ButtonMarketing
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/circle-badge.mdx
+++ b/content/components/circle-badge.mdx
@@ -1,8 +1,8 @@
 ---
-title: Banner
-description: Use Banner to highlight important information.
-componentId: banner
-railsId: Primer::Alpha::Banner
+title: Circle badge
+description: Circle badge visually connects logos of third-party services like in the marketplace.
+componentId: circle_badge
+reactId: circle_badge
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/circle-badge.mdx
+++ b/content/components/circle-badge.mdx
@@ -15,12 +15,14 @@ export default ComponentLayout
   Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>
 
-## Usage
-
-Use circle badge to visually connect logos of third party services. 
+<br />
 
 <img
   width="960"
   alt="Circle badge component displayed in small, medium, and large sizes"
   src="https://github.com/primer/design/assets/586552/b60426b5-8f43-449b-8158-2b98221acce0"
 />
+
+## Usage
+
+Use circle badge to visually connect logos of third party services. 

--- a/content/components/circle-badge.mdx
+++ b/content/components/circle-badge.mdx
@@ -14,3 +14,13 @@ export default ComponentLayout
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>
+
+## Usage
+
+Use circle badge to visually connect logos of third party services. 
+
+<img
+  width="960"
+  alt="Circle badge component displayed in small, medium, and large sizes"
+  src="https://github.com/primer/design/assets/586552/b60426b5-8f43-449b-8158-2b98221acce0"
+/>

--- a/content/components/clipboard-copy.mdx
+++ b/content/components/clipboard-copy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Clipboard copy
-description: Copies element text content or input values to the clipboard.
+description: Clipboard copy copies element text content or input values to the clipboard.
 railsIds:
 - Primer::Beta::ClipboardCopy
 ---
@@ -14,3 +14,13 @@ export default ComponentLayout
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+
+<br />
+
+<img
+  src="https://github.com/primer/design/assets/586552/cb2d8742-09ad-423e-91df-63915e5d4a80"
+  role="presentation"
+  width="960"
+  alt="The copy icon next to text that says Copy to clipboard"
+/>
+

--- a/content/components/clipboard-copy.mdx
+++ b/content/components/clipboard-copy.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::ClipboardCopy
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/close-button.mdx
+++ b/content/components/close-button.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::CloseButton
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/component-documentation-guidelines/component-MVP-documentation-guidelines.md
+++ b/content/components/component-documentation-guidelines/component-MVP-documentation-guidelines.md
@@ -40,8 +40,8 @@ Take a look at the [Component documentation guides](../component-documentation-g
 - A great starting off point is to consolidate existing documentation for the component that's already available. Places to look:
   - Figma ([Primer Web file](https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=179%3A3870))
   - [CSS documentation](https://primer.style/css/)
-  - [React documentation](https://primer.style/react/)
-  - [Rails documentation](https://primer.style/view-components/)
+  - [React Storybook](https://primer.style/react/storybook/?path=/story/)
+  - [Rails Lookbook](https://primer.style/view-components/lookbook)
   - [Interface guidelines component documentation](/components)
   - [Interface guidelines UI pattern documentation](/ui-patterns)
   - [Interface guidelines Accessibility documentation](/guides/accessibility)

--- a/content/components/component-documentation-guidelines/component-documentation-guidelines.md
+++ b/content/components/component-documentation-guidelines/component-documentation-guidelines.md
@@ -27,8 +27,8 @@ See our full [documentation guidelines here](https://primer.style/contribute/doc
 ### Types of components
 
 - **Regular**: Standard components used to build Primer UI. See [ActionList](/components/action-list).
-- **Internal**: Components used by other components that do not exist on their own. See [Overlay](https://primer.style/react/Overlay).
-- **Behavioral**: Components with no real anatomy or structure, rather behaviors. See [Truncate](https://primer.style/react/Truncate).
+- **Internal**: Components used by other components that do not exist on their own. See [Overlay](/../components/overlay).
+- **Behavioral**: Components with no real anatomy or structure, rather behaviors. See [Truncate](/../components/truncate).
 
 ### Component documentation structure
 

--- a/content/components/counter-label.mdx
+++ b/content/components/counter-label.mdx
@@ -11,15 +11,15 @@ rails: https://primer.style/view-components/components/beta/counter
 import ComponentLayout from '~/src/layouts/component-layout'
 export default ComponentLayout
 
-## Usage
-
-Use counter label to add a count to navigational elements and buttons.
-
 <img
   width="960"
   alt="A image showing two examples of buttons with counters"
   src="https://user-images.githubusercontent.com/586552/205141782-bfe137b1-6d83-4b9d-bcdd-bcd1877f864b.png"
 />
+
+## Usage
+
+Use counter label to add a count to navigational elements and buttons.
 
 ## Accessibility
 

--- a/content/components/dropdown.mdx
+++ b/content/components/dropdown.mdx
@@ -6,10 +6,11 @@ railsIds:
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Usage for this component is not encouraged</Text>
+  <Text>Instead, please see <Link as={GatsbyLink} to="/components/action-menu">action menu</Link>.</Text>
 </Note>

--- a/content/components/flash.mdx
+++ b/content/components/flash.mdx
@@ -4,6 +4,7 @@ description: Flash alert informs users of successful or pending actions.
 reactId: flash
 railsIds:
 - Primer::Beta::Flash
+- Primer::Alpha::Banner
 figmaId: banner
 rails: https://primer.style/view-components/components/beta/flash
 ---

--- a/content/components/header.mdx
+++ b/content/components/header.mdx
@@ -1,8 +1,8 @@
 ---
-title: Pointer box
-description: A customisable bordered box with a caret pointer
-componentId: pointer_box
-reactId: pointer_box
+title: Header
+description: Header is a navigation bar that has all of its items aligned vertically with consistent horizontal spacing.
+componentId: header
+reactId: header
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/hidden-text-expander.mdx
+++ b/content/components/hidden-text-expander.mdx
@@ -1,6 +1,6 @@
 ---
-title: HiddenTextExpander
-description: Use HiddenTextExpander to indicate and toggle hidden text.
+title: Hidden text expander
+description: Hidden text expander indicates and toggles hidden text.
 railsIds:
 - Primer::Alpha::HiddenTextExpander
 ---

--- a/content/components/image-crop.mdx
+++ b/content/components/image-crop.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::ImageCrop
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/image.mdx
+++ b/content/components/image.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::Image
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/label-group.mdx
+++ b/content/components/label-group.mdx
@@ -1,7 +1,7 @@
 ---
-title: HiddenTextExpander
-description: Use HiddenTextExpander to indicate and toggle hidden text.
-railsId: Primer::Alpha::HiddenTextExpander
+title: Label group
+description: Use label group to add commonly used margins and other layout constraints to groups of Labels
+reactId: label_group
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/label-group.mdx
+++ b/content/components/label-group.mdx
@@ -13,3 +13,18 @@ export default ComponentLayout
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+
+<img
+  width="960"
+  role="presentation"
+  src="https://github.com/primer/react/assets/2313998/814ee0d8-d17f-46e1-b62e-ed5f3e7b8cab"
+/>
+
+## Usage
+
+A label group is a component to handle the layout of a collection of labels or tokens.
+
+## Related links
+
+- [Label](/components/label/)
+- [Token](/components/token/)

--- a/content/components/label.mdx
+++ b/content/components/label.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::Label
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/label.mdx
+++ b/content/components/label.mdx
@@ -1,6 +1,7 @@
 ---
 title: Label
 description: Use the label component to add contextual metadata to a design.
+reactId: label
 railsIds:
 - Primer::Beta::Label
 ---

--- a/content/components/label.mdx
+++ b/content/components/label.mdx
@@ -14,3 +14,20 @@ export default ComponentLayout
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+
+<img
+  width="960"
+  role="presentation"
+  src="https://github.com/primer/design/assets/2313998/c2bfee0c-8443-4076-aba8-27e6f2fbb4e0"
+/>
+
+## Usage
+
+A label is a piece of text that is stylized to differentiate it as contextual metadata. It can be used to add a status, category, or other metadata to a design.
+
+## Related links
+
+- [Counter label](/components/counter-label/)
+- [Label group](/components/label-group/)
+- [State label](/components/state-label/)
+- [Token](/components/token/)

--- a/content/components/layout.mdx
+++ b/content/components/layout.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::Layout
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/link.mdx
+++ b/content/components/link.mdx
@@ -214,8 +214,8 @@ Some examples of this are:
 ### For engineers
 
 - Use Primer link components:
-  - [Link in Primer ViewComponents](https://primer.style/view-components/components/beta/link)
-  - [Link in Primer React](https://primer.style/react/Link)
+  - [Rails component](/components/link/rails)
+  - [React component](/components/link/react)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard (reference: [Focus management](/guides/accessibility/focus-management))
 - Don't use the `title` attribute

--- a/content/components/markdown.mdx
+++ b/content/components/markdown.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::Markdown
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/menu.mdx
+++ b/content/components/menu.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::Menu
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/menu.mdx
+++ b/content/components/menu.mdx
@@ -11,6 +11,6 @@ import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Usage for this component is not encouraged</Text>
+  <Text>Instead, please see <Link as={GatsbyLink} to="/components/nav-list">nav list</Link>.</Text>
 </Note>

--- a/content/components/octicon-symbols.mdx
+++ b/content/components/octicon-symbols.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::OcticonSymbols
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -7,12 +7,12 @@ reactID: overlay
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Link, Text} from '@primer/react'
-export default ComponentLayout
 import {Link as GatsbyLink} from 'gatsby'
+export default ComponentLayout
 
 ### Usage
 
-Overlay is an internal component, meaning it's intended to be used as a private API, composing other components. It is not intended to be used on its own. 
+Overlay is an internal component and is intended to be used as a private API, composing other components. It is not intended to be used on its own. 
 
 The Overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the base component for many of our overlay-type components. Overlays use shadows to express elevation.
 

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -3,7 +3,7 @@ title: Overlay
 description: Overlay components codify design patterns related to floating surfaces such as dialogs and menus.
 reactId: overlay
 railsIds:
-Primer::Alpha::Overlay
+- Primer::Alpha::Overlay
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -6,8 +6,9 @@ reactID: overlay
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
 export default ComponentLayout
+import {Link as GatsbyLink} from 'gatsby'
 
 ### Usage
 
@@ -16,6 +17,6 @@ Overlay is an internal component, meaning it's intended to be used as a private 
 The Overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the base component for many of our overlay-type components. Overlays use shadows to express elevation.
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -2,7 +2,7 @@
 title: Overlay
 description: Overlay components codify design patterns related to floating surfaces such as dialogs and menus.
 railsId: Primer::Alpha::Overlay
-reactID: overlay
+reactId: overlay
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -14,7 +14,7 @@ export default ComponentLayout
 
 Overlay is an internal component and is intended to be used as a private API, composing other components. It is not intended to be used on its own. 
 
-The Overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the base component for many of our overlay-type components. Overlays use shadows to express elevation.
+The overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the base component for many of our overlay-type components. Overlays use shadows to express elevation.
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -11,13 +11,12 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-### Usage
+## Usage
 
 Overlay is an internal component and is intended to be used as a private API, composing other components. It is not intended to be used on its own. 
 
-The overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the base component for many of our overlay-type components. Overlays use shadows to express elevation.
+The overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the internal, or base component for many of our overlay-type components. Overlays use shadows to express elevation.
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
-</Note>
+## Related components
+
+- [Anchored overlay](/components/anchored-overlay)

--- a/content/components/overlay.mdx
+++ b/content/components/overlay.mdx
@@ -2,11 +2,18 @@
 title: Overlay
 description: Overlay components codify design patterns related to floating surfaces such as dialogs and menus.
 railsId: Primer::Alpha::Overlay
+reactID: overlay
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Text} from '@primer/react'
 export default ComponentLayout
+
+### Usage
+
+Overlay is an internal component, meaning it's intended to be used as a private API, composing other components. It is not intended to be used on its own. 
+
+The Overlay component handles all behaviors needed by overlay UIs as well as the common styles that all overlays should have. Overlay is the base component for many of our overlay-type components. Overlays use shadows to express elevation.
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>

--- a/content/components/page-layout.mdx
+++ b/content/components/page-layout.mdx
@@ -1,14 +1,16 @@
 ---
-title: Pointer box
-description: A customisable bordered box with a caret pointer
-componentId: pointer_box
-reactId: pointer_box
+title: Page layout
+description: Page layout defines the header, main, pane, and footer areas of a page.
+componentId: page_layout
+reactId: page_layout
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
+
+### Usage
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>

--- a/content/components/page-layout.mdx
+++ b/content/components/page-layout.mdx
@@ -10,8 +10,6 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-### Usage
-
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>

--- a/content/components/pagehead.mdx
+++ b/content/components/pagehead.mdx
@@ -1,0 +1,37 @@
+---
+title: Pagehead
+description: Pagehead denotes the title and start of a given section.
+component: pagehead
+reactId: pagehead
+railsIds:
+- Primer::Beta::Subhead
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
+export default ComponentLayout
+
+<img
+  src="https://github.com/primer/design/assets/586552/a3f4a112-bb48-44c8-9c57-ab011a3cd032"
+  role="presentation"
+  width="960"
+  alt="Pagehead component"
+/>
+
+## Usage
+
+Pagehead is a heading component for the title and start of a given page section. The same component in our Rails framework is called [subhead](/component/pagehead/rails/beta). 
+
+### Options
+
+**Basic pagehead**: The basic pagehead is the simplest form of the pagehead component which shows only a text layer.
+
+**Pagehead with avatars and actions**: Avatars can be included next to the pagehead title, and actions can be added after the title.
+
+<img
+  src="https://github.com/primer/design/assets/586552/b972eb5b-9af5-46dc-bf2b-6d3c2dc4ea53"
+  role="presentation"
+  width="960"
+  alt="Pagehead component showing variations including avatars and actions"
+/>

--- a/content/components/pointer-box.mdx
+++ b/content/components/pointer-box.mdx
@@ -1,7 +1,7 @@
 ---
-title: HiddenTextExpander
-description: Use HiddenTextExpander to indicate and toggle hidden text.
-railsId: Primer::Alpha::HiddenTextExpander
+title: Pointer box
+description: A customisable, bordered Box with a caret pointer
+reactID: pointer_box
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/spinner.mdx
+++ b/content/components/spinner.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::Spinner
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/spinner.mdx
+++ b/content/components/spinner.mdx
@@ -3,6 +3,7 @@ title: Spinner
 description: Use Spinner to let users know that content is being loaded.
 railsIds:
 - Primer::Beta::Spinner
+reactId: spinner
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/split-page-layout.mdx
+++ b/content/components/split-page-layout.mdx
@@ -1,8 +1,8 @@
 ---
-title: Pointer box
-description: A customisable bordered box with a caret pointer
-componentId: pointer_box
-reactId: pointer_box
+title: Split page layout
+description: Split page layout is used to provide structure for a split layout.
+componentId: split_page_layout
+reactId: split_page_layout
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -10,7 +10,11 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
+## Usage
+This component provides structure for a split layout, including independent scrolling for the pane and content regions. This is useful for responsive list and detail patterns when an item in the pane updates the page content on selection.
+
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+

--- a/content/components/split-page-layout.mdx
+++ b/content/components/split-page-layout.mdx
@@ -10,11 +10,10 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-## Usage
-This component provides structure for a split layout, including independent scrolling for the pane and content regions. This is useful for responsive list and detail patterns when an item in the pane updates the page content on selection.
-
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
 
+## Usage
+This component provides structure for a split layout, including independent scrolling for the pane and content regions. This is useful for responsive list and detail patterns when an item in the pane updates the page content on selection.

--- a/content/components/state-label.mdx
+++ b/content/components/state-label.mdx
@@ -6,10 +6,11 @@ railsId: Primer::Beta::State
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/state-label.mdx
+++ b/content/components/state-label.mdx
@@ -1,17 +1,50 @@
 ---
-title: State
-description: Use state for rendering the status of an item.
+title: State label
+description: State label is used for rendering the status of an item.
 reactId: state_label
 railsIds:
 - Primer::Beta::State
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Link, Text} from '@primer/react'
+import {Box, Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
-</Note>
+## Usage
+Use state label to show the status of an issue or pull request.
+
+## Anatomy
+<img
+  width="960"
+  alt="State label showing an open and merged label"
+  src="https://github.com/primer/design/assets/586552/00cadd5f-67df-491a-b4a4-629a25a10188"
+/>
+
+### Types and states
+
+The State label variant can be used for issues, which uses the issues icon, or pull requests, which uses the pull request icon. 
+
+Status for the State label can be one of the following options: draft (gray), open (green), closed (purple for issues and red for pull requests), or merged (purple, used for pull requests
+ only).
+
+<Box
+  mb={3}
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <img
+    width="369"
+    role="presentation"
+    alt="State label displayed for issues and pull requests"
+    src="https://github.com/primer/design/assets/586552/d779f1ac-e004-4ef7-8c6a-4249b3e394ea"
+  />
+  <img
+    width="400"
+    role="presentation"
+    alt="State labels displayed in all status variations, including draft, open, closed, and merged."
+    src="https://github.com/primer/design/assets/586552/b835e654-9414-462a-8488-af6d447b372c"
+  />
+</Box>

--- a/content/components/subhead.mdx
+++ b/content/components/subhead.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::Subhead
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/subhead.mdx
+++ b/content/components/subhead.mdx
@@ -10,7 +10,4 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
-</Note>
+For subhead component guidelines, see [pagehead](/components/pagehead).

--- a/content/components/subnav.mdx
+++ b/content/components/subnav.mdx
@@ -9,13 +9,22 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-## Usage
-
-Use the SubNav component for navigation on a dashboard-type interface with another set of navigation components above it. This helps distinguish navigation hierarchy.
-
-Make sure to properly label your SubNav with an aria-label to provide context about the type of navigation contained in SubNav.
-
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+
+<br />
+
+<img
+  src="https://github.com/primer/design/assets/586552/f4f48662-4269-4067-b1fb-b56e24ba8e4d"
+  role="presentation"
+  width="960"
+  alt="Subnav component"
+/>
+
+## Usage
+
+Use the subnav component for navigation on a dashboard-type interface with another set of navigation components above it. This helps distinguish navigation hierarchy.
+
+Make sure to properly label your subnav with an aria-label to provide context about the type of navigation contained in subnav.

--- a/content/components/subnav.mdx
+++ b/content/components/subnav.mdx
@@ -1,5 +1,5 @@
 ---
-title: Subnav
+title: Sub nav
 description: Use the sub nav component for navigation on a dashboard-type interface with another set of navigation components above it.
 reactId: subnav
 ---

--- a/content/components/subnav.mdx
+++ b/content/components/subnav.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sub nav
 description: Use the sub nav component for navigation on a dashboard-type interface with another set of navigation components above it.
-reactId: subnav
+reactId: sub_nav
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/subnav.mdx
+++ b/content/components/subnav.mdx
@@ -1,13 +1,19 @@
 ---
-title: HiddenTextExpander
-description: Use HiddenTextExpander to indicate and toggle hidden text.
-railsId: Primer::Alpha::HiddenTextExpander
+title: Subnav
+description: Use the sub nav component for navigation on a dashboard-type interface with another set of navigation components above it.
+reactId: subnav
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
 import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
+
+## Usage
+
+Use the SubNav component for navigation on a dashboard-type interface with another set of navigation components above it. This helps distinguish navigation hierarchy.
+
+Make sure to properly label your SubNav with an aria-label to provide context about the type of navigation contained in SubNav.
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>

--- a/content/components/tab-container.mdx
+++ b/content/components/tab-container.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::TabContainer
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/timeline-item.mdx
+++ b/content/components/timeline-item.mdx
@@ -10,7 +10,4 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
-</Note>
+For usage guidelines of this component, see [timeline](/components/timeline).

--- a/content/components/timeline-item.mdx
+++ b/content/components/timeline-item.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Beta::TimelineItem
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/timeline.mdx
+++ b/content/components/timeline.mdx
@@ -2,6 +2,8 @@
 title: Timeline
 description: The timeline component is used to display items on a vertical timeline, connected by timeline elements.
 reactId: timeline
+railsIds:
+- Primer::Beta::TimelineItem
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -13,3 +15,23 @@ export default ComponentLayout
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
   <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>
+
+<br />
+
+<img
+  width="960"
+  role="presentation"
+  src="https://github.com/primer/design/assets/586552/f1ef5e7c-86fb-4131-be14-4831923065cf"
+  alt="timeline component item"
+/>
+
+## Usage
+
+Timeline displays items on a connected vertical timeline. It's primarily used to document the history and activity of a given pull request or issue.
+
+<img
+  width="960"
+  role="presentation"
+  src="https://github.com/primer/design/assets/586552/d44a8384-44fc-4879-9f1b-a4d33a53d994"
+  alt="timeline component"
+/>

--- a/content/components/timeline.mdx
+++ b/content/components/timeline.mdx
@@ -5,10 +5,11 @@ reactId: timeline
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/timeline.mdx
+++ b/content/components/timeline.mdx
@@ -1,8 +1,7 @@
 ---
-title: Tooltip
-description: Tooltips add additional context to other UI elements and appear on mouse hover or keyboard focus.
-railsId: Primer::Alpha::Tooltip
-reactId: tooltip
+title: Timeline
+description: The timeline component is used to display items on a vertical timeline, connected by timeline elements.
+reactId: timeline
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/token.mdx
+++ b/content/components/token.mdx
@@ -206,3 +206,7 @@ To make tokens accessible to keyboard users and those who require accessible con
 - when in focus a token must have a visible focus outline
 - if a token can be removed, the keyboard focus must be moved to the previous token after deletion. If no token remains, it must focus on the input itself.
 - if a close button is used, it’s name should use the token’s label to make it unique
+
+## Related links
+
+- [Label](/components/label/)

--- a/content/components/tooltip.mdx
+++ b/content/components/tooltip.mdx
@@ -8,10 +8,11 @@ Primer::Tooltip
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/tooltip.mdx
+++ b/content/components/tooltip.mdx
@@ -12,7 +12,32 @@ import {Link, Text} from '@primer/react'
 import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
+
+## Usage
+
+The tooltip component adds a tooltip to add context to interactive elements on the page.
+
+<img
+  width="960"
+  role="presentation"
+  src="https://github.com/primer/design/assets/586552/787873b7-d496-454c-b669-0c2400ef503f"
+  alt="three examples of tooltips on interactive elements"
+/>
+
+## Accessibility
+
+<Note variant="danger">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>⚠️ Usage Warning ⚠️</Text>
+  <Text>Tooltips as a UI pattern should be our last resort for conveying information because it is hidden by default and often with zero or little visual indicator of its existence.</Text>
 </Note>
+
+Before adding a tooltip, please consider: Is this information essential and necessary? Can the UI be made clearer? Can the information be shown on the page by default? See Tooltip alternatives for more accessible alternatives.
+
+We use aria-label for tooltip contents. However, aria-label replaces the text content of an element in screen readers, so only use Tooltip on elements with no existing text content.
+
+A tooltip may only be used on an element that is interactive such as a button or a link. Even if an element is focusable, a tooltip may only be used if the element does something when it's clicked.
+
+### Tooltip alternatives
+
+Most UI cases don't call for tooltips. Learn some [alternative methods to use in place of tooltips](/../guides/accessibility/tooltip-alternatives).
+

--- a/content/components/tooltip.mdx
+++ b/content/components/tooltip.mdx
@@ -11,5 +11,5 @@ export default ComponentLayout
 
 <Note variant="warning">
   <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link>
 </Note>

--- a/content/components/tooltip.mdx
+++ b/content/components/tooltip.mdx
@@ -3,8 +3,8 @@ title: Tooltip
 description: Tooltips add additional context to other UI elements and appear on mouse hover or keyboard focus.
 reactId: tooltip
 railsIds:
-Primer::Alpha::Tooltip
-Primer::Tooltip
+- Primer::Alpha::Tooltip
+- Primer::Tooltip
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/truncate.mdx
+++ b/content/components/truncate.mdx
@@ -6,10 +6,11 @@ reactId: truncate
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/components/truncate.mdx
+++ b/content/components/truncate.mdx
@@ -2,6 +2,7 @@
 title: Truncate
 description: Use Truncate to shorten overflowing text with an ellipsis.
 railsId: Primer::Beta::Truncate
+reactId: truncate
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/truncate.mdx
+++ b/content/components/truncate.mdx
@@ -3,8 +3,8 @@ title: Truncate
 description: Use Truncate to shorten overflowing text with an ellipsis.
 reactId: truncate
 railsIds:
-Primer::Beta::Truncate
-Primer::Truncate
+- Primer::Beta::Truncate
+- Primer::Truncate
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -5,10 +5,11 @@ railsId: Primer::Alpha::UnderlinePanels
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Text} from '@primer/react'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 
 <Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-  We are currently working on general guidance for this component.
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
 </Note>

--- a/content/guides/accessibility/links.mdx
+++ b/content/guides/accessibility/links.mdx
@@ -179,8 +179,8 @@ Some examples of this are:
 ### For engineers
 
 - Use Primer link components:
-  - [Link in Primer ViewComponents](https://primer.style/view-components/components/beta/link)
-  - [Link in Primer React](https://primer.style/react/Link)
+  - [Rails component](/../components/link/rails)
+  - [React component](/../components/link/react)
 - Don't override the link styling provided in the components
 - Make sure links receive our global focus indicator styling when navigating the page with a keyboard (reference: [Focus management](/guides/accessibility/focus-management))
 - Don't use the `title` attribute

--- a/content/guides/contribute/documentation.mdx
+++ b/content/guides/contribute/documentation.mdx
@@ -107,8 +107,6 @@ When creating images with example UI for docs make sure that:
 
 When documenting components, consider the core elements needed to convey its main purpose and proper usage within the UI.
 
-See our full [documentation guidelines here](https://primer.style/contribute/documentation/).
-
 ### Documentation preferences
 
 - Use sentence case when referring to component names. Do not capitalize the component in the middle of a sentence.

--- a/content/ui-patterns/common-actions.mdx
+++ b/content/ui-patterns/common-actions.mdx
@@ -1,4 +1,0 @@
----
-title: Common actions
-description: Actions that are commonly used across various workflows across the application.
----

--- a/content/ui-patterns/common-actions.mdx
+++ b/content/ui-patterns/common-actions.mdx
@@ -1,0 +1,4 @@
+---
+title: Common actions
+description: Actions that are commonly used across various workflows across the application.
+---

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -168,6 +168,8 @@
       url: /components/checkbox
     - title: Checkbox group
       url: /components/checkbox-group
+    - title: Circle badge
+      url: /components/circle-badge   
     - title: Clipboard copy
       url: /components/clipboard-copy
     - title: Close button
@@ -188,6 +190,8 @@
       url: /components/flash
     - title: Form control
       url: /components/form-control
+    - title: Header
+      url: /components/header
     - title: Heading
       url: /components/heading
     - title: Hidden text expander
@@ -220,6 +224,8 @@
       url: /components/overlay
     - title: Page header
       url: /components/page-header
+    - title: Page layout 
+      url: /components/page-layout
     - title: Pagination
       url: /components/pagination
     - title: Popover
@@ -242,6 +248,8 @@
       url: /components/selectpanel
     - title: Spinner
       url: /components/spinner
+    - title: Split page layout
+      url: /components/split-page-layout
     - title: State label
       url: /components/state-label
     - title: Subhead

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -204,14 +204,14 @@
       url: /components/label-group
     - title: Layout
       url: /components/layout
+    - title: Link
+      url: /components/link
     - title: Icon
       url: /components/icon
     - title: Image
       url: /components/image
     - title: Image crop
       url: /components/image-crop
-    - title: Link
-      url: /components/link
     - title: Markdown
       url: /components/markdown
     - title: Menu

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -256,6 +256,8 @@
       url: /components/text-input-with-tokens
     - title: Textarea
       url: /components/textarea
+    - title: Timeline
+      url: /components/timeline
     - title: Timeline item
       url: /components/timeline-item
     - title: Toggle switch

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -182,8 +182,6 @@
       url: /components/details
     - title: Dialog
       url: /components/dialog
-    - title: Dropdown
-      url: /components/dropdown
     - title: Filter input
       url: /components/filter-input
     - title: Flash

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -214,8 +214,6 @@
       url: /components/image-crop
     - title: Markdown
       url: /components/markdown
-    - title: Menu
-      url: /components/menu
     - title: Nav list
       url: /components/nav-list
     - title: Octicon symbols

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -146,8 +146,6 @@
       url: /components/avatar-pair
     - title: Avatar stack
       url: /components/avatar-stack
-    - title: Banner
-      url: /components/banner
     - title: Blankslate
       url: /components/blankslate
     - title: Border box

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -270,8 +270,6 @@
       url: /components/textarea
     - title: Timeline
       url: /components/timeline
-    - title: Timeline item
-      url: /components/timeline-item
     - title: Toggle switch
       url: /components/toggle-switch
     - title: Token

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -196,6 +196,8 @@
       url: /components/icon-button
     - title: Label
       url: /components/label
+    - title: Label group
+      url: /components/label-group
     - title: Layout
       url: /components/layout
     - title: Icon
@@ -222,16 +224,18 @@
       url: /components/pagination
     - title: Popover
       url: /components/popover
+    - title: Pointer box
+      url: /components/pointer-box
     - title: Progress bar
       url: /components/progress-bar
-    - title: Segmented control
-      url: /components/segmented-control
     - title: Radio
       url: /components/radio
     - title: Radio group
       url: /components/radio-group
     - title: Relative time
       url: /components/relative-time
+    - title: Segmented control
+      url: /components/segmented-control
     - title: Select
       url: /components/select
     - title: Select panel
@@ -242,6 +246,8 @@
       url: /components/state-label
     - title: Subhead
       url: /components/subhead
+    - title: Subnav
+      url: /components/subnav
     - title: Tab container
       url: /components/tab-container
     - title: Tab nav

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -204,6 +204,8 @@
       url: /components/image-crop
     - title: Label
       url: /components/label
+    - title: Label group
+      url: /components/label-group
     - title: Layout
       url: /components/layout
     - title: Link

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -220,6 +220,8 @@
       url: /components/octicon-symbols
     - title: Overlay
       url: /components/overlay
+    - title: Pagehead
+      url: /components/pagehead
     - title: Page header
       url: /components/page-header
     - title: Page layout 
@@ -250,8 +252,6 @@
       url: /components/split-page-layout
     - title: State label
       url: /components/state-label
-    - title: Subhead
-      url: /components/subhead
     - title: Subnav
       url: /components/subnav
     - title: Tab container

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -115,12 +115,6 @@ export default function ReactComponentLayout({data}) {
           </Box>
           <Box sx={{minWidth: 0}}>
             {/* @ts-ignore */}
-            <Note variant="warning">
-              <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Work in progress</Text>
-              We are currently transferring the React documentation for {name} from a different site to this page. To
-              view the original documentation with code examples, please visit the{' '}
-              <Link href={`https://primer.style/react/${name}`}>Primer React documentation for {name}</Link>.
-            </Note>
             <Box
               sx={{
                 display: 'flex',


### PR DESCRIPTION
Tasks

- [x] add the remainder of the Primer react components that were missing
- [x] Update the "missing guidelines" messaging to include a prompt for contributions
- [x] Update links

This PR should allow us to close out the coverage Epic from this quarter. Next quarter, we'll focus on the remaining of missing component guidelines, with a priority on those with known accessibility issues to document. 