### PR TITLE
Remove marketing button page

### DIFF
--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -165,8 +165,6 @@
       url: /components/button
     - title: Button group
       url: /components/button-group
-    - title: Button marketing
-      url: /components/button-marketing
     - title: Checkbox
       url: /components/checkbox
     - title: Checkbox group


### PR DESCRIPTION
Removing the marketing button page since that now lives in primer.style/brand.