### PR TITLE
Fix markdown linter

### DIFF
--- a/content/guides/development/rails/index.mdx
+++ b/content/guides/development/rails/index.mdx
@@ -23,7 +23,7 @@ require "view_component"
 require "primer/view_components/engine"
 ```
 
-##### CSS
+### CSS
 
 Load CSS as a JS module into the pipeline. Update `app/assets/config/manifest.js` with:
 
@@ -32,11 +32,12 @@ Load CSS as a JS module into the pipeline. Update `app/assets/config/manifest.js
 ```
 
 Add it in your `application.html.erb` in the `<head>` tag:
+
 ```erb
 <%= stylesheet_link_tag("primer_view_components") %>
 ```
 
-##### JS
+### JS
 
 Optionally, to add the JavaScript behaviours, in your `application.html.erb` in the `<head>` tag add:
 


### PR DESCRIPTION
My [latest PR](https://github.com/primer/design/pull/588) has markdown linter issues.
So I fixed them here.
However there is a slight change in headers appearance

BEFORE

<img width="900" alt="Screenshot 2023-09-12 at 19 52 15" src="https://github.com/primer/design/assets/14095146/1d8e8723-b7c8-4716-8ac7-a4d41aa058ab">

AFTER

<img width="899" alt="Screenshot 2023-09-12 at 19 52 58" src="https://github.com/primer/design/assets/14095146/0498a460-54c6-4687-8bf5-20f368b2d37e">
