### PR TITLE
Update guidance on icon colors for the ActionMenu items

### DIFF
--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -253,6 +253,27 @@ Especially when providing single or multi select items that rely on a crossmark 
   </Dont>
 </DoDontContainer>
 
+In order to maintain a consistent apperance, avoid using colored icons as a leading visual. Colored icons should be reserved for destructive actions.   
+
+<DoDontContainer>
+  <Do>
+    <img 
+      width="464" 
+      alt="Do" 
+      src="https://user-images.githubusercontent.com/1295166/277831671-5b063a9e-06cd-4585-a0dc-0883a67e2deb.png"
+    />
+    <Caption>Avoid using colored icons for standard menu items. This makes desctructive actions stand out.</Caption>
+  </Do>
+  <Dont>
+    <img 
+      width="464" 
+      alt="Dont" 
+      src="https://user-images.githubusercontent.com/1295166/277831673-8247c140-e819-4593-adf6-db5c8444fa78.png"
+    />
+    <Caption>When multiple colored icons are used, the meaning behind each color becomes diluted.</Caption>
+  </Dont>
+</DoDontContainer>
+
 ### Dividers
 
 To enhance the readability of menus that contain numerous item descriptions, it is recommended to incorporate dividers. This can effectively prevent the menu from becoming overwhelming.


### PR DESCRIPTION
There's some ambiguity about whether or not we should recommend different colors for leading icons in the ActionMenu.   

This PR updates the guidance to recommend against using colored icons for anything other than destructive actions. 

<img width="886" alt="CleanShot 2023-10-24 at 16 51 30@2x" src="https://github.com/primer/design/assets/1295166/092d5aa7-8805-45f3-b2f1-ecdcd8b306c4">
