### PR TITLE
Add additional accessibility documentation for `Dialog` and live region usage

### DIFF
--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -438,6 +438,12 @@ When a dialog is opened, the first interactive element (typically the close butt
 />
 <Caption>When a dialog is closed, focus is returned to the trigger button.</Caption>
 
+### Live region usage
+Use extra caution when utilizing a live region that exists outside of the `<Dialog>` component. 
+This is because some browser and screen reader combinations will ignore the live region entirely if it does not exist within the dialog itself.
+
+If you need to use a live region whilst the dialog is active, place the live region within the dialog, rather than outside of it.
+
 ### Known accessibility issues (GitHub staff only)
 
  <AccessibilityLink label="Dialog"/>

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -442,7 +442,7 @@ When a dialog is opened, the first interactive element (typically the close butt
 Use extra caution when utilizing a live region that exists outside of the `<Dialog>` component. 
 This is because some browser and screen reader combinations will ignore the live region entirely if it does not exist within the dialog itself.
 
-If you need to use a live region whilst the dialog is active, place the live region within the dialog, rather than outside of it.
+If you need to use a live region while a dialog is active, place the live region within the dialog, rather than outside of it.
 
 ### Known accessibility issues (GitHub staff only)
 

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -440,7 +440,7 @@ When a dialog is opened, the first interactive element (typically the close butt
 
 ### Live region usage
 Use extra caution when utilizing a live region that exists outside of the `<Dialog>` component. 
-This is because some browser and screen reader combinations will ignore the live region entirely if it does not exist within the dialog itself.
+This is because some browser and screen reader combinations may ignore the live region entirely if it does not already exist within the dialog.
 
 If you need to use a live region while a dialog is active, place the live region within the dialog, rather than outside of it.
 


### PR DESCRIPTION
This PR adds a note in our documentation on live region usage and the `Dialog` component. This mainly stems from the following issue regarding `Dialog`: https://github.com/github/accessibility-audits/issues/7126