### PR TITLE
Update header image in the button docs

### DIFF
--- a/content/components/button.mdx
+++ b/content/components/button.mdx
@@ -17,7 +17,7 @@ export default ComponentLayout
 <img
   width="960"
   alt="Image displaying each variation of button, from left: Secondary, Primary, Danger, Invisible."
-  src="https://user-images.githubusercontent.com/586552/217628240-8ff527d5-8cac-4b3d-b7ac-8fd3b36ffd64.png"
+  src="https://github.com/primer/design/assets/980622/8a02c179-61d1-48a6-8dd8-7a0ccdfecef7"
 />
 
 ## Usage


### PR DESCRIPTION
Some time back, @asiermartinez contacted us to inform us about an error in the documentation regarding the `invisible` button variant display. Although I had noted this task for later, I felt that this week provided the ideal opportunity to address this minor issue.

The header image now displays the invisible button with blue text instead of foreground text.