### PR TITLE
Fix React component fetching

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -82,7 +82,9 @@ async function sourcePrimerReactData({actions, createNodeId, createContentDigest
   // Save the current version of Primer React to the GraphQL store.
   // This will be the latest version at the time the site is built.
   // If a new version is released, we'll need to rebuild the site.
-  const {version} = await fetch('https://unpkg.com/@primer/react/package.json').then(res => res.json())
+  const {version} = await fetch(
+    'https://unpkg.com/@primer/react/package.json', {redirect: 'follow'}
+  ).then(res => res.json())
 
   const nodeData = {
     version,
@@ -100,11 +102,9 @@ async function sourcePrimerReactData({actions, createNodeId, createContentDigest
   actions.createNode(newNode)
 
   // Save the Primer React data to the GraphQL store
-  const json = await fetch(
-    `https://api.github.com/repos/primer/react/contents/generated/components.json?ref=v${version}`,
+  const content = await fetch(
+    `https://unpkg.com/@primer/react/generated/components.json`, {redirect: 'follow'}
   ).then(res => res.json())
-
-  const content = JSON.parse(Buffer.from(json.content, 'base64').toString())
 
   for (const component of Object.values(content.components)) {
     const newNode = {
@@ -124,7 +124,9 @@ async function sourceOcticonData({actions, createNodeId, createContentDigest}) {
   // Save the current version of Octicons to the GraphQL store.
   // This will be the latest version at the time the site is built.
   // If a new version is released, we'll need to rebuild the site.
-  const {version} = await fetch('https://unpkg.com/@primer/octicons/package.json').then(res => res.json())
+  const {version} = await fetch(
+    'https://unpkg.com/@primer/octicons/package.json', {redirect: 'follow'}
+  ).then(res => res.json())
 
   const nodeData = {
     version,
@@ -142,7 +144,9 @@ async function sourceOcticonData({actions, createNodeId, createContentDigest}) {
   actions.createNode(newNode)
 
   // Save the icon data to the GraphQL store
-  const octiconData = await fetch('https://unpkg.com/@primer/octicons/build/data.json').then(res => res.json())
+  const octiconData = await fetch(
+    'https://unpkg.com/@primer/octicons/build/data.json', {redirect: 'follow'}
+  ).then(res => res.json())
 
   for (const icon of Object.values(octiconData)) {
     for (const [height, data] of Object.entries(icon.heights)) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gatsby-plugin-svgr": "^3.0.0-beta.0",
     "gatsby-plugin-typescript": "^2.12.1",
     "jspdf": "^2.5.1",
-    "node-fetch": "^2.6.9",
+    "node-fetch": "^2.6.12",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^8.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11142,10 +11142,17 @@ node-fetch@2.6.1:
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^2.5.0, node-fetch@^2.6.1, node-fetch@^2.6.9:
+node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.9"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.12:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
+  integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
We've received reports of errors when starting up the Gatsby dev server. It looks like the generated/ directory [was recently removed](https://github.com/primer/react/pull/3479) from primer/react and is now treated as a build artifact. Gatsby is attempting to fetch this file from the repo, which fails. This PR fixes things by fetching generated/components.json from unpkg instead of from the primer/react git repo directly.