### PR TITLE
Setting consistent maxWidth across documentation content area

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/prettier-config": "^0.0.6",
     "@primer/component-metadata": "^0.5.1",
-    "@primer/gatsby-theme-doctocat": "^4.6.3",
+    "@primer/gatsby-theme-doctocat": "0.0.0-202371815594",
     "@primer/octicons-react": "^17.3.0",
     "@primer/react": "35.5.0",
     "@svgr/webpack": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/prettier-config": "^0.0.6",
     "@primer/component-metadata": "^0.5.1",
-    "@primer/gatsby-theme-doctocat": "0.0.0-202371815594",
+    "@primer/gatsby-theme-doctocat": "^4.7.0",
     "@primer/octicons-react": "^17.3.0",
     "@primer/react": "35.5.0",
     "@svgr/webpack": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,9 +1591,10 @@
   version "0.5.1"
   resolved "https://registry.npmjs.org/@primer/component-metadata/-/component-metadata-0.5.1.tgz"
 
-"@primer/gatsby-theme-doctocat@^4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.6.3.tgz#82fc1a30fcae5c5390ad66a15b9308af15f7e9e7"
+"@primer/gatsby-theme-doctocat@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.7.0.tgz#7b8b763e783ede78cf629a552b8681096e413013"
+  integrity sha512-i7DkLfVsMIZqs0gqj/R5dQ0KEREuKVNzQ2qBxqwCWGz5aQox3QyMT+YAKpQjVu/YQKb17G12csg0rVhR81X/bg==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"


### PR DESCRIPTION
Let's set a consistent maxWidth across documentation content so that the widths don't jump when browsing across the site

### Before/After

**Before: component pages are more narrow than UI patterns pages 👇**

<img width="1507" alt="Screenshot 2023-08-18 at 12 10 30 PM" src="https://github.com/primer/design/assets/586552/45dc75ee-4939-484b-8efd-06944ecd7b39">


<img width="1508" alt="Screenshot 2023-08-18 at 12 10 24 PM" src="https://github.com/primer/design/assets/586552/748f8c32-60b5-42f1-a8c9-097eecf89920">

----------

**After: consistent maxWidth across pages**
<img width="1505" alt="Screenshot 2023-08-18 at 12 13 22 PM" src="https://github.com/primer/design/assets/586552/25969d48-06dc-45fb-952d-c6c9f8dbc9ad">

<img width="1508" alt="Screenshot 2023-08-18 at 12 13 05 PM" src="https://github.com/primer/design/assets/586552/841c0756-10ba-452f-a1dd-bb445a2950f5">



### Dependencies:
https://github.com/primer/doctocat/pull/623
