### PR TITLE
Adding ActionBar rails IDs

### DIFF
--- a/content/components/action-bar.mdx
+++ b/content/components/action-bar.mdx
@@ -3,6 +3,8 @@ title: Action bar
 status: Experimental
 description: Action bar contains a collection of horizontally aligned icon buttons.
 figmaId: action_bar
+railsIds:
+- Primer::Alpha::ActionBar
 ---
 
 import {Box, Text} from '@primer/react'


### PR DESCRIPTION
ActionBar just shipped in https://github.com/primer/view_components/releases/tag/v0.4.0

This PR adds the Rails tab.