### PR TITLE
Only publish Rails docs for the current release

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -196,7 +196,7 @@ async function sourcePrimerRailsData({actions, createNodeId, createContentDigest
   actions.createNode(newNode)
 
   // Save the PVC data to the GraphQL store
-  const url = `https://api.github.com/repos/primer/view_components/contents/static/info_arch.json?ref=main`
+  const url = `https://api.github.com/repos/primer/view_components/contents/static/info_arch.json?ref=v${version}`
   const argsJson = await fetch(url).then(res => res.json())
 
   const argsContent = JSON.parse(Buffer.from(argsJson.content, 'base64').toString())


### PR DESCRIPTION
We've accidentally been publishing Rails docs for `main` for a long time and it got us in trouble yesterday. This PR ensures docs are only published for the current release.