### PR TITLE
Fix broken link to Subhead (Rails beta) component

### DIFF
--- a/content/components/pagehead.mdx
+++ b/content/components/pagehead.mdx
@@ -22,7 +22,7 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ## Usage
 
-Pagehead is a heading component for the title and start of a given page section. The same component in our Rails framework is called [subhead](/component/pagehead/rails/beta). 
+Pagehead is a heading component for the title and start of a given page section. The same component in our Rails framework is called [subhead](/components/subhead/rails/beta). 
 
 ### Options
 


### PR DESCRIPTION
Noticed this link is currently broken on https://primer.style/design/components/pagehead