### PR TITLE
About page layout

### DIFF
--- a/content/about.mdx
+++ b/content/about.mdx
@@ -2,7 +2,7 @@
 title: Meet the team
 ---
 
-import {Team} from '../../src/components/team'
+import {Team} from '~/src/components/team'
 import MinimalLayout from '~/src/layouts/minimal-layout'
 export default MinimalLayout
 

--- a/content/guides/about.mdx
+++ b/content/guides/about.mdx
@@ -3,5 +3,7 @@ title: Meet the team
 ---
 
 import {Team} from '../../src/components/team'
+import MinimalLayout from '~/src/layouts/minimal-layout'
+export default MinimalLayout
 
 <Team />

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -2,8 +2,6 @@
   children:
     - title: Introduction
       url: /guides/introduction
-    - title: About
-      url: /guides/about
     - title: Figma
       url: /guides/figma
       children:
@@ -167,7 +165,7 @@
     - title: Checkbox group
       url: /components/checkbox-group
     - title: Circle badge
-      url: /components/circle-badge   
+      url: /components/circle-badge
     - title: Clipboard copy
       url: /components/clipboard-copy
     - title: Close button
@@ -222,7 +220,7 @@
       url: /components/pagehead
     - title: Page header
       url: /components/page-header
-    - title: Page layout 
+    - title: Page layout
       url: /components/page-layout
     - title: Pagination
       url: /components/pagination

--- a/src/components/avatar-shape.js
+++ b/src/components/avatar-shape.js
@@ -1,100 +1,27 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import {Box, Link, themeGet} from '@primer/react'
-import {color} from 'styled-system'
-import {ReactComponent as Circle} from '../images/circle.svg'
-import {ReactComponent as Hexagon} from '../images/hexagon.svg'
-import {ReactComponent as Square} from '../images/square.svg'
-import {ReactComponent as Diamond} from '../images/diamond.svg'
 
 const TRANSITION_STYLE = '0.8s ease'
 
-const Shape = styled(({className, shape}) => {
-  const shapes = {
-    hexagon: Hexagon,
-    circle: Circle,
-    square: Square,
-    diamond: Diamond,
-  }
-  const Tag = shapes[shape]
-  return <Tag className={className} />
-})`
-  position: relative;
-  width: 100%;
-  height: auto;
-  fill: none;
-`
-
 const Image = styled('img')`
   object-fit: cover;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
+  width: 240px;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 6px;
   transition: filter ${TRANSITION_STYLE};
   filter: grayscale(1);
   ${({$hover}) => $hover && `filter: grayscale(0);`}
 `
 
-const A = styled(Box)`
-  position: relative;
-  display: inline-block;
-  clip-path: url('#clip-${props => props.shape}');
-  &:after {
-    content: '';
-    transition: opacity ${TRANSITION_STYLE};
-    position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(ellipse at top left, ${themeGet('colors.blue.4')}, transparent),
-      radial-gradient(ellipse at bottom right, ${themeGet('colors.orange.4')}, transparent),
-      linear-gradient(to right, ${themeGet('colors.orange.5')} 50%, transparent),
-      linear-gradient(to left, ${themeGet('colors.blue.6')} 50%, transparent);
-    mix-blend-mode: multiply;
-    opacity: 0;
-  }
-  &:hover:after {
-    opacity: 1;
-  }
-`
-
-const ShapeOutline = styled(Link)`
-  padding: 2px;
-  position: relative;
-  background: transparent !important;
-  display: block;
-  &:before {
-    content: '';
-    clip-path: url('#clip-${props => props.shape}');
-    ${color};
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-  }
-`
-
-const AvatarShape = props => (
-  <ShapeOutline shape={props.shape} bg={props.bg} {...props}>
-    <A className={props.className} shape={props.shape}>
-      <Image src={props.src} $hover={props.hover} alt={props.name} />
-      <Shape shape={props.shape} />
-    </A>
-  </ShapeOutline>
-)
+const AvatarShape = props => <Image src={props.src} $hover={props.hover} alt={props.name} {...props} />
 
 AvatarShape.defaultProps = {
-  bg: 'blue.4',
   hover: false,
 }
 
 AvatarShape.propTypes = {
-  shape: PropTypes.oneOf(['hexagon', 'square', 'circle', 'diamond']),
   hover: PropTypes.bool,
 }
 

