### PR TITLE
Update team titles

### DIFF
--- a/src/data/team.js
+++ b/src/data/team.js
@@ -12,7 +12,7 @@ const teamContent = [
   },
   {
     name: 'Rayta van Rijswijk',
-    title: 'Senior Engineering Manager',
+    title: 'Engineering Manager',
     handle: 'raytalks',
     questionOne: `Having worked in and with several different software development teams before, I've learned it takes more than a process to deliver fast, reliable, high performant, quality products.
   
@@ -139,7 +139,7 @@ const teamContent = [
   },
   {
     name: 'Leslie Cohn-Wein',
-    title: 'Design Engineering Director',
+    title: 'Engineering Manager',
     handle: 'lesliecdubs',
     questionOne: `As an agency developer early in my career, it seemed we were always building the same UI with different styles. So why not build once, with enough flexibility to customize for many clients?
   


### PR DESCRIPTION
Updating team titles on the /about page of primer.style; we usually list the role only, and not internal level.