### PR TITLE
Correct anatomy diagrams

### DIFF
--- a/content/components/text-input.mdx
+++ b/content/components/text-input.mdx
@@ -52,7 +52,7 @@ For more information about the "valid" and "invalid" states, see the [validation
 <img
   width="960"
   role="presentation"
-  src="https://user-images.githubusercontent.com/2313998/224447079-f95c75d2-5a3a-4175-bf9f-8725ad127a08.png"
+  src="https://user-images.githubusercontent.com/6905903/274238980-22a35352-95c7-49bb-8b35-3c8741426b89.png"
 />
 
 **Label (required):** The input's title. It should be as concise as possible and convey the purpose of the input. The label may be visually hidden in rare cases, but a label must be defined for assistive technologies such as a screen reader.

--- a/content/components/textarea.mdx
+++ b/content/components/textarea.mdx
@@ -46,7 +46,7 @@ For more information about the "valid" and "invalid" states, see the [validation
 <img
   width="960"
   role="presentation"
-  src="https://user-images.githubusercontent.com/2313998/226424286-6cf3c07b-140c-4e86-bfeb-5857509a12c0.png"
+  src="https://user-images.githubusercontent.com/6905903/274239156-064abae9-6d16-4c1a-b673-ec8f96429ed9.png"
 />
 
 **Label (required):** The input's title. It should be as concise as possible and convey the purpose of the input. The label may be visually hidden in rare cases, but a label must be defined for assistive technologies such as a screen reader.


### PR DESCRIPTION
Updates anatomy diagrams for text input and textarea components, where "validation" and "caption" annotations were reversed.

I've also updated the diagrams in Figma.
 
Closes https://github.com/primer/design/issues/515