### PR TITLE
Fix 'require' in Rails setup docs

### DIFF
--- a/content/guides/development/rails/index.mdx
+++ b/content/guides/development/rails/index.mdx
@@ -20,7 +20,7 @@ In `config/application.rb`, add **after the application definition**:
 
 ```ruby
 require "view_component"
-require "primer/view_components/engine"
+require "primer/view_components"
 ```
 
 ### CSS


### PR DESCRIPTION
Apps should require `primer/view_components` instead of `primer/view_components/engine`.