### PR TITLE
Fix for breadcrumbs links

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@github/prettier-config": "^0.0.6",
     "@primer/component-metadata": "^0.5.1",
-    "@primer/gatsby-theme-doctocat": "^4.7.0",
+    "@primer/gatsby-theme-doctocat": "0.0.0-202372416622",
     "@primer/octicons-react": "^17.3.0",
     "@primer/react": "35.5.0",
     "@svgr/webpack": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "gatsby develop",
     "clean": "gatsby clean",
     "build": "gatsby build --prefix-paths",
+    "serve": "gatsby serve --prefix-paths",
     "build:preview": "gatsby build",
     "now-build": "yarn build",
     "lint": "eslint .",
@@ -14,7 +15,7 @@
   "dependencies": {
     "@github/prettier-config": "^0.0.6",
     "@primer/component-metadata": "^0.5.1",
-    "@primer/gatsby-theme-doctocat": "0.0.0-202372416622",
+    "@primer/gatsby-theme-doctocat": "^4.7.1",
     "@primer/octicons-react": "^17.3.0",
     "@primer/react": "35.5.0",
     "@svgr/webpack": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,10 +1591,10 @@
   version "0.5.1"
   resolved "https://registry.npmjs.org/@primer/component-metadata/-/component-metadata-0.5.1.tgz"
 
-"@primer/gatsby-theme-doctocat@^4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.7.0.tgz#7b8b763e783ede78cf629a552b8681096e413013"
-  integrity sha512-i7DkLfVsMIZqs0gqj/R5dQ0KEREuKVNzQ2qBxqwCWGz5aQox3QyMT+YAKpQjVu/YQKb17G12csg0rVhR81X/bg==
+"@primer/gatsby-theme-doctocat@0.0.0-202372416622":
+  version "0.0.0-202372416622"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.0.0-202372416622.tgz#28c568c17de819ce8fe2f462dd19e2633d315859"
+  integrity sha512-k0npib4UEKpFBP6eRwyOQNT5dCjYP5mdO6eLzJeOAM91dcoZ6WGHm23WFxANebMA3foXKCUoBdUT8d1VNgHSRw==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,10 +1591,10 @@
   version "0.5.1"
   resolved "https://registry.npmjs.org/@primer/component-metadata/-/component-metadata-0.5.1.tgz"
 
-"@primer/gatsby-theme-doctocat@0.0.0-202372416622":
-  version "0.0.0-202372416622"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.0.0-202372416622.tgz#28c568c17de819ce8fe2f462dd19e2633d315859"
-  integrity sha512-k0npib4UEKpFBP6eRwyOQNT5dCjYP5mdO6eLzJeOAM91dcoZ6WGHm23WFxANebMA3foXKCUoBdUT8d1VNgHSRw==
+"@primer/gatsby-theme-doctocat@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.7.1.tgz#7b32f899d021e90608d4c7b591f5e6d88331005e"
+  integrity sha512-HECstW9d48noHcIK2KmLKJdP8msK7qC7xh1EZwDWPuvoAk1v6ZCnP74NnB5OKQeBAKZatwSNo7mDtAGMDDakqA==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"


### PR DESCRIPTION
Breadcrumbs in primer.style/design are broken right now because the URL is pointing to primer.style instead of the full primer.style/design URL. 

To test:
1. visit URL: https://primer.style/design/native/cli/getting-started
2. click on the middle path in the breadcrumb (CLI)
3. note the URL it takes you to, it will 404. 