### PR TITLE
fix: point to the web archive version of article

### DIFF
--- a/content/guides/accessibility/accessibility-at-github.mdx
+++ b/content/guides/accessibility/accessibility-at-github.mdx
@@ -41,7 +41,7 @@ Each disability category can be further divided into three sub-categories:
 - **Situational:** The environment someone is in plays a huge factor in how they interact with web content.
   - Example: Someone who is at a loud sporting event
 
-For an informative list on real-life disability situations, check [An Alphabet of Accessibility Issues](https://the-pastry-box-project.net/anne-gibson/2014-july-31), published by The Pastry Box Project.
+For an informative list on real-life disability situations, check [An Alphabet of Accessibility Issues](https://web.archive.org/web/20230307004829/https://the-pastry-box-project.net/anne-gibson/2014-july-31), published by The Pastry Box Project.
 
 Microsoft has created a downloadable PDF that looks into the area of inclusive design from a people perspective, with several informative examples. Navigate to the ‘Inclusive 101’ toolkit on the main page of [Microsoft’s Inclusive Design website](https://www.microsoft.com/design/inclusive/).
 

--- a/content/guides/accessibility/guidelines.mdx
+++ b/content/guides/accessibility/guidelines.mdx
@@ -13,7 +13,7 @@ Accessible experiences start with designers. Tacking on accessibility after a de
 
 When we consider accessibility from the beginning, we design for everyone from the start.
 
-Consider how different people will experience your design. For an informative list on real-life disability situations, check [An Alphabet of Accessibility Issues](https://the-pastry-box-project.net/anne-gibson/2014-july-31), published in The Pastry Box Project.
+Consider how different people will experience your design. For an informative list on real-life disability situations, check [An Alphabet of Accessibility Issues](https://web.archive.org/web/20230307004829/https://the-pastry-box-project.net/anne-gibson/2014-july-31), published in The Pastry Box Project.
 
 ## Feature checklist
 


### PR DESCRIPTION
## Summary

Closes https://github.com/primer/design/issues/614

This updates the reference to `An Alphabet of Accessibility Issues` to the Internet Archive's last available, known, and rendered version, since the original website is no longer reachable.