### PR TITLE
Add information about loading ActionList items

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -207,13 +207,34 @@ Action list items can be selected. Single selections are represented with a [`ch
 
 Inactive action list item text still needs to meet an accessible color contrast ratio.
 
+It's required to show a tooltip with context about why the item is inactive. It should be triggered by the alert icon in the leading visual or trailing visual.
+
 If there's a leading visual, replace it with an alert icon.
 
-If there's *not* a leading visual, use an alert icon as the leading visual.
-
-It's required to show a tooltip with context about why the item is inactive. It should be triggered by the leading visual.
+If there's *not* a leading visual, the alert icon is put in the same position as the trailing visual.
 
 See the [accessibility](#accessibility) section for information on the assistive technology user experience.
+
+</Box>
+
+<Box justifyContent="center">
+    <img
+        width="464"
+        alt="An action list with the first item in a loading state"
+        src="https://github.com/primer/design/assets/2313998/8811ddfa-1874-4a1d-a3ce-af39dd23bc62"
+    />
+</Box>
+<Box sx={{h3: {marginTop: 0}}}>
+
+### Loading items
+
+If an action list item is not yet interactive because the required data is still loading, it may be rendered in a loading state.
+
+The position of the loading icon depends on the same logic as where the alert icon goes in inactive items:
+
+If there's a leading visual, replace it with a loading indicator.
+
+If there's *not* a leading visual, the loading indicator is put in the same position as the trailing visual.
 
 </Box>
 


### PR DESCRIPTION
These changes add guidelines for ActionList items in a loading state, and also corrects some typos in the inactive item guidelines.

<img width="899" alt="Screenshot 2023-12-18 at 12 24 33 PM" src="https://github.com/primer/design/assets/2313998/8d19c7c9-ccba-48fe-84ce-e0cfa75ae017">
