### PR TITLE
Removes guidance about optional dialog on inactive ActionList items

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -213,8 +213,6 @@ If there's *not* a leading visual, use an alert icon as the leading visual.
 
 It's required to show a tooltip with context about why the item is inactive. It should be triggered by the leading visual.
 
-Optionally, you may open a dialog when the user clicks the leading visual to show more detailed information about why the item is inactive.
-
 See the [accessibility](#accessibility) section for information on the assistive technology user experience.
 
 </Box>


### PR DESCRIPTION
I think it's safe to start without the option to show a dialog with longer/more detailed information than we can fit in a tooltip or underneath the ActionList.Item description text.

Supporting this functionality is non-trivial, and could always be added later.