### PR TITLE
Fix broken link

### DIFF
--- a/content/foundations/icons/design-guidelines.mdx
+++ b/content/foundations/icons/design-guidelines.mdx
@@ -141,7 +141,7 @@ Use round caps and joins.
 
 ## Corners
 
-Use 1px radius for corners unless a different radius makes the icon more recognizable (e.g. [repo](/repo-16)). 
+Use 1px radius for corners unless a different radius makes the icon more recognizable (e.g. [repo](./repo-16)). 
 
 <Box display="grid" gridTemplateColumns={['1fr', null, null, null, '1fr 1fr']} gridGap={4} mb={4}>
     <div>


### PR DESCRIPTION
Link to `repo` icon page is broken on https://primer.style/design/foundations/icons/design-guidelines#corners as it seems to be looking for it on the root and not relative to the icons page.

Currently leads to https://primer.style/design/repo-16/ (a 404).