### PR TITLE
Make redirects more foolproof

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -460,6 +460,7 @@ async function createComponentPages({actions, graphql}) {
   const railsComponentLayout = path.resolve(__dirname, 'src/layouts/rails-component-layout.tsx')
   const figmaComponentLayout = path.resolve(__dirname, 'src/layouts/figma-component-layout.tsx')
   const cssComponentLayout = path.resolve(__dirname, 'src/layouts/css-component-layout.tsx')
+  const redirectLayout = path.resolve(__dirname, 'src/layouts/redirect-layout.tsx')
 
   for (const {slug, frontmatter} of data.allMdx.nodes) {
     if (frontmatter.reactId) {
@@ -481,11 +482,12 @@ async function createComponentPages({actions, graphql}) {
         }
       }
 
-      actions.createRedirect({
-        fromPath: `/${slug}/react/latest`,
-        toPath: `/${slug}/react/${latestStatusFrom(statuses)}`,
-        redirectInBrowser: true,
-        force: true,
+      actions.createPage({
+        path: `/${slug}/react/latest`,
+        component: redirectLayout,
+        context: {
+          location: `/${slug}/react/${latestStatusFrom(statuses)}`
+        }
       })
     }
 
@@ -514,11 +516,12 @@ async function createComponentPages({actions, graphql}) {
         })
       })
 
-      actions.createRedirect({
-        fromPath: `/${slug}/rails/latest`,
-        toPath: `/${slug}/rails/${latestStatusFrom(statuses)}`,
-        redirectInBrowser: true,
-        force: true,
+      actions.createPage({
+        path: `/${slug}/rails/latest`,
+        component: redirectLayout,
+        context: {
+          location: `/${slug}/rails/${latestStatusFrom(statuses)}`
+        }
       })
     }
 

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -489,6 +489,14 @@ async function createComponentPages({actions, graphql}) {
           location: `/${slug}/react/${latestStatusFrom(statuses)}`
         }
       })
+
+      actions.createPage({
+        path: `/${slug}/react`,
+        component: redirectLayout,
+        context: {
+          location: `/${slug}/react/${latestStatusFrom(statuses)}`
+        }
+      })
     }
 
     if (frontmatter.railsIds) {
@@ -518,6 +526,14 @@ async function createComponentPages({actions, graphql}) {
 
       actions.createPage({
         path: `/${slug}/rails/latest`,
+        component: redirectLayout,
+        context: {
+          location: `/${slug}/rails/${latestStatusFrom(statuses)}`
+        }
+      })
+
+      actions.createPage({
+        path: `/${slug}/rails`,
         component: redirectLayout,
         context: {
           location: `/${slug}/rails/${latestStatusFrom(statuses)}`

--- a/src/layouts/redirect-layout.tsx
+++ b/src/layouts/redirect-layout.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import { navigate } from 'gatsby'
 
 export default function RedirectLayout({pageContext}) {
-  navigate(pageContext.location)
+  if (typeof window !== "undefined") {
+    navigate(pageContext.location)
+  }
+
   return <></>
 }

--- a/src/layouts/redirect-layout.tsx
+++ b/src/layouts/redirect-layout.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import { navigate } from 'gatsby'
+
+export default function RedirectLayout({pageContext}) {
+  navigate(pageContext.location)
+  return <></>
+}


### PR DESCRIPTION
As of a few hours ago, all our components can be reached by appending /latest to the URL, which will take you to the latest version of the component. Unfortunately these redirects only work if you're clicking a link within the docsite. Gatsby intercepts the navigation attempt and searches through all the configured redirects, ultimately routing you to the right place. However, these redirects don't work if you visit the page from outside the docsite, or type the URL directly into your browser, because there's no backend server at play.

This PR adds a special layout that, when visited, navigates you to the provided URL. It also creates actual pages for /latest URLs using this layout, which works for every type of visit, eg. both within the docsite and outside of it.