### PR TITLE
Fix link in action-menu docs

### DIFF
--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -158,7 +158,7 @@ The focus should always remain on menu items, and therefore the menu shouldn't i
       src="https://user-images.githubusercontent.com/980622/234083619-40ebf8b6-6194-4e66-a7e8-597ee43f9ed8.png"
     />
     <Caption>
-      Don't add form controls like a filterable input, use [select panel](/components/selectpanel) instead.
+      Don't add form controls like a filterable input, use <Link href="/components/selectpanel">select panel</Link> instead.
     </Caption>
   </Dont>
 </DoDontContainer>


### PR DESCRIPTION
Link was broken here https://primer.style/design/components/action-menu#avoid-input-controls.

I used a Link component instead of markdown link []() because it looks like it's not able to put a link inside a Caption component this way.