### PR TITLE
Replace broken link with the working one

### DIFF
--- a/content/guides/development/rails/index.mdx
+++ b/content/guides/development/rails/index.mdx
@@ -67,7 +67,7 @@ Render Primer ViewComponents in Rails templates:
 
 ## Dependencies
 
-In addition to the dependencies declared in the `gemspec`, Primer ViewComponents assumes the presence of [Primer CSS](https://primer.style/css/getting-started).
+In addition to the dependencies declared in the `gemspec`, Primer ViewComponents assumes the presence of [Primer CSS](https://primer.style/css/storybook/?path=/docs/gettingstarted--docs).
 
 ## Migration and upgrade guides
 

--- a/content/guides/development/rails/index.mdx
+++ b/content/guides/development/rails/index.mdx
@@ -67,7 +67,7 @@ Render Primer ViewComponents in Rails templates:
 
 ## Dependencies
 
-In addition to the dependencies declared in the `gemspec`, Primer ViewComponents assumes the presence of [Primer CSS](https://primer.style/css/storybook/?path=/docs/gettingstarted--docs).
+In addition to the dependencies declared in the `gemspec`, Primer ViewComponents assumes the presence of [Primer CSS](https://primer.style/css).
 
 ## Migration and upgrade guides
 


### PR DESCRIPTION
Current link leads to a 404 page.
<img width="1312" alt="Screenshot 2023-09-18 at 00 28 28" src="https://github.com/primer/design/assets/14095146/22784f11-82f7-4974-a20a-4e869eaa9f5c">

So, I replaced it with the working one
<img width="1305" alt="Screenshot 2023-09-18 at 00 28 42" src="https://github.com/primer/design/assets/14095146/fa9616eb-f406-48e7-9b97-8793803a4752">

