### PR TITLE
Add docs for the ClipboardCopyButton

### DIFF
--- a/content/components/clipboard-copy-button.mdx
+++ b/content/components/clipboard-copy-button.mdx
@@ -1,0 +1,23 @@
+---
+title: ClipboardCopyButton
+description: The `ClipboardCopy` component styled as a Primer button.
+railsIds:
+- Primer::Beta::ClipboardCopyButton
+---
+
+import ComponentLayout from '~/src/layouts/component-layout'
+import {Link, Text} from '@primer/react'
+import {Link as GatsbyLink} from 'gatsby'
+export default ComponentLayout
+import {AccessibilityLink} from '~/src/components/accessibility-link'
+
+<Note variant="warning">
+  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
+  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
+</Note>
+
+## Accessibility
+
+### Known accessibility issues (GitHub staff only)
+
+ <AccessibilityLink label="ClipboardCopyButton"/>


### PR DESCRIPTION
The `ClipboardCopyButton` component was [recently merged](https://github.com/primer/view_components/pull/2335) into PVC. Since there is no React analog, and because it's confusing for there to be `ClipboardCopy` and `ClipboardCopyButton` components, I have chosen to not expose it in the nav. Instead, I'm going to submit a PR to link it from `ClipboardCopy`.