### PR TITLE
Fix link to system arguments

### DIFF
--- a/src/components/rails-markdown.tsx
+++ b/src/components/rails-markdown.tsx
@@ -85,7 +85,7 @@ export default function RailsMarkdown({text, parentRailsId}) {
   }
 
   const mustacheViewContext = {
-    link_to_system_arguments_docs: `[System arguments](https://primer.style/view-components/lookbook/system_arguments)`,
+    link_to_system_arguments_docs: `[System arguments](https://primer.style/view-components/lookbook/pages/system_arguments)`,
     link_to_typography_docs: `[Typography](${withPrefix('/foundations/typography')})`,
     link_to_accessibility: `[Accessibility](${withPrefix('/guides/accessibility/accessibility-at-github')})`,
     link_to_octicons: `[Octicons](${withPrefix('/foundations/icons')})`,


### PR DESCRIPTION
The link to Rails system arguments is currently broken. This should fix it.