### PR TITLE
Adds examples for button loading state

### DIFF
--- a/content/ui-patterns/loading.mdx
+++ b/content/ui-patterns/loading.mdx
@@ -369,24 +369,26 @@ However, the button that initiates the a loading process may not be semantically
 {/*<!-- _TODO: Consider moving most of the button loading state details to the [Button interface guidelines](/components/button)_ -->*/}
 </>
 
-<Box display="flex" flexDirection={['column', 'column', 'column', 'column', 'row']} sx={{alignItems: 'start', gap: 3}}>
+<img
+  width="960"
+  alt="A button in a loading state with a11y annotations"
+  src="https://github.com/primer/design/assets/2313998/f5d20468-9c9c-4b85-8111-a26373e7c88b"
+/>
+
+<Box display="flex" flexDirection={['column', 'column', 'column', 'column', 'row']} sx={{alignItems: 'start', gap: 3, marginTop: 3}}>
 
 <Box flex={1}>
 
 When implementing a "loading" button state, don't remove the button from the DOM or pass the `disabled` attribute. Doing so would make it impossible to tab to the button. If the button was just focused and activated, it would reset focus. Resetting focus would disrupt the keyboard navigation flow, and creates a confusing experience for assistive technologies such as screen readers.
 
-</Box>
-
-<img
-  width="456"
-  alt="A button in a loading state with a11y annotations"
-  src="replace-me-with-real-src"
-/>
-</Box>
-
 Once the button is activated (and is in a loading state), it becomes `aria-disabled` and receives `aria-describedby` that indicates that it's processing and may take a while. 
 
 A separate, visually hidden element should be rendered outside of the `<button>` with a message to communicate the loading status. For example, "Saving profile".
+
+</Box>
+
+<CustomVideoPlayer loop autoplay width="456" src="https://github.com/primer/design/assets/2313998/ffaff3c9-5428-4d67-95e5-693a5f8880a4" />
+</Box>
 
 The visually hidden status message element receives `aria-live="polite"` and `aria-busy="true"` attributes.
 


### PR DESCRIPTION
### Before
![Screenshot 2023-10-12 at 10 37 11 AM](https://github.com/primer/design/assets/2313998/b4e5be77-8bb1-4ae0-a3e0-83dbb0e83e88)

### After
![Screenshot 2023-10-12 at 10 36 24 AM](https://github.com/primer/design/assets/2313998/636c23f0-4a56-4a5a-acb5-c247fb55c32d)

