### PR TITLE
Add `Primer::Beta::NavList` as a valid railsId

### DIFF
--- a/content/components/nav-list.mdx
+++ b/content/components/nav-list.mdx
@@ -4,6 +4,7 @@ description: Nav list renders a vertical list of navigation links.
 reactId: nav_list
 railsIds:
 - Primer::Alpha::NavList
+- Primer::Beta::NavList
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/src/components/rails-provider.tsx
+++ b/src/components/rails-provider.tsx
@@ -106,8 +106,7 @@ export const RailsProvider = ({children}) => {
     const parentComponent = findParentComponentForRailsId(railsId, data.allRailsComponent.nodes)
 
     // No parent component means the component isn't a top-level component or a subcomponent of a
-    // top-level component, i.e. it's not documented in this system at all; return the ID
-    // instead of a link.
+    // top-level component, i.e. it's not documented in this system at all; return null.
     if (!parentComponent) return null
 
     // We're dealing with a top-level component, so link to the parent.


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/2675

We recently graduated `NavList` to beta, and therefore need to add `Primer::Beta::NavList` as a valid railsId for the nav list docs.