### PR TITLE
Fix broken links to Forms page in docs

### DIFF
--- a/content/components/checkbox-group.mdx
+++ b/content/components/checkbox-group.mdx
@@ -41,7 +41,7 @@ Use checkbox group to allow users to select multiple items from a list of indivi
 
 **Options:** A list of options represented using [checkboxes](/components/checkbox).
 
-**Validation message:** A message explaining why the selection failed validation. See the [form pattern documentation](../ui-patterns/forms#validation) for more information on form validation patterns.
+**Validation message:** A message explaining why the selection failed validation. See the [form pattern documentation](../ui-patterns/forms/overview#validation) for more information on form validation patterns.
 
 ## Accessibility
 
@@ -50,7 +50,7 @@ Alternative: you can use a [toggle switch](/components/toggle-switch) to immedia
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Form control](/components/form-control)
 - [Checkbox](/components/checkbox)
 - [Radio](/components/radio)

--- a/content/components/checkbox.mdx
+++ b/content/components/checkbox.mdx
@@ -37,12 +37,12 @@ Checkboxes are capable of showing two forms of selection: checked (left) or inde
 
 ### Best practices
 
-- An individual checkbox should not have its own validation message or style. Instead, show a validation message on the [checkbox group](/components/checkbox-group). For more information, see the [Validation Message](../ui-patterns/forms#validation) section in the Forms documentation.
-- An individual checkbox button cannot be marked as required. Instead, make a selection required using the [checkbox group](/components/checkbox-group). For more information, see the [Required field indicator](../ui-patterns/forms/#required-field-indicator) in the Forms documentation.
+- An individual checkbox should not have its own validation message or style. Instead, show a validation message on the [checkbox group](/components/checkbox-group). For more information, see the [Validation Message](../ui-patterns/forms/overview#validation) section in the Forms documentation.
+- An individual checkbox button cannot be marked as required. Instead, make a selection required using the [checkbox group](/components/checkbox-group). For more information, see the [Required field indicator](../ui-patterns/forms/overview#required-field-indicator) in the Forms documentation.
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Form control](/components/form-control)
 - [Checkbox group](/components/checkbox-group)
 - [Radio](/components/radio)

--- a/content/components/radio-group.mdx
+++ b/content/components/radio-group.mdx
@@ -39,7 +39,7 @@ A vertical orientation makes options easier to visually scan. A horizontal orien
 
 **Options:** A list of mutually exclusive options represented using [radio buttons](/components/radio)
 
-**Validation message:** A message explaining why the selection failed validation. See the [form pattern documentation](../ui-patterns/forms#validation) for more information on form validation patterns.
+**Validation message:** A message explaining why the selection failed validation. See the [form pattern documentation](../ui-patterns/forms/overview#validation) for more information on form validation patterns.
 
 ### Best practices
 
@@ -58,7 +58,7 @@ A vertical orientation makes options easier to visually scan. A horizontal orien
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Form control](/components/form-control)
 - [Saving](../ui-patterns/saving)
 - [Radio](/components/radio)

--- a/content/components/radio.mdx
+++ b/content/components/radio.mdx
@@ -30,12 +30,12 @@ Radio buttons have static dimensions and three different states when checked or 
 
 - A radio button may not be used on it's own: it _must_ be rendered in a group of related radio buttons using a [radio group](/components/radio-group).
 - Radio buttons cannot be unchecked, so only use radio buttons when a selection is required
-- An individual radio should not have its own validation message or style. Instead, show a validation message on the [radio group](/components/radio-group). For more information, see the [Validation Message](../ui-patterns/forms#validation) section in the Forms documentation.
-- An individual radio button cannot be marked as required. Instead, make a selection required using the [radio group](/components/radio-group). For more information, see the [Required field indicator](../ui-patterns/forms/#required-field-indicator) in the Forms documentation.
+- An individual radio should not have its own validation message or style. Instead, show a validation message on the [radio group](/components/radio-group). For more information, see the [Validation Message](../ui-patterns/forms/overview#validation) section in the Forms documentation.
+- An individual radio button cannot be marked as required. Instead, make a selection required using the [radio group](/components/radio-group). For more information, see the [Required field indicator](../ui-patterns/forms/overview#required-field-indicator) in the Forms documentation.
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Form control](/components/form-control)
 - [Checkbox](/components/checkbox)
 - [Radio group](/components/radio-group)

--- a/content/components/select.mdx
+++ b/content/components/select.mdx
@@ -36,7 +36,7 @@ Use select to allow users to pick a single option from a dropdown menu of predet
 
 **Valid:** The value passed validation.
 
-For more information about the "valid" and "invalid" states, see the [validation section](https://primer.style/design/ui-patterns/forms#validation) of the form design pattern guidelines.
+For more information about the "valid" and "invalid" states, see the [validation section](../ui-patterns/forms/overview#validation) of the form design pattern guidelines.
 
 ### Best practices
 
@@ -110,7 +110,7 @@ Select options should not be prefixed with emoji, as that disrupts typeahead beh
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Action menu](/components/action-menu)
 - [Autocomplete](/components/autocomplete)
 - [Checkbox group](/components/checkbox-group)

--- a/content/components/text-input-with-tokens.mdx
+++ b/content/components/text-input-with-tokens.mdx
@@ -107,7 +107,7 @@ the input will be populated with it's text value.
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Autocomplete](/components/autocomplete)
 - [Text input](/components/text-input)
 - [Tokens](/components/tokens)

--- a/content/components/text-input.mdx
+++ b/content/components/text-input.mdx
@@ -38,7 +38,7 @@ Use a text input to allow users to input short free-form text. It may also be us
 
 **Valid:** The value passed validation.
 
-For more information about the "valid" and "invalid" states, see the [validation section](https://primer.style/design/ui-patterns/forms#validation) of the form design pattern guidelines.
+For more information about the "valid" and "invalid" states, see the [validation section](../ui-patterns/forms/overview#validation) of the form design pattern guidelines.
 
 ### Best practices
 
@@ -158,6 +158,6 @@ See [text input with tokens](/components/text-input-with-tokens)
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Autocomplete](/components/autocomplete)
 - [Text input with tokens](/components/text-input-with-tokens)

--- a/content/components/textarea.mdx
+++ b/content/components/textarea.mdx
@@ -36,7 +36,7 @@ Use a textarea to allow users to input a long string of free-form text.
 
 **Valid:** The value passed validation.
 
-For more information about the "valid" and "invalid" states, see the [validation section](https://primer.style/design/ui-patterns/forms#validation) of the form design pattern guidelines.
+For more information about the "valid" and "invalid" states, see the [validation section](../ui-patterns/forms/overview#validation) of the form design pattern guidelines.
 
 ### Best practices
 
@@ -106,5 +106,5 @@ You can limit a user's resizing options to:
 
 ## Related links
 
-- [Forms](../ui-patterns/forms)
+- [Forms](../ui-patterns/forms/overview)
 - [Text input](/components/text-input)


### PR DESCRIPTION
Fix broken links to "Forms" page in the documentation.