--- a/src/components/avatar-shape.js
+++ b/src/components/avatar-shape.js
@@ -6,12 +6,13 @@ const TRANSITION_STYLE = '0.8s ease'
 
 const Image = styled('img')`
   object-fit: cover;
-  width: 240px;
+  width: 320px;
   aspect-ratio: 1;
   overflow: hidden;
-  border-radius: 6px;
+  border-radius: 100%;
   transition: filter ${TRANSITION_STYLE};
   filter: grayscale(1);
+  margin-bottom: 16px;
   ${({$hover}) => $hover && `filter: grayscale(0);`}
 `
 

--- a/src/components/avatar-shape.js
+++ b/src/components/avatar-shape.js
@@ -2,15 +2,12 @@ import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
-const TRANSITION_STYLE = '0.8s ease'
-
 const Image = styled('img')`
   object-fit: cover;
-  width: 320px;
+  width: 280px;
   aspect-ratio: 1;
   overflow: hidden;
-  border-radius: 100%;
-  transition: filter ${TRANSITION_STYLE};
+  border-radius: 8px;
   filter: grayscale(1);
   margin-bottom: 16px;
   ${({$hover}) => $hover && `filter: grayscale(0);`}

--- a/src/components/avatar-shape.js
+++ b/src/components/avatar-shape.js
@@ -1,19 +1,31 @@
 import React from 'react'
 import styled from 'styled-components'
+import {Box} from '@primer/react'
 import PropTypes from 'prop-types'
 
 const Image = styled('img')`
   object-fit: cover;
   width: 280px;
-  aspect-ratio: 1;
+  height: 280px;
   overflow: hidden;
   border-radius: 8px;
   filter: grayscale(1);
-  margin-bottom: 16px;
   ${({$hover}) => $hover && `filter: grayscale(0);`}
 `
 
-const AvatarShape = props => <Image src={props.src} $hover={props.hover} alt={props.name} {...props} />
+const AvatarShape = props => (
+  <Box
+    sx={{
+      position: ['relative', 'relative', 'relative', 'sticky', 'sticky'],
+      top: [0, 0, 0, 10, 10],
+      display: 'flex',
+      alignSelf: ['initial', 'initial', 'initial', 'start', 'start'],
+      marginBottom: [5, 5, 5, 0, 0],
+    }}
+  >
+    <Image src={props.src} $hover={props.hover} alt={props.name} {...props} />
+  </Box>
+)
 
 AvatarShape.defaultProps = {
   hover: false,

--- a/src/components/base-layout.tsx
+++ b/src/components/base-layout.tsx
@@ -4,15 +4,17 @@ import Head from '@primer/gatsby-theme-doctocat/src/components/head'
 import Header from '@primer/gatsby-theme-doctocat/src/components/header'
 import Sidebar from '@primer/gatsby-theme-doctocat/src/components/sidebar'
 
-export function BaseLayout({title, description, children}) {
+export function BaseLayout({title, description, children, showSidebar = true}) {
   return (
     <Box sx={{flexDirection: 'column', minHeight: '100vh', display: 'flex'}}>
       <Head title={title} description={description} />
       <Header />
       <Box sx={{zIndex: 0, flex: '1 1 auto', flexDirection: 'row', display: 'flex'}}>
-        <Box sx={{display: ['none', null, null, 'block']}}>
-          <Sidebar />
-        </Box>
+        {showSidebar ? (
+          <Box sx={{display: ['none', null, null, 'block']}}>
+            <Sidebar />
+          </Box>
+        ) : null}
         <Box as="main" sx={{minWidth: 0, width: '100%'}} id="skip-nav">
           {children}
         </Box>

--- a/src/components/member-container.js
+++ b/src/components/member-container.js
@@ -19,6 +19,7 @@ export default function Member(props) {
       alignItems={['center', 'center', 'center', 'initial', 'initial']}
       flexDirection="column"
       as="article"
+      id={member.handle}
     >
       <header style={{textAlign: 'center'}}>
         <AvatarShape

--- a/src/components/member-container.js
+++ b/src/components/member-container.js
@@ -3,11 +3,6 @@ import {Box, Heading, Link, Text} from '@primer/react'
 import MemberQuestions from './member-questions'
 import AvatarShape from './avatar-shape'
 
-const direction = isOdd =>
-  isOdd
-    ? ['column-reverse', 'column-reverse', 'column-reverse', 'row-reverse', 'row-reverse']
-    : ['column-reverse', 'column-reverse', 'column-reverse', 'row', 'row']
-
 export default function Member(props) {
   const [hover, setHover] = useState(false)
 
@@ -44,7 +39,6 @@ export default function Member(props) {
           @{member.handle}
         </Link>
       </header>
-
       <MemberQuestions member={member} colorName={colorName} />
     </Box>
   )

--- a/src/components/member-container.js
+++ b/src/components/member-container.js
@@ -1,7 +1,12 @@
 import React, {useState} from 'react'
-import {Box, Heading, Link, Text} from '@primer/react'
+import {Box} from '@primer/react'
 import MemberQuestions from './member-questions'
 import AvatarShape from './avatar-shape'
+
+const direction = isOdd =>
+  isOdd
+    ? ['column-reverse', 'column-reverse', 'column-reverse', 'row-reverse', 'row-reverse']
+    : ['column-reverse', 'column-reverse', 'column-reverse', 'row', 'row']
 
 export default function Member(props) {
   const [hover, setHover] = useState(false)
@@ -17,30 +22,23 @@ export default function Member(props) {
       pb={12}
       justifyContent="flex-end"
       alignItems={['center', 'center', 'center', 'initial', 'initial']}
-      flexDirection="column"
+      flexDirection={direction(isOdd)}
       as="article"
       id={member.handle}
+      sx={{gap: [0, 0, 0, 8, 8]}}
     >
-      <header style={{textAlign: 'center'}}>
-        <AvatarShape
-          shape={shape}
-          src={avatarImage}
-          bg={color}
-          hover={hover}
-          name={member.name}
-          onFocus={() => setHover(true)}
-          onBlur={() => setHover(false)}
-          onMouseOver={() => setHover(true)}
-          onMouseOut={() => setHover(false)}
-        />
-        <Heading>{member.name}</Heading>
-        <Text sx={{color: 'fg.subtle'}}>{member.title}</Text>
-        <Text sx={{color: 'fg.muted'}}>{' • '}</Text>
-        <Link sx={{mt: 2, color: color, hoverColor: color, fontSize: 2}} href={`https://github.com/${member.handle}`}>
-          @{member.handle}
-        </Link>
-      </header>
       <MemberQuestions member={member} colorName={colorName} />
