### PR TITLE
Refactor status order

### DIFF
--- a/src/rails-status.js
+++ b/src/rails-status.js
@@ -14,19 +14,10 @@ const statusOrder = [
  * @returns {string | null} latest status if valid, `null` otherwise
  */
 export const latestStatusFrom = (statuses) => {
-  let highestRank = -1
-  let latestStatus = null
-
-  for (const status of statuses) {
-    const rank = statusOrder.indexOf(status)
-
-    if (rank > highestRank) {
-      highestRank = rank
-      latestStatus = status
-    }
-  }
-
-  return latestStatus
+  return statuses
+      .filter(status => statusOrder.includes(status))
+      .sort(compareStatuses)
+      .at(-1) ?? null
 }
 
 /**


### PR DESCRIPTION
### What?

Refactor `latestStatusFrom` function, so it leverages the existing `compareStatuses` function.

### Why?

Code reuse and simplification: there is now one source of truth for comparing statuses. Follow-up on #679 

Tested by running the following manual tests:

```js
console.assert(latestStatusFrom(['alpha', 'stable']) === 'stable')
console.assert(latestStatusFrom(['stable', 'alpha']) === 'stable')
console.assert(latestStatusFrom(['nope', 'invalid']) === null)
```

Note that v18 of Node and later [come bundled with a test runner](https://nodejs.org/api/test.html). See #681 for upgrade.