### PR TITLE
About page layout

### DIFF
--- a/content/guides/about.mdx
+++ b/content/guides/about.mdx
@@ -3,5 +3,7 @@ title: Meet the team
 ---
 
 import {Team} from '../../src/components/team'
+import MinimalLayout from '~/src/layouts/minimal-layout'
+export default MinimalLayout
 
 <Team />

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -2,8 +2,6 @@
   children:
     - title: Introduction
       url: /guides/introduction
-    - title: About
-      url: /guides/about
     - title: Figma
       url: /guides/figma
       children:
@@ -167,7 +165,7 @@
     - title: Checkbox group
       url: /components/checkbox-group
     - title: Circle badge
-      url: /components/circle-badge   
+      url: /components/circle-badge
     - title: Clipboard copy
       url: /components/clipboard-copy
     - title: Close button
@@ -222,7 +220,7 @@
       url: /components/pagehead
     - title: Page header
       url: /components/page-header
-    - title: Page layout 
+    - title: Page layout
       url: /components/page-layout
     - title: Pagination
       url: /components/pagination

--- a/src/components/base-layout.tsx
+++ b/src/components/base-layout.tsx
@@ -4,15 +4,17 @@ import Head from '@primer/gatsby-theme-doctocat/src/components/head'
 import Header from '@primer/gatsby-theme-doctocat/src/components/header'
 import Sidebar from '@primer/gatsby-theme-doctocat/src/components/sidebar'
 
-export function BaseLayout({title, description, children}) {
+export function BaseLayout({title, description, children, showSidebar = true}) {
   return (
     <Box sx={{flexDirection: 'column', minHeight: '100vh', display: 'flex'}}>
       <Head title={title} description={description} />
       <Header />
       <Box sx={{zIndex: 0, flex: '1 1 auto', flexDirection: 'row', display: 'flex'}}>
-        <Box sx={{display: ['none', null, null, 'block']}}>
-          <Sidebar />
-        </Box>
+        {showSidebar ? (
+          <Box sx={{display: ['none', null, null, 'block']}}>
+            <Sidebar />
+          </Box>
+        ) : null}
         <Box as="main" sx={{minWidth: 0, width: '100%'}} id="skip-nav">
           {children}
         </Box>

--- a/src/layouts/minimal-layout.tsx
+++ b/src/layouts/minimal-layout.tsx
@@ -4,13 +4,12 @@ import TableOfContents from '@primer/gatsby-theme-doctocat/src/components/table-
 import {Box, Heading, Text} from '@primer/react'
 import React from 'react'
 import {BaseLayout} from '../components/base-layout'
-import {ComponentPageNav} from '../components/component-page-nav'
 
-export default function ComponentLayout({pageContext, children, path}) {
-  const {title, description, reactId, railsIds, figmaId} = pageContext.frontmatter
+export default function MinimalLayout({pageContext, children, path}) {
+  const {title, description} = pageContext.frontmatter
 
   return (
-    <BaseLayout title={title} description={description}>
+    <BaseLayout showSidebar={false} title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
         <Heading as="h1">{title}</Heading>
         {description ? (
@@ -18,15 +17,6 @@ export default function ComponentLayout({pageContext, children, path}) {
             {description}
           </Text>
         ) : null}
-        <Box sx={{mb: 4}}>
-          <ComponentPageNav
-            basePath={path}
-            includeReact={reactId}
-            includeRails={railsIds}
-            includeFigma={figmaId}
-            current="overview"
-          />
-        </Box>
         <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
           <Box
             sx={{

--- a/src/layouts/minimal-layout.tsx
+++ b/src/layouts/minimal-layout.tsx
@@ -10,77 +10,25 @@ export default function MinimalLayout({pageContext, children, path}) {
 
   return (
     <BaseLayout showSidebar={false} title={title} description={description}>
-      <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
+      <Box sx={{maxWidth: 960, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
         <Heading as="h1">{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
           </Text>
         ) : null}
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{minWidth: 0, flexGrow: 1}}>
           <Box
             sx={{
-              width: 220,
-              flex: '0 0 auto',
-              position: 'sticky',
-              top: HEADER_HEIGHT + 24,
-              maxHeight: `calc(100vh - ${HEADER_HEIGHT}px - 24px)`,
-              display: ['none', null, 'block'],
+              '& > :first-child': {
+                mt: 0,
+              },
+              '& > :last-child': {
+                mb: 0,
+              },
             }}
           >
-            {pageContext.tableOfContents.items ? (
-              <>
-                <Heading
-                  as="h3"
-                  sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}}
-                  id="toc-heading"
-                >
-                  On this page
-                </Heading>
-                <TableOfContents aria-labelledby="toc-heading" items={pageContext.tableOfContents.items} />
-              </>
-            ) : null}
-          </Box>
-          <Box sx={{minWidth: 0, flexGrow: 1}}>
-            {/* Narrow table of contents */}
-            {pageContext.tableOfContents.items ? (
-              <Box
-                sx={{
-                  display: ['block', null, 'none'],
-                  mb: 5,
-                  borderColor: 'border.muted',
-                  bg: 'canvas.subtle',
-                  borderWidth: '1px',
-                  borderStyle: 'solid',
-                  borderRadius: 2,
-                }}
-              >
-                <Box sx={{px: 3, py: 2}}>
-                  <Box
-                    sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
-                  >
-                    <Heading as="h3" sx={{fontSize: 2, fontWeight: 'bold'}} id="toc-heading-narrow">
-                      On this page
-                    </Heading>
-                  </Box>
-                </Box>
-                <Box sx={{borderTop: '1px solid', borderColor: 'border.muted'}}>
-                  <TableOfContents aria-labelledby="toc-heading-narrow" items={pageContext.tableOfContents.items} />
-                </Box>
-              </Box>
-            ) : null}
-            <Box
-              sx={{
-                '& > :first-child': {
-                  mt: 0,
-                },
-                '& > :last-child': {
-                  mb: 0,
-                },
-              }}
-            >
-              {children}
-            </Box>
+            {children}
           </Box>
         </Box>
         <PageFooter editUrl={pageContext.editUrl} contributors={pageContext.contributors} />


### PR DESCRIPTION
Fixes: https://github.com/github/primer/issues/2425

👓 : https://primer-9487c19a78-26441320.drafts.github.io/guides/about

- [x] Swap /about to a full-width layout
- [x] Fix margin underneath the h1
- [x] Remove "About" from the sidebar