+      <AvatarShape
+        shape={shape}
+        src={avatarImage}
+        bg={color}
+        hover={hover}
+        name={member.name}
+        onFocus={() => setHover(true)}
+        onBlur={() => setHover(false)}
+        onMouseOver={() => setHover(true)}
+        onMouseOut={() => setHover(false)}
+      />
     </Box>
   )
 }

--- a/src/components/member-container.js
+++ b/src/components/member-container.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {Box} from '@primer/react'
+import {Box, Heading, Link, Text} from '@primer/react'
 import MemberQuestions from './member-questions'
 import AvatarShape from './avatar-shape'
 
@@ -22,24 +22,30 @@ export default function Member(props) {
       pb={12}
       justifyContent="flex-end"
       alignItems={['center', 'center', 'center', 'initial', 'initial']}
-      flexDirection={direction(isOdd)}
+      flexDirection="column"
+      as="article"
     >
+      <header style={{textAlign: 'center'}}>
+        <AvatarShape
+          shape={shape}
+          src={avatarImage}
+          bg={color}
+          hover={hover}
+          name={member.name}
+          onFocus={() => setHover(true)}
+          onBlur={() => setHover(false)}
+          onMouseOver={() => setHover(true)}
+          onMouseOut={() => setHover(false)}
+        />
+        <Heading>{member.name}</Heading>
+        <Text sx={{color: 'fg.subtle'}}>{member.title}</Text>
+        <Text sx={{color: 'fg.muted'}}>{' • '}</Text>
+        <Link sx={{mt: 2, color: color, hoverColor: color, fontSize: 2}} href={`https://github.com/${member.handle}`}>
+          @{member.handle}
+        </Link>
+      </header>
+
       <MemberQuestions member={member} colorName={colorName} />
-      <Box mb={[6, 8, 8, 0, 0]} style={{flexShrink: 0, position: 'relative'}}>
-        <Box sx={{color: color}} display={'flex'} mr={isOdd ? [0, 0, 0, 8, 8] : 0} ml={isOdd ? 0 : [0, 0, 8, 8, 8]}>
-          <AvatarShape
-            shape={shape}
-            src={avatarImage}
-            bg={color}
-            hover={hover}
-            name={member.name}
-            onFocus={() => setHover(true)}
-            onBlur={() => setHover(false)}
-            onMouseOver={() => setHover(true)}
-            onMouseOut={() => setHover(false)}
-          />
-        </Box>
-      </Box>
     </Box>
   )
 }

