### PR TITLE
Only show highest-ranking status for Rails components on status page

### DIFF
--- a/src/components/status.js
+++ b/src/components/status.js
@@ -5,6 +5,7 @@ import React from 'react'
 import styled from 'styled-components'
 import StatusRows from './status-rows'
 import { useRails } from './rails-provider'
+import { compareStatuses } from '../rails-status'
 
 const Table = styled.table`
   width: 100%;
@@ -201,7 +202,7 @@ async function getComponents(railsActions, railsData) {
     viewComponent: {
       url: '',
       data: (() => {
-        const vcs = []
+        const vcs = {}
 
         railsData.allRailsComponent.nodes.forEach(vc => {
           const componentInfo = railsActions.getRailsComponentInfo(vc.railsId)
@@ -211,18 +212,21 @@ async function getComponents(railsActions, railsData) {
               componentInfo.page.context.frontmatter.reactId ||
                 vc.railsId.split('::').slice(-1)[0]
 
-            vcs.push({
-              id: id,
-              displayName: vc.name,
-              description: vc.description,
-              path: componentInfo.urlPath,
-              status: vc.status,
-              a11yReviewed: vc.a11y_reviewed
-            })
+            // only replace entry if status is greater
+            if (!vcs[id] || compareStatuses(vc.status, vcs[id].status) > 0) {
+              vcs[id] = {
+                id: id,
+                displayName: vc.name,
+                description: vc.description,
+                path: componentInfo.urlPath,
+                status: vc.status,
+                a11yReviewed: vc.a11y_reviewed
+              }
+            }
           }
         })
 
-        return vcs
+        return Object.values(vcs)
       })(),
     },
   }

--- a/src/rails-status.js
+++ b/src/rails-status.js
@@ -21,3 +21,16 @@ export const latestStatusFrom = (statuses) => {
 
   return latestStatus
 }
+
+export const compareStatuses = (first, second) => {
+  const firstRank = statusOrder.indexOf(first)
+  const secondRank = statusOrder.indexOf(second)
+
+  if (firstRank > secondRank) {
+    return 1
+  } else if (firstRank < secondRank) {
+    return -1
+  } else {
+    return 0
+  }
+}


### PR DESCRIPTION
At the moment the component status page says the Rails `Button` component has been deprecated 😱 Obviously that's not true! The problem is that we have multiple versions of `Button`. The deprecated one is taking precedence when it shouldn't.