### PR TITLE
Component page design updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/prettier-config": "^0.0.6",
     "@primer/component-metadata": "^0.5.1",
-    "@primer/gatsby-theme-doctocat": "^4.4.3",
+    "@primer/gatsby-theme-doctocat": "4.5.1",
     "@primer/octicons-react": "^17.3.0",
     "@primer/react": "35.5.0",
     "@svgr/webpack": "^6.5.1",

--- a/src/layouts/component-layout.tsx
+++ b/src/layouts/component-layout.tsx
@@ -71,7 +71,7 @@ export default function ComponentLayout({pageContext, children, path}) {
                   <Box
                     sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
                   >
-                    <Heading as="h3" sx={{fontSize: 1, fontWeight: 'semibold'}} id="toc-heading-narrow">
+                    <Heading as="h3" sx={{fontSize: 1, fontWeight: 'bold'}} id="toc-heading-narrow">
                       On this page
                     </Heading>
                   </Box>

--- a/src/layouts/component-layout.tsx
+++ b/src/layouts/component-layout.tsx
@@ -14,7 +14,7 @@ export default function ComponentLayout({pageContext, children, path}) {
   return (
     <BaseLayout title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1">{title}</Heading>
+        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
@@ -29,7 +29,7 @@ export default function ComponentLayout({pageContext, children, path}) {
             current="overview"
           />
         </Box>
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
           <Box
             sx={{
               width: 220,
@@ -44,7 +44,7 @@ export default function ComponentLayout({pageContext, children, path}) {
               <>
                 <Heading
                   as="h3"
-                  sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}}
+                  sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}}
                   id="toc-heading"
                 >
                   On this page
@@ -71,7 +71,7 @@ export default function ComponentLayout({pageContext, children, path}) {
                   <Box
                     sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
                   >
-                    <Heading as="h3" sx={{fontSize: 2, fontWeight: 'bold'}} id="toc-heading-narrow">
+                    <Heading as="h3" sx={{fontSize: 1, fontWeight: 'semibold'}} id="toc-heading-narrow">
                       On this page
                     </Heading>
                   </Box>

--- a/src/layouts/figma-component-layout.tsx
+++ b/src/layouts/figma-component-layout.tsx
@@ -81,7 +81,7 @@ export default function FigmaComponentLayout({data}) {
   return (
     <BaseLayout title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1">{title}</Heading>
+        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
@@ -96,7 +96,7 @@ export default function FigmaComponentLayout({data}) {
             current="figma"
           />
         </Box>
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
           <Box
             sx={{
               width: 220,
@@ -107,7 +107,7 @@ export default function FigmaComponentLayout({data}) {
               display: ['none', null, 'block'],
             }}
           >
-            <Heading as="h3" sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
+            <Heading as="h3" sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
               On this page
             </Heading>
             <TableOfContents aria-labelledby="toc-heading" items={tableOfContents.items} />

--- a/src/layouts/forms-layout.tsx
+++ b/src/layouts/forms-layout.tsx
@@ -13,7 +13,7 @@ export default function FormsLayout({pageContext, children, _path}) {
   return (
     <BaseLayout title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1">{title}</Heading>
+        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
@@ -32,7 +32,7 @@ export default function FormsLayout({pageContext, children, _path}) {
             </UnderlineNav.Link>
           </UnderlineNav>
         </Box>
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
           <Box
             sx={{
               width: 220,

--- a/src/layouts/rails-component-layout.tsx
+++ b/src/layouts/rails-component-layout.tsx
@@ -289,7 +289,7 @@ export default function RailsComponentLayout({data}) {
   return (
     <BaseLayout title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1">{title}</Heading>
+        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
@@ -304,7 +304,7 @@ export default function RailsComponentLayout({data}) {
             current="rails"
           />
         </Box>
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
           <Box
             sx={{
               width: 220,
@@ -315,9 +315,9 @@ export default function RailsComponentLayout({data}) {
               display: ['none', null, 'block'],
             }}
           >
-            <Text sx={{display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
+            <Heading as="h3" sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
               On this page
-            </Text>
+            </Heading>
             <TableOfContents aria-labelledby="toc-heading" items={tableOfContents.items} />
           </Box>
           <Box sx={{'flexGrow': 1}}>

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -82,7 +82,7 @@ export default function ReactComponentLayout({data}) {
   return (
     <BaseLayout title={title} description={description}>
       <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1">{title}</Heading>
+        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
         {description ? (
           <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
             {description}
@@ -97,7 +97,7 @@ export default function ReactComponentLayout({data}) {
             current="react"
           />
         </Box>
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: 4}}>
+        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
           <Box
             sx={{
               width: 220,
@@ -108,7 +108,7 @@ export default function ReactComponentLayout({data}) {
               display: ['none', null, 'block'],
             }}
           >
-            <Heading as="h3" sx={{fontSize: 2, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
+            <Heading as="h3" sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
               On this page
             </Heading>
             <TableOfContents aria-labelledby="toc-heading" items={tableOfContents.items} />
@@ -188,7 +188,7 @@ export default function ReactComponentLayout({data}) {
                 <Box
                   sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
                 >
-                  <Heading as="h3" sx={{fontSize: 2, fontWeight: 'bold'}} id="toc-heading-narrow">
+                  <Heading as="h3" sx={{fontSize: 1, fontWeight: 'bold'}} id="toc-heading-narrow">
                     On this page
                   </Heading>
                 </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,10 +1815,10 @@
   resolved "https://registry.npmjs.org/@primer/component-metadata/-/component-metadata-0.5.1.tgz"
   integrity sha512-+3tuJScHWRifOAyMV+cn1I533j+PcprvPXbKnH1W7N+vhaGyaaHTao8Dkyyhxbhklmumcf8XR+Lz6dK1ojDrCg==
 
-"@primer/gatsby-theme-doctocat@^4.4.3":
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.4.3.tgz#5df9d6a31035893502abbaea548c708d3d8f2270"
-  integrity sha512-OdvE6k9F6ZXbYFXpRVKWcCc7SwTQBER1ojcFzVQRUi9SXuEcF8Qzq/OG4ojliM+itvAx1kSyfo3G9yHxVl2xNw==
+"@primer/gatsby-theme-doctocat@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.5.1.tgz#f053733ca0c58981dafb74ae7aeb7f6c0ad9c9cb"
+  integrity sha512-C01078zcfBhwVLKI9URXP1YX+FA1I6TyVEPpwIwXQMAyXJUxsPbvZwKBp01dtkkMwQI4tZ2NthM4zSysTXtc5A==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"


### PR DESCRIPTION
Relates to https://github.com/github/primer/issues/2427

Note: we decided not to change the table of contents link color to blue

Before:
![Screenshot 2023-07-18 at 12 08 03 PM](https://github.com/primer/design/assets/2313998/8a669ed4-b219-4c55-90ec-378d03552aba)

After:
![Screenshot 2023-07-18 at 12 07 35 PM](https://github.com/primer/design/assets/2313998/5b8bae63-3d7a-44a9-a590-085cf69fa4e7)