--- a/src/components/member-container.js
+++ b/src/components/member-container.js
@@ -2,16 +2,6 @@ import React, {useState} from 'react'
 import {Box} from '@primer/react'
 import MemberQuestions from './member-questions'
 import AvatarShape from './avatar-shape'
-import {ReactComponent as DotsSVG} from '../images/dots.svg'
-
-const Dots = ({shape}) => {
-  const css = {
-    position: 'absolute',
-    height: '92px',
-    width: '168px',
-  }
-  return <DotsSVG shape={shape} style={Object.assign(css, shapeStyles[shape])} />
-}
 
 const direction = isOdd =>
   isOdd
@@ -36,20 +26,13 @@ export default function Member(props) {
     >
       <MemberQuestions member={member} colorName={colorName} />
       <Box mb={[6, 8, 8, 0, 0]} style={{flexShrink: 0, position: 'relative'}}>
-        <Box
-          sx={{color: color}}
-          display={'flex'}
-          mr={isOdd ? [0, 0, 0, 12, 12] : 0}
-          ml={isOdd ? 0 : [0, 0, 12, 12, 12]}
-        >
-          <Dots shape={shape} />
+        <Box sx={{color: color}} display={'flex'} mr={isOdd ? [0, 0, 0, 8, 8] : 0} ml={isOdd ? 0 : [0, 0, 8, 8, 8]}>
           <AvatarShape
             shape={shape}
             src={avatarImage}
             bg={color}
             hover={hover}
             name={member.name}
-            href={`https://github.com/${member.handle}`}
             onFocus={() => setHover(true)}
             onBlur={() => setHover(false)}
             onMouseOver={() => setHover(true)}
@@ -59,25 +42,4 @@ export default function Member(props) {
       </Box>
     </Box>
   )
-}
-
-const shapeStyles = {
-  hexagon: {
-    top: '230px',
-    left: '130px',
-    transform: 'rotate(180deg)',
-  },
-  square: {
-    top: '250px',
-    left: '75px',
-  },
-  circle: {
-    top: '236px',
-    left: '181px',
-    transform: 'rotate(180deg)',
-  },
-  diamond: {
-    top: '245px',
-    left: '65px',
-  },
 }

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
-import {Text, Heading, Link, Box, StyledOcticon} from '@primer/react'
-import {MarkGithubIcon} from '@primer/octicons-react'
+import {Text, Link, Box} from '@primer/react'
 
 const MemberMarkdown = ({source, colorName}) => {
   const link = props => (
@@ -17,7 +16,7 @@ const MemberMarkdown = ({source, colorName}) => {
 const MemberInfo = ({member, colorName}) => {
   const color = colorName === 'orange' ? 'severe.fg' : 'accent.fg'
   return (
-    <Box width={[1, 1, 1, 1]} id={member.handle}>
+    <Box width={[1, 1, 1, 1]} id={member.handle} mt={5}>
       <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         What drew you into design systems?
       </Text>

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
-import {Text, Link, Box} from '@primer/react'
+import {Text, Link, Box, Heading} from '@primer/react'
 
 const MemberMarkdown = ({source, colorName}) => {
   const link = props => (
@@ -31,7 +31,15 @@ const MemberInfo = ({member, colorName}) => {
   }
 
   return (
-    <Box mt={5}>
+    <Box flex="1">
+      <header>
+        <Heading>{member.name}</Heading>
+        <Text sx={{color: 'fg.subtle'}}>{member.title}</Text>
+        <Text sx={{color: 'fg.muted'}}>{' • '}</Text>
+        <Link sx={{mt: 2, color: color, hoverColor: color, fontSize: 2}} href={`https://github.com/${member.handle}`}>
+          @{member.handle}
+        </Link>
+      </header>
       <Text {...questionProps}>What drew you into design systems?</Text>
       <MemberMarkdown source={member.questionOne} colorName={color} />
       <Text {...questionProps}>Who have you learned from or been inspired by?</Text>

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -20,7 +20,7 @@ const MemberInfo = ({member, colorName}) => {
     <Box width={[1, 1, 1, 1]} id={member.handle}>
       <Heading>{member.name}</Heading>
       <Text sx={{color: 'fg.subtle'}}>{member.title}</Text>
-      {' • '}
+      <Text sx={{color: 'fg.muted'}}>{' • '}</Text>
       <Link sx={{mt: 2, color: color, hoverColor: color, fontSize: 2}} href={`https://github.com/${member.handle}`}>
         @{member.handle}
       </Link>

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -31,7 +31,7 @@ const MemberInfo = ({member, colorName}) => {
   }
 
   return (
-    <Box id={member.handle} mt={5}>
+    <Box mt={5}>
       <Text {...questionProps}>What drew you into design systems?</Text>
       <MemberMarkdown source={member.questionOne} colorName={color} />
       <Text {...questionProps}>Who have you learned from or been inspired by?</Text>

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -9,40 +9,38 @@ const MemberMarkdown = ({source, colorName}) => {
     </Link>
   )
 
+  const paragraph = props => (
+    <Text as="p" fontSize={3} mt={1} mb={3} {...props}>
+      {props.children}
+    </Text>
+  )
+
   const trimmedSource = source.replace(/\n */g, '\n')
-  return <ReactMarkdown className="markdown" children={trimmedSource} components={{a: link}} />
+  return <ReactMarkdown className="markdown" children={trimmedSource} components={{a: link, p: paragraph}} />
 }
 
 const MemberInfo = ({member, colorName}) => {
   const color = colorName === 'orange' ? 'severe.fg' : 'accent.fg'
   return (
-    <Box width={[1, 1, 1, 1]} id={member.handle} mt={5}>
+    <Box id={member.handle} mt={5}>
       <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         What drew you into design systems?
       </Text>
-      <Text fontSize={3} mt={0}>
-        <MemberMarkdown source={member.questionOne} colorName={color} />
-      </Text>
+      <MemberMarkdown source={member.questionOne} colorName={color} />
       <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         Who have you learned from or been inspired by?
       </Text>
-      <Text fontSize={3} mt={0}>
-        <MemberMarkdown source={member.questionTwo} colorName={color} />
-      </Text>
+      <MemberMarkdown source={member.questionTwo} colorName={color} />
       <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         Favorite tools
       </Text>
-      <Text fontSize={3} mt={0}>
-        <MemberMarkdown source={member.favoriteTools} colorName={color} />
-      </Text>
+      <MemberMarkdown source={member.favoriteTools} colorName={color} />
       {member.cssFeature ? (
         <>
           <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
             Favorite CSS feature
           </Text>
-          <Text color={`${colorName}.1`} fontSize={3} mt={0}>
-            <MemberMarkdown source={member.cssFeature} colorName={color} />
-          </Text>
+          <MemberMarkdown source={member.cssFeature} colorName={color} />
         </>
       ) : null}
     </Box>

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -10,7 +10,7 @@ const MemberMarkdown = ({source, colorName}) => {
   )
 
   const paragraph = props => (
-    <Text as="p" fontSize={3} mt={1} mb={3} {...props}>
+    <Text as="p" fontSize={3} mt={0} mb={3} {...props}>
       {props.children}
     </Text>
   )
@@ -21,25 +21,26 @@ const MemberMarkdown = ({source, colorName}) => {
 
 const MemberInfo = ({member, colorName}) => {
   const color = colorName === 'orange' ? 'severe.fg' : 'accent.fg'
+
+  const questionProps = {
+    as: 'p',
+    fontSize: 3,
+    fontWeight: 'bold',
+    mt: 7,
+    mb: 2,
+  }
+
   return (
     <Box id={member.handle} mt={5}>
-      <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
-        What drew you into design systems?
-      </Text>
+      <Text {...questionProps}>What drew you into design systems?</Text>
       <MemberMarkdown source={member.questionOne} colorName={color} />
-      <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
-        Who have you learned from or been inspired by?
-      </Text>
+      <Text {...questionProps}>Who have you learned from or been inspired by?</Text>
       <MemberMarkdown source={member.questionTwo} colorName={color} />
-      <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
-        Favorite tools
-      </Text>
+      <Text {...questionProps}>Favorite tools</Text>
       <MemberMarkdown source={member.favoriteTools} colorName={color} />
       {member.cssFeature ? (
         <>
-          <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
-            Favorite CSS feature
-          </Text>
+          <Text {...questionProps}>Favorite CSS feature</Text>
           <MemberMarkdown source={member.cssFeature} colorName={color} />
         </>
       ) : null}

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -17,40 +17,37 @@ const MemberMarkdown = ({source, colorName}) => {
 const MemberInfo = ({member, colorName}) => {
   const color = colorName === 'orange' ? 'severe.fg' : 'accent.fg'
   return (
-    <Box width={[1, 1, 1, 1 / 2]} id={member.handle}>
-      <Heading sx={{color: color}} fontSize={5} pb={3} lineHeight={1.25}>
-        {member.name}, {member.title}
-      </Heading>
-      <Link
-        sx={{mt: 2, fontFamily: 'mono', color: color, hoverColor: color, fontSize: 2}}
-        href={`https://github.com/${member.handle}`}
-      >
-        <StyledOcticon icon={MarkGithubIcon} size={24} sx={{mr: 3, verticalAlign: 'middle'}} />@{member.handle}
+    <Box width={[1, 1, 1, 1]} id={member.handle}>
+      <Heading>{member.name}</Heading>
+      <Text sx={{color: 'fg.subtle'}}>{member.title}</Text>
+      {' • '}
+      <Link sx={{mt: 2, color: color, hoverColor: color, fontSize: 2}} href={`https://github.com/${member.handle}`}>
+        @{member.handle}
       </Link>
-      <Text fontFamily="mono" color={color} as="div" fontSize={3} mt={7} mb={0}>
+      <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         What drew you into design systems?
       </Text>
-      <Text fontSize={3}>
+      <Text fontSize={3} mt={0}>
         <MemberMarkdown source={member.questionOne} colorName={color} />
       </Text>
-      <Text fontFamily="mono" color={color} as="div" fontSize={3} mt={7} mb={0}>
+      <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         Who have you learned from or been inspired by?
       </Text>
-      <Text fontSize={3}>
+      <Text fontSize={3} mt={0}>
         <MemberMarkdown source={member.questionTwo} colorName={color} />
       </Text>
-      <Text fontFamily="mono" color={color} as="div" fontSize={3} mt={7} mb={0}>
+      <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         Favorite tools
       </Text>
-      <Text fontSize={3}>
+      <Text fontSize={3} mt={0}>
         <MemberMarkdown source={member.favoriteTools} colorName={color} />
       </Text>
       {member.cssFeature ? (
         <>
-          <Text fontFamily="mono" color={color} as="div" fontSize={3} mt={7} mb={0}>
+          <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
             Favorite CSS feature
           </Text>
-          <Text color={`${colorName}.1`} fontSize={3}>
+          <Text color={`${colorName}.1`} fontSize={3} mt={0}>
             <MemberMarkdown source={member.cssFeature} colorName={color} />
           </Text>
         </>

--- a/src/components/member-questions.js
+++ b/src/components/member-questions.js
@@ -18,12 +18,6 @@ const MemberInfo = ({member, colorName}) => {
   const color = colorName === 'orange' ? 'severe.fg' : 'accent.fg'
   return (
     <Box width={[1, 1, 1, 1]} id={member.handle}>
-      <Heading>{member.name}</Heading>
-      <Text sx={{color: 'fg.subtle'}}>{member.title}</Text>
-      <Text sx={{color: 'fg.muted'}}>{' • '}</Text>
-      <Link sx={{mt: 2, color: color, hoverColor: color, fontSize: 2}} href={`https://github.com/${member.handle}`}>
-        @{member.handle}
-      </Link>
       <Text as="p" fontSize={3} fontWeight="bold" mt={7} mb={0}>
         What drew you into design systems?
       </Text>

--- a/src/layouts/minimal-layout.tsx
+++ b/src/layouts/minimal-layout.tsx
@@ -4,13 +4,12 @@ import TableOfContents from '@primer/gatsby-theme-doctocat/src/components/table-
 import {Box, Heading, Text} from '@primer/react'
 import React from 'react'
 import {BaseLayout} from '../components/base-layout'
-import {ComponentPageNav} from '../components/component-page-nav'
 
-export default function ComponentLayout({pageContext, children, path}) {
-  const {title, description, reactId, railsIds, figmaId} = pageContext.frontmatter
+export default function MinimalLayout({pageContext, children, path}) {
+  const {title, description} = pageContext.frontmatter
 
   return (
-    <BaseLayout title={title} description={description}>
+    <BaseLayout showSidebar={false} title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
         <Heading as="h1">{title}</Heading>
         {description ? (
@@ -18,15 +17,6 @@ export default function ComponentLayout({pageContext, children, path}) {
             {description}
           </Text>
         ) : null}
-        <Box sx={{mb: 4}}>
-          <ComponentPageNav
-            basePath={path}
-            includeReact={reactId}
-            includeRails={railsIds}
-            includeFigma={figmaId}
-            current="overview"
-          />
-        </Box>
         <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
           <Box
             sx={{

--- a/src/layouts/minimal-layout.tsx
+++ b/src/layouts/minimal-layout.tsx
@@ -10,77 +10,25 @@ export default function MinimalLayout({pageContext, children, path}) {
 
   return (
     <BaseLayout showSidebar={false} title={title} description={description}>
-      <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
+      <Box sx={{maxWidth: 960, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
         <Heading as="h1">{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
           </Text>
         ) : null}
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{minWidth: 0, flexGrow: 1}}>
           <Box
             sx={{
-              width: 220,
-              flex: '0 0 auto',
-              position: 'sticky',
-              top: HEADER_HEIGHT + 24,
-              maxHeight: `calc(100vh - ${HEADER_HEIGHT}px - 24px)`,
-              display: ['none', null, 'block'],
+              '& > :first-child': {
+                mt: 0,
+              },
+              '& > :last-child': {
+                mb: 0,
+              },
             }}
           >
-            {pageContext.tableOfContents.items ? (
-              <>
-                <Heading
-                  as="h3"
-                  sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}}
-                  id="toc-heading"
-                >
-                  On this page
-                </Heading>
-                <TableOfContents aria-labelledby="toc-heading" items={pageContext.tableOfContents.items} />
-              </>
-            ) : null}
-          </Box>
-          <Box sx={{minWidth: 0, flexGrow: 1}}>
-            {/* Narrow table of contents */}
-            {pageContext.tableOfContents.items ? (
-              <Box
-                sx={{
-                  display: ['block', null, 'none'],
-                  mb: 5,
-                  borderColor: 'border.muted',
-                  bg: 'canvas.subtle',
-                  borderWidth: '1px',
-                  borderStyle: 'solid',
-                  borderRadius: 2,
-                }}
-              >
-                <Box sx={{px: 3, py: 2}}>
-                  <Box
-                    sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
-                  >
-                    <Heading as="h3" sx={{fontSize: 2, fontWeight: 'bold'}} id="toc-heading-narrow">
-                      On this page
-                    </Heading>
-                  </Box>
-                </Box>
-                <Box sx={{borderTop: '1px solid', borderColor: 'border.muted'}}>
-                  <TableOfContents aria-labelledby="toc-heading-narrow" items={pageContext.tableOfContents.items} />
-                </Box>
-              </Box>
-            ) : null}
-            <Box
-              sx={{
-                '& > :first-child': {
-                  mt: 0,
-                },
-                '& > :last-child': {
-                  mb: 0,
-                },
-              }}
-            >
-              {children}
-            </Box>
+            {children}
           </Box>
         </Box>
         <PageFooter editUrl={pageContext.editUrl} contributors={pageContext.contributors} />

--- a/src/layouts/minimal-layout.tsx
+++ b/src/layouts/minimal-layout.tsx
@@ -11,7 +11,7 @@ export default function MinimalLayout({pageContext, children, path}) {
   return (
     <BaseLayout showSidebar={false} title={title} description={description}>
       <Box sx={{maxWidth: 960, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1" sx={{fontSize: 7, mb: 2}}>
+        <Heading as="h1" sx={{fontSize: 7}}>
           {title}
         </Heading>
         {description ? (

--- a/src/layouts/minimal-layout.tsx
+++ b/src/layouts/minimal-layout.tsx
@@ -11,7 +11,9 @@ export default function MinimalLayout({pageContext, children, path}) {
   return (
     <BaseLayout showSidebar={false} title={title} description={description}>
       <Box sx={{maxWidth: 960, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1">{title}</Heading>
+        <Heading as="h1" sx={{fontSize: 7, mb: 2}}>
+          {title}
+        </Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}


### PR DESCRIPTION
`About` page layout and style changes 

Fixes: https://github.com/github/primer/issues/2425

👀 https://primer-b621672794-26441320.drafts.github.io/about


- [x] Swap /about to a full-width layout
- [x] Fix margin underneath the h1
- [x] Remove "About" from the sidebar