### PR TITLE
Remove status from figma section

### DIFF
--- a/src/layouts/figma-component-layout.tsx
+++ b/src/layouts/figma-component-layout.tsx
@@ -1,4 +1,4 @@
-import {Note, StatusLabel} from '@primer/gatsby-theme-doctocat'
+import {Note} from '@primer/gatsby-theme-doctocat'
 import {HEADER_HEIGHT} from '@primer/gatsby-theme-doctocat/src/components/header'
 import {Box, Heading, Label, Link, Text} from '@primer/react'
 import FigmaLink from '@primer/gatsby-theme-doctocat/src/components/figma-link'
@@ -33,7 +33,6 @@ export const query = graphql`
     figmaComponent(figmaId: {eq: $figmaId}, status: {ne: "DEPRECATED"}) {
       name
       figmaId
-      status
       updatedAt
       componentUrl: url
       thumbnails {
@@ -67,7 +66,7 @@ const lastUpdated = date => {
 }
 
 export default function FigmaComponentLayout({data}) {
-  const {name, componentUrl, status, updatedAt, properties, thumbnails} = data.figmaComponent || {}
+  const {name, componentUrl, updatedAt, properties, thumbnails} = data.figmaComponent || {}
   const description = data.sitePage?.context.frontmatter.description || ''
   const title = data.sitePage?.context.frontmatter.title || name
 
@@ -152,9 +151,6 @@ export default function FigmaComponentLayout({data}) {
                   >
                     <li>
                       <Label size="large">{lastUpdated(updatedAt)}</Label>
-                    </li>
-                    <li>
-                      <StatusLabel status={sentenceCase(status)} />
                     </li>
                   </Box>
                   <Box


### PR DESCRIPTION
## Change
This PR removes the status label from the figma docs page

Before | After
--- | ---
<img width="577" alt="Screenshot 2023-11-08 at 11 22 31" src="https://github.com/primer/design/assets/813754/35a9d3be-418a-4a54-a255-c02615ef5c4d"> | <img width="580" alt="Screenshot 2023-11-08 at 11 29 32" src="https://github.com/primer/design/assets/813754/761bed92-a3de-4caa-a43c-8577b3b32f9b">



## Reasoning
We don't really have a lifecycle for Figma components. Once they are added to Figma they are `stable` in regards to Figma. They may not be stable in other implementations, but this has no direct impact on Figma. 

For this reason, having a `stable` label may be confusing for users and does not really bring any benefit.