### PR TITLE
Port over draft components

### DIFF
--- a/content/components/dialog/react/draft.mdx
+++ b/content/components/dialog/react/draft.mdx
@@ -1,0 +1,190 @@
+---
+title: Dialog
+description:
+  Dialog is a floating surface used to display transient content such as confirmation actions, selection options, and
+  more.
+reactId: dialog
+reactStatus: draft
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query DialogDraftQuery($componentId: String! = "dialog", $parentPath: String! = "/components/dialog", $status: String! = "draft") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data} showExamples={false} showProps={false} showImport={false} tocItems={[{url: "#import", title: "Import"}, {url: "#props", title: "Props"}, {url: "#confirmationdialog", title: "ConfirmationDialog"}]}>
+    {children}
+  </ReactComponentPage>
+}
+
+The dialog component is the Primer implementation of the ARIA design pattern [Dialog](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal). A dialog is a type of overlay that can be used for confirming actions, asking for disambiguation, and presenting small forms. They generally allow the user to focus on a quick task without having to navigate to a different page.
+
+**Dialogs appear in the page after a direct user interaction**. Don't show dialogs on page load or as system alerts.
+
+**Dialogs appear centered in the page**, with a visible backdrop that dims the rest of the window for focus.
+
+**All dialogs should have a title and a close button**. Use the `title` prop to set the title. The close button is created automatically, but must be handled with an `onClose` prop.
+
+**Dialogs are modal**. Dialogs can be dismissed by clicking on the close button, by interacting with another button in the overlay, or by clicking outside of the overlay.
+
+Dialogs should not be dismissed by clicking outside the dialog's content area if used to add, update, or remove information. This would be the equivalent of a cancel action and may cause accidental data loss.
+
+**(Coming soon) Make sure larger dialogs remain mobile-friendly**. Even large dialogs need to be responsive. A dialog's width and height will be readjusted depending on the screen size and should never exceed the available space. Use responsive solutions to adjust the UI so they behave well on smaller screens.
+
+**(Coming soon) Simple and small dialogs can remain as-is on mobile**. As more elements are added to it, mobile-specific style variations such as **Bottom sheet** and **Full-screen** should be considered.
+
+## Import
+
+```javascript
+import {Dialog} from '@primer/react/drafts'
+```
+
+### State
+
+The dialog component is completely stateless. The parent component must conditionally render a dialog based on the necessary criteria. The parent component can be notified by a gesture to close the dialog (e.g. by clicking the "X" button or by pressing the Escape key) by passing in the `onClose` prop.
+
+### Accessibility
+
+The dialog component is fully accessible out-of-the-box. The dialog's title is used for `aria-labelledby`, and the dialog's description is used for `aria-describedby`. The `aria-modal="true"` attribute is used to inform screen readers that the rest of the content on the page is inert.
+
+#### Keyboard
+
+The default keyboard API for a dialog employs three mechanisms:
+
+1. The Escape key can be pressed to close the dialog.
+2. Focus is trapped within the top-most dialog. When a dialog is opened, the close button receives initial focus by default, or on a button defined with `autoFocus: true`.
+3. If there are buttons in the dialog footer, focus can be moved between them with left and right arrow keys or tab/shift+tab.
+4. When a dialog is closed, it can optionally handle returning focus to the element that was focused immediately before the dialog was opened. Otherwise, it is the consumer's responsibility to move focus to a suitable element.
+
+### Custom rendering
+
+**Note: using custom rendering allows breaking out of the defined design, UX, and accessibility patterns of the dialog. Use only as a last resort.**
+
+By default, the Dialog component implements the design and interactions defined by the Primer design system. If necessary, you can provide custom renderers for the header, body, or footer using the `renderHeader`, `renderBody`, and `renderFooter` props, respectively. The JSX produced by these render props will render full-bleed into their respective areas of the dialog. If you are using the custom renderers, you should use the provided sub-components `Dialog.Header`, `Dialog.Title`, `Dialog.Subtitle`, `Dialog.CloseButton`, `Dialog.Body`, `Dialog.Footer`, and `Dialog.Buttons` to the extent possible.
+
+### Example
+
+```jsx live drafts
+<State default={false}>
+  {([isOpen, setIsOpen]) => {
+    const openDialog = React.useCallback(() => setIsOpen(true), [setIsOpen])
+    const closeDialog = React.useCallback(() => setIsOpen(false), [setIsOpen])
+    return (
+      <>
+        <Button onClick={openDialog}>Open</Button>
+        {isOpen && (
+          <Dialog
+            title="Dialog example"
+            subtitle={
+              <>
+                This is a <b>description</b> of the dialog.
+              </>
+            }
+            footerButtons={[{content: 'Ok', onClick: closeDialog}]}
+            onClose={closeDialog}
+          >
+            <Text fontFamily="sans-serif">Some content</Text>
+          </Dialog>
+        )}
+      </>
+    )
+  }}
+</State>
+```
+
+## Props
+
+### DialogHeaderProps
+
+The `DialogHeaderProps` interface extends `DialogProps` and adds these additional properties:
+
+| Prop name           | Type     | Description                                                                                                                                                     |
+| :------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dialogLabelId       | `string` | ID of the element that will be used as the `aria-labelledby` attribute on the dialog. This ID should be set to the element that renders the dialog's title.     |
+| dialogDescriptionId | `string` | ID of the element that will be used as the `aria-describedby` attribute on the dialog. This ID should be set to the element that renders the dialog's subtitle. |
+
+### DialogButtonProps
+
+The `DialogButtonProps` interface extends `ButtonProps` (see Button) and adds these additional properties:
+
+| Prop name  | Type                              | Default  | Description                                                                                                                                                        |
+| :--------- | :-------------------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| buttonType | `"normal" │ "primary" │ "danger"` | `Button` | The type of button to render                                                                                                                                       |
+| content    | `React.ReactNode`                 |          | Required. The button's inner content.                                                                                                                              |
+| autoFocus  | `boolean`                         | false    | If true, this button will be automatically focused when the dialog is first rendered. If `autoFocus` is true on subsequent button definitions, it will be ignored. |
+
+## ConfirmationDialog
+
+A `ConfirmationDialog` is a special kind of dialog with more rigid behavior. It is used to confirm a user action. `ConfirmationDialog`s always have exactly two buttons: one to cancel the action and one to confirm it. No custom rendering capabilities are provided for ConfirmationDialog.
+
+### useConfirm hook
+
+An alternate way to use `ConfirmationDialog` is with the `useConfirm()` hook. It takes no parameters and returns an `async` function, `confirm`. When `confirm` is called (see ConfirmOptions below for its argument), it shows the confirmation dialog. When the dialog is dismissed, a promise is resolved with `true` or `false` depending on whether or not the confirm button was used.
+
+### Example (with `useConfirm` hook)
+
+```javascript live noinline
+function ShorthandExample2() {
+  const confirm = useConfirm()
+  const buttonClick = React.useCallback(
+    async function (e) {
+      if (await confirm({title: 'Are you sure?', content: 'You must confirm this action to continue.'})) {
+        e.target.textContent = 'Confirmed!'
+      }
+    },
+    [confirm],
+  )
+  return (
+    <>
+      <Button onClick={buttonClick}>Confirmable action</Button>
+    </>
+  )
+}
+render(<ShorthandExample2 />)
+```
+
+### Example (using the full `ConfirmationDialog` component)
+
+```jsx live
+<State default={false}>
+  {([isOpen, setIsOpen]) => {
+    const openDialog = React.useCallback(() => setIsOpen(true), [setIsOpen])
+    const closeDialog = React.useCallback(() => setIsOpen(false), [setIsOpen])
+    return (
+      <>
+        <Button onClick={openDialog}>Open</Button>
+        {isOpen && (
+          <ConfirmationDialog title="Confirm action?" onClose={closeDialog}>
+            Are you sure you want to confirm this action?
+          </ConfirmationDialog>
+        )}
+      </>
+    )
+  }}
+</State>
+```
+
+### ConfirmationDialogProps
+
+| Prop name            | Type                                                                  | Default    | Description                                                                                                                   |
+| :------------------- | :-------------------------------------------------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| title                | `React.ReactNode`                                                     |            | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute.                     |
+| onClose              | `(gesture: 'confirm' │ 'cancel' │ 'close-button' │ 'escape') => void` |            | Required. This callback is invoked when a gesture to close the dialog is performed. The first argument indicates the gesture. |
+| cancelButtonContent  | `React.ReactNode`                                                     | `"Cancel"` | The content to use for the cancel button.                                                                                     |
+| confirmButtonContent | `React.ReactNode`                                                     | `"OK"`     | The content to use for the confirm button.                                                                                    |
+| confirmButtonType    | `"normal" │ "primary" │ "danger"`                                     | `Button`   | The type of button to use for the confirm button.                                                                             |
+
+### ConfirmOptions
+
+| Prop name            | Type                              | Default    | Description                                                                                               |
+| :------------------- | :-------------------------------- | :--------- | :-------------------------------------------------------------------------------------------------------- |
+| title                | `React.ReactNode`                 |            | Required. Sets the title of the dialog, which by default is also used as the `aria-labelledby` attribute. |
+| content              | `React.ReactNode`                 |            | Required. Used as the body of the ConfirmationDialog that is displayed.                                   |
+| cancelButtonContent  | `React.ReactNode`                 | `"Cancel"` | The content to use for the cancel button.                                                                 |
+| confirmButtonContent | `React.ReactNode`                 | `"OK"`     | The content to use for the confirm button.                                                                |
+| confirmButtonType    | `"normal" │ "primary" │ "danger"` | `Button`   | The type of button to use for the confirm button.                                                         |

--- a/content/components/dialog/react/draft.mdx
+++ b/content/components/dialog/react/draft.mdx
@@ -8,6 +8,7 @@ reactStatus: draft
 ---
 
 import ReactComponentPage from '~/src/components/react-component-page'
+import ReactPropsTable from '~/src/components/react-props-table'
 import { graphql } from "gatsby"
 
 export const query = graphql`
@@ -98,6 +99,8 @@ By default, the Dialog component implements the design and interactions defined 
 ```
 
 ## Props
+
+<ReactPropsTable props={props.data.reactComponent.props} />
 
 ### DialogHeaderProps
 

--- a/content/components/hidden.mdx
+++ b/content/components/hidden.mdx
@@ -1,7 +1,7 @@
 ---
-title: Filter list
-description: The FilterList component is a menu with filter options that filter the main content of the page.
-reactId: filter_list
+title: Hidden
+description: Use Hidden to responsively hide or show content in narrow, regular and wide viewports.
+reactId: hidden
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -19,4 +19,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="FilterList"/>
+<AccessibilityLink label="Hidden"/>

--- a/content/components/hidden/react/draft.mdx
+++ b/content/components/hidden/react/draft.mdx
@@ -1,0 +1,41 @@
+---
+title: Hidden
+description: Use Hidden to responsively hide or show content in narrow, regular and wide viewports.
+reactId: hidden
+reactStatus: draft
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query HiddenDraftQuery($componentId: String! = "hidden", $parentPath: String! = "/components/hidden", $status: String! = "draft") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data}>{children}</ReactComponentPage>
+}
+
+The `Hidden` component is a utility component that helps hide or show content/components in different viewports.
+
+<Note>Use Hidden only to control behaviour in a responsive manner. It does not take any `sx` props.</Note>
+
+## Examples
+
+### Single viewport value provided
+
+```jsx drafts
+<Hidden when="narrow">
+  <Placeholder height="80px" label="This is not visible in narrow viewport" />
+</Hidden>
+```
+
+### Multiple viewport values provided
+
+```jsx drafts
+<Hidden when={['narrow', 'wide']}>
+  <Placeholder height="80px" label="This is not visible in narrow and wide viewport" />
+</Hidden>
+```

--- a/content/components/page-header/react/draft.mdx
+++ b/content/components/page-header/react/draft.mdx
@@ -1,0 +1,315 @@
+---
+title: PageHeader
+reactId: page_header
+reactStatus: draft
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query PageHeaderDraftQuery($componentId: String! = "page_header", $parentPath: String! = "/components/page-header", $status: String! = "draft") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data} showImport={false} tocItems={[{url: "#import", title: "Import"}, {url: "#examples", title: "Examples"}]}>
+    {children}
+  </ReactComponentPage>
+}
+
+```js
+import {PageHeader} from '@primer/react/drafts'
+```
+
+## Examples
+
+### Has title only
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Title</PageHeader.Title>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### Title `variant="large"`
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea variant="large">
+    <PageHeader.Title>Title</PageHeader.Title>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With leading and trailing visuals
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.LeadingVisual>
+      <GitPullRequestIcon />
+    </PageHeader.LeadingVisual>
+    <PageHeader.Title>Title</PageHeader.Title>
+    <PageHeader.TrailingVisual>
+      <Label>Beta</Label>
+    </PageHeader.TrailingVisual>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With leading visual is hidden on regular viewport
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.LeadingVisual hidden={{regular: true}}>
+      <GitPullRequestIcon />
+    </PageHeader.LeadingVisual>
+    <PageHeader.Title>Title</PageHeader.Title>
+    <PageHeader.TrailingVisual>
+      <Label>Beta</Label>
+    </PageHeader.TrailingVisual>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### Component as Title
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <Breadcrumbs>
+      <Breadcrumbs.Item href="#">...</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">primer</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">react</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">src</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">PageHeader</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="#">PageHeader.tsx</Breadcrumbs.Item>
+    </Breadcrumbs>
+    <Heading
+      as="h2"
+      sx={{
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: 0,
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: 0,
+      }}
+    >
+      Visually Hidden Title
+    </Heading>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With leading and trailing actions
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.LeadingAction>
+      <IconButton aria-label="Expand" icon={SidebarExpandIcon} variant="invisible" />
+    </PageHeader.LeadingAction>
+    <PageHeader.Title>Title</PageHeader.Title>
+    <PageHeader.TrailingAction>
+      <IconButton aria-label="Edit" icon={PencilIcon} variant="invisible" />
+    </PageHeader.TrailingAction>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With actions
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Title</PageHeader.Title>
+    <PageHeader.Actions>
+      <IconButton aria-label="Workflows" icon={WorkflowIcon} />
+      <IconButton aria-label="Insights" icon={GraphIcon} />
+      <Button variant="primary" trailingVisual={TriangleDownIcon}>
+        Add Item
+      </Button>
+      <IconButton aria-label="Settings" icon={GearIcon} />
+    </PageHeader.Actions>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With description slot
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>add-pageheader-docs</PageHeader.Title>
+  </PageHeader.TitleArea>
+  <PageHeader.Description>
+    <Text sx={{fontSize: 1, color: 'fg.muted'}}>
+      <Link href="#" muted sx={{fontWeight: 'bold'}}>
+        broccolinisoup
+      </Link>{' '}
+      created this branch 5 days ago · 14 commits · updated today
+    </Text>
+  </PageHeader.Description>
+</PageHeader>
+```
+
+### With navigation slot
+
+#### Utilizing a Navigation component
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Pull request title</PageHeader.Title>
+  </PageHeader.TitleArea>
+  <PageHeader.Navigation>
+    <UnderlineNav aria-label="Pull Request">
+      <UnderlineNav.Item icon={CommentDiscussionIcon} counter="12" aria-current="page">
+        Conversation
+      </UnderlineNav.Item>
+      <UnderlineNav.Item counter={3} icon={CommitIcon}>
+        Commits
+      </UnderlineNav.Item>
+      <UnderlineNav.Item counter={7} icon={ChecklistIcon}>
+        Checks
+      </UnderlineNav.Item>
+      <UnderlineNav.Item counter={4} icon={FileDiffIcon}>
+        Files Changes
+      </UnderlineNav.Item>
+    </UnderlineNav>
+  </PageHeader.Navigation>
+</PageHeader>
+```
+
+#### Utilizing a custom navigation
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Page Title</PageHeader.Title>
+  </PageHeader.TitleArea>
+  <PageHeader.Navigation as="nav" aria-label="Item list">
+    <Box as="ul" sx={{display: 'flex', gap: '8px', listStyle: 'none', paddingY: 0, paddingX: 3}} role="list">
+      <li>
+        <Link href="#" aria-current="page">
+          Item 1
+        </Link>
+      </li>
+      <li>
+        <Link href="#">Item 2</Link>
+      </li>
+    </Box>
+  </PageHeader.Navigation>
+</PageHeader>
+```
+
+### With ContextArea
+
+#### With parent link and actions (only visible on mobile)
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.ContextArea>
+    <PageHeader.ParentLink href="http://github.com">Parent Link</PageHeader.ParentLink>
+
+    <PageHeader.ContextAreaActions>
+      <Button size="small" leadingVisual={GitBranchIcon}>
+        Main
+      </Button>
+      <IconButton size="small" aria-label="More Options" icon={KebabHorizontalIcon} />
+    </PageHeader.ContextAreaActions>
+  </PageHeader.ContextArea>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Title</PageHeader.Title>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+#### With context bar and actions (only visible on mobile)
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.ContextArea>
+    <PageHeader.ContextBar>
+      <Breadcrumbs>
+        <Breadcrumbs.Item href="#">...</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">primer</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">react</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">src</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">PageHeader</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">PageHeader.tsx</Breadcrumbs.Item>
+      </Breadcrumbs>
+    </PageHeader.ContextBar>
+
+    <PageHeader.ContextAreaActions>
+      <Button size="small" leadingVisual={GitBranchIcon}>
+        Main
+      </Button>
+      <IconButton size="small" aria-label="More Options" icon={KebabHorizontalIcon} />
+    </PageHeader.ContextAreaActions>
+  </PageHeader.ContextArea>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Title</PageHeader.Title>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+#### With a ContextArea with all possible children (always visible)
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.ContextArea hidden={false}>
+    <PageHeader.ParentLink href="http://github.com" hidden={false}>
+      Parent Link
+    </PageHeader.ParentLink>
+
+    <PageHeader.ContextBar hidden={false}>
+      <Breadcrumbs>
+        <Breadcrumbs.Item href="#">...</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">primer</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">react</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">src</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">PageHeader</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="#">PageHeader.tsx</Breadcrumbs.Item>
+      </Breadcrumbs>
+    </PageHeader.ContextBar>
+
+    <PageHeader.ContextAreaActions hidden={false}>
+      <Button size="small" leadingVisual={GitBranchIcon}>
+        Main
+      </Button>
+      <IconButton size="small" aria-label="More Options" icon={KebabHorizontalIcon} />
+    </PageHeader.ContextAreaActions>
+  </PageHeader.ContextArea>
+  <PageHeader.TitleArea>
+    <PageHeader.Title>Title</PageHeader.Title>
+  </PageHeader.TitleArea>
+</PageHeader>
+```
+
+### With actions that have responsive content
+
+```jsx live drafts
+<PageHeader>
+  <PageHeader.TitleArea>
+    <PageHeader.Title as="h2">Webhooks</PageHeader.Title>
+    <PageHeader.Actions>
+      <Hidden when={['narrow']}>
+        <Button variant="primary">New webhook</Button>
+      </Hidden>
+      <Hidden when={['regular', 'wide']}>
+        <Button variant="primary">New</Button>
+      </Hidden>
+    </PageHeader.Actions>
+  </PageHeader.TitleArea>
+</PageHeader>
+```

--- a/content/components/selectpanel/react/draft.mdx
+++ b/content/components/selectpanel/react/draft.mdx
@@ -1,0 +1,27 @@
+---
+title: SelectPanel
+description: Select panel is a semantic dialog that allows for complex selection options within an overlay.
+reactId: select_panel
+reactStatus: draft
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query PageHeaderDraftQuery($componentId: String! = "select_panel", $parentPath: String! = "/components/selectpanel", $status: String! = "draft") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data} showImport={false} tocItems={[{url: "#import", title: "Import"}]}>
+    {children}
+  </ReactComponentPage>
+}
+
+## Import
+
+```js
+import {SelectPanel} from '@primer/react/drafts'
+```

--- a/content/components/tooltip/react/draft.mdx
+++ b/content/components/tooltip/react/draft.mdx
@@ -1,0 +1,82 @@
+---
+title: Tooltip
+description: Tooltips add additional context to interactive UI elements and appear on mouse hover or keyboard focus.
+reactId: tooltip
+reactStatus: draft
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query TooltipDraftQuery($componentId: String! = "tooltip", $parentPath: String! = "/components/tooltip", $status: String! = "draft") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data} showImport={false} tocItems={[{url: "#import", title: "Import"}, {url: "#examples", title: "Examples"}]}>
+    {children}
+  </ReactComponentPage>
+}
+
+## Import
+
+```javascript
+import {Tooltip} from '@primer/react/drafts'
+```
+
+## Examples
+
+### Default (For additional context)
+
+Default tooltip is suitable for interactive controls that require additional context.
+
+```jsx live
+<Tooltip text="This change cannot be undone.">
+  <Button>Delete</Button>
+</Tooltip>
+```
+
+### As a label
+
+Tooltip can be used to label interactive controls that has no visible text label such as interactive icon links.
+
+```jsx live
+<Tooltip text="Contribution Documentation for 'Primer React'" type="label">
+  <Link href="https://github.com/primer/react/contributor-docs/CONTRIBUTING.md" sx={{ml: 1, color: 'fg.muted'}}>
+    <Octicon icon={BookIcon} sx={{color: 'fg.muted'}} />
+  </Link>
+</Tooltip>
+```
+
+### With direction
+
+```jsx live
+<Box sx={{padding: 5, display: 'flex', gap: '8px'}}>
+  <Tooltip direction="n" text="Supplementary text">
+    <Button>North</Button>
+  </Tooltip>
+  <Tooltip direction="s" text="Supplementary text">
+    <Button>South</Button>
+  </Tooltip>
+  <Tooltip direction="e" text="Supplementary text">
+    <Button>East</Button>
+  </Tooltip>
+  <Tooltip direction="w" text="Supplementary text">
+    <Button>West</Button>
+  </Tooltip>
+  <Tooltip direction="ne" text="Supplementary text">
+    <Button>North East</Button>
+  </Tooltip>
+  <Tooltip direction="nw" text="Supplementary text">
+    <Button>North West</Button>
+  </Tooltip>
+  <Tooltip direction="se" text="Supplementary text">
+    <Button>Southeast</Button>
+  </Tooltip>
+  <Tooltip direction="sw" text="Supplementary text">
+    <Button>Southwest</Button>
+  </Tooltip>
+</Box>
+```

--- a/content/deprecated-components/filtered-search.mdx
+++ b/content/deprecated-components/filtered-search.mdx
@@ -19,4 +19,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="CloseButton"/>
+<AccessibilityLink label="FilteredSearch"/>

--- a/content/deprecated-components/inline-autocomplete.mdx
+++ b/content/deprecated-components/inline-autocomplete.mdx
@@ -1,7 +1,7 @@
 ---
-title: Filter list
-description: The FilterList component is a menu with filter options that filter the main content of the page.
-reactId: filter_list
+title: Inline autocomplete
+description: Provides inline auto completion suggestions for an input or textarea.
+reactId: inline_autocomplete
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -19,4 +19,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="FilterList"/>
+<AccessibilityLink label="InlineAutocomplete"/>

--- a/content/deprecated-components/inline-autocomplete/react/deprecated.mdx
+++ b/content/deprecated-components/inline-autocomplete/react/deprecated.mdx
@@ -1,0 +1,41 @@
+---
+title: Inline autocomplete
+description: Provides inline auto completion suggestions for an input or textarea.
+reactId: inline_autocomplete
+reactStatus: deprecated
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query InlineAutocompleteDraftQuery($componentId: String! = "inline_autocomplete", $parentPath: String! = "/deprecated-components/inline-autocomplete", $status: String! = "deprecated") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data}>{children}</ReactComponentPage>
+}
+
+The `Hidden` component is a utility component that helps hide or show content/components in different viewports.
+
+<Note>Use Hidden only to control behaviour in a responsive manner. It does not take any `sx` props.</Note>
+
+## Examples
+
+### Single viewport value provided
+
+```jsx drafts
+<Hidden when="narrow">
+  <Placeholder height="80px" label="This is not visible in narrow viewport" />
+</Hidden>
+```
+
+### Multiple viewport values provided
+
+```jsx drafts
+<Hidden when={['narrow', 'wide']}>
+  <Placeholder height="80px" label="This is not visible in narrow and wide viewport" />
+</Hidden>
+```

--- a/content/deprecated-components/markdown-editor.mdx
+++ b/content/deprecated-components/markdown-editor.mdx
@@ -1,7 +1,7 @@
 ---
-title: Filter list
-description: The FilterList component is a menu with filter options that filter the main content of the page.
-reactId: filter_list
+title: Markdown editor
+description: Provides inline auto completion suggestions for an input or textarea.
+reactId: markdown_editor
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -19,4 +19,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="FilterList"/>
+<AccessibilityLink label="MarkdownEditor"/>

--- a/content/deprecated-components/markdown-editor/react/deprecated.mdx
+++ b/content/deprecated-components/markdown-editor/react/deprecated.mdx
@@ -1,0 +1,165 @@
+---
+title: Markdown editor
+description: Full-featured Markdown input.
+reactId: markdown_editor
+reactStatus: deprecated
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query MarkdownEditorDeprecatedQuery($componentId: String! = "markdown_editor", $parentPath: String! = "/deprecated-components/markdown-editor", $status: String! = "deprecated") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data} showImport={false} tocItems={[{url: "#import", title: "Import"}, {url: "#examples", title: "Examples"}]}>{children}</ReactComponentPage>
+}
+
+`MarkdownEditor` is a full-featured editor for GitHub Flavored Markdown, with support for:
+
+- Formatting (keyboard shortcuts & toolbar buttons)
+- File uploads (drag & drop, paste, click to upload)
+- Inline suggestions (emojis, `@` mentions, and `#` references)
+- Saved replies
+- Markdown pasting (ie, paste URL onto selected text to create a link)
+- List editing (create a new list item on `Enter`)
+- Indenting selected text
+
+## Import
+
+```js
+import {MarkdownEditor} from '@primer/react/drafts'
+```
+
+## Examples
+
+### Minimal Example
+
+A `Label` is always required for accessibility:
+
+```jsx noinline drafts
+const renderMarkdown = async markdown => {
+  // In production code, this would make a query to some external API endpoint to render
+  return 'Rendered Markdown.'
+}
+
+const MinimalExample = () => {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <MarkdownEditor value={value} onChange={setValue} onRenderPreview={renderMarkdown}>
+      <MarkdownEditor.Label>Minimal Example</MarkdownEditor.Label>
+    </MarkdownEditor>
+  )
+}
+
+render(MinimalExample)
+```
+
+### Suggestions, File Uploads, and Saved Replies
+
+```jsx noinline drafts
+const renderMarkdown = async markdown => 'Rendered Markdown.'
+
+const uploadFile = async file => ({
+  url: `https://example.com/${encodeURIComponent(file.name)}`,
+  file,
+})
+
+const emojis = [
+  {name: '+1', character: '👍'},
+  {name: '-1', character: '👎'},
+  {name: 'heart', character: '❤️'},
+  {name: 'wave', character: '👋'},
+  {name: 'raised_hands', character: '🙌'},
+  {name: 'pray', character: '🙏'},
+  {name: 'clap', character: '👏'},
+  {name: 'ok_hand', character: '👌'},
+  {name: 'point_up', character: '☝️'},
+  {name: 'point_down', character: '👇'},
+  {name: 'point_left', character: '👈'},
+  {name: 'point_right', character: '👉'},
+  {name: 'raised_hand', character: '✋'},
+  {name: 'thumbsup', character: '👍'},
+  {name: 'thumbsdown', character: '👎'},
+]
+
+const references = [
+  {id: '1', titleText: 'Add logging functionality', titleHtml: 'Add logging functionality'},
+  {
+    id: '2',
+    titleText: 'Error: `Failed to install` when installing',
+    titleHtml: 'Error: <code>Failed to install</code> when installing',
+  },
+  {id: '3', titleText: 'Add error-handling functionality', titleHtml: 'Add error-handling functionality'},
+]
+
+const mentionables = [
+  {identifier: 'monalisa', description: 'Monalisa Octocat'},
+  {identifier: 'github', description: 'GitHub'},
+  {identifier: 'primer', description: 'Primer'},
+]
+
+const savedReplies = [
+  {name: 'Duplicate', content: 'Duplicate of #'},
+  {name: 'Welcome', content: 'Welcome to the project!\n\nPlease be sure to read the contributor guidelines.'},
+  {name: 'Thanks', content: 'Thanks for your contribution!'},
+]
+
+const MinimalExample = () => {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <MarkdownEditor
+      value={value}
+      onChange={setValue}
+      onRenderPreview={renderMarkdown}
+      onUploadFile={uploadFile}
+      emojiSuggestions={emojis}
+      referenceSuggestions={references}
+      mentionSuggestions={mentionables}
+      savedReplies={savedReplies}
+    >
+      <MarkdownEditor.Label>Suggestions, File Uploads, and Saved Replies Example</MarkdownEditor.Label>
+    </MarkdownEditor>
+  )
+}
+
+render(MinimalExample)
+```
+
+### Custom Buttons
+
+```jsx noinline drafts
+const renderMarkdown = async markdown => 'Rendered Markdown.'
+
+const MinimalExample = () => {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <MarkdownEditor value={value} onChange={setValue} onRenderPreview={renderMarkdown}>
+      <MarkdownEditor.Label visuallyHidden>Custom Buttons</MarkdownEditor.Label>
+
+      <MarkdownEditor.Toolbar>
+        <MarkdownEditor.ToolbarButton icon={SquirrelIcon} aria-label="Custom button 1" />
+        <MarkdownEditor.DefaultToolbarButtons />
+        <MarkdownEditor.ToolbarButton icon={BugIcon} aria-label="Custom button 2" />
+      </MarkdownEditor.Toolbar>
+
+      <MarkdownEditor.Footer>
+        <MarkdownEditor.FooterButton variant="danger">Custom Button</MarkdownEditor.FooterButton>
+
+        <MarkdownEditor.Action>
+          <MarkdownEditor.ActionButton variant="danger">Cancel</MarkdownEditor.ActionButton>
+          <MarkdownEditor.ActionButton variant="primary">Submit</MarkdownEditor.ActionButton>
+        </MarkdownEditor.Action>
+      </MarkdownEditor.Footer>
+    </MarkdownEditor>
+  )
+}
+
+render(MinimalExample)
+```

--- a/content/deprecated-components/markdown-viewer.mdx
+++ b/content/deprecated-components/markdown-viewer.mdx
@@ -1,7 +1,7 @@
 ---
-title: Filter list
-description: The FilterList component is a menu with filter options that filter the main content of the page.
-reactId: filter_list
+title: Markdown viewer
+description: Displays rendered Markdown and facilitates interaction.
+reactId: markdown_viewer
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
@@ -19,4 +19,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="FilterList"/>
+<AccessibilityLink label="MarkdownEditor"/>

--- a/content/deprecated-components/markdown-viewer/react/deprecated.mdx
+++ b/content/deprecated-components/markdown-viewer/react/deprecated.mdx
@@ -1,0 +1,93 @@
+---
+title: Markdown viewer
+description: Displays rendered Markdown and facilitates interaction.
+reactId: markdown_viewer
+reactStatus: deprecated
+---
+
+import ReactComponentPage from '~/src/components/react-component-page'
+import { graphql } from "gatsby"
+
+export const query = graphql`
+  query MarkdownViewerDeprecatedQuery($componentId: String! = "markdown_viewer", $parentPath: String! = "/deprecated-components/markdown-viewer", $status: String! = "deprecated") {
+    ...ReactComponentInfo
+  }
+`
+
+export default function Layout({data, children}) {
+  return <ReactComponentPage data={data} showImport={false} tocItems={[{url: "#import", title: "Import"}, {url: "#examples", title: "Examples"}]}>
+    {children}
+  </ReactComponentPage>
+}
+
+The `MarkdownViewer` displays rendered Markdown and handles interaction (link clicking and checkbox checking/unchecking) with that content.
+
+## Import
+
+```js
+import {MarkdownViewer} from '@primer/react/drafts'
+```
+
+## Examples
+
+### Simple Example
+
+```javascript noinline drafts
+const MarkdownViewerExample = () => {
+  return (
+    // eslint-disable-next-line github/unescaped-html-literal
+    <MarkdownViewer dangerousRenderedHTML={{__html: '<strong>Lorem ipsum</strong> dolor sit amet.'}} />
+  )
+}
+
+render(MarkdownViewerExample)
+```
+
+### Link-Handling Example
+
+```javascript noinline drafts
+const MarkdownViewerExample = () => {
+  return (
+    <MarkdownViewer
+      // eslint-disable-next-line github/unescaped-html-literal
+      dangerousRenderedHTML={{__html: "<a href='https://example.com'>Example link</a>"}}
+      onLinkClick={ev => console.log(ev)}
+    />
+  )
+}
+
+render(MarkdownViewerExample)
+```
+
+### Checkbox Interaction Example
+
+```javascript noinline drafts
+const markdownSource = `
+text before list
+
+- [ ] item 1
+- [ ] item 2
+
+text after list`
+
+const renderedHtml = `
+<p>text before list</p>
+<ul class='contains-task-list'>
+  <li class='task-list-item'><input type='checkbox' class='task-list-item-checkbox' disabled/> item 1</li>
+  <li class='task-list-item'><input type='checkbox' class='task-list-item-checkbox' disabled/> item 2</li>
+</ul>
+<p>text after list</p>`
+
+const MarkdownViewerExample = () => {
+  return (
+    <MarkdownViewer
+      dangerousRenderedHTML={{__html: renderedHtml}}
+      markdownValue={markdownSource}
+      onChange={value => console.log(value) /* save the value to the server */}
+      disabled={false}
+    />
+  )
+}
+
+render(MarkdownViewerExample)
+```

--- a/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -235,6 +235,8 @@
       url: /components/header
     - title: Heading
       url: /components/heading
+    - title: Hidden
+      url: /components/hidden
     - title: Hidden text expander
       url: /components/hidden-text-expander
     - title: Icon
@@ -337,6 +339,12 @@
       url: /deprecated-components/filter-list
     - title: Filtered search
       url: /deprecated-components/filtered-search
+    - title: Inline autocomplete
+      url: /deprecated-components/inline-autocomplete
+    - title: Markdown editor
+      url: /deprecated-components/markdown-editor
+    - title: Markdown viewer
+      url: /deprecated-components/markdown-viewer
     - title: Menu
       url: /deprecated-components/menu
     - title: Select menu

--- a/src/components/react-component-page.tsx
+++ b/src/components/react-component-page.tsx
@@ -2,17 +2,15 @@ import {AccessibilityLabel, Note, StatusLabel} from '@primer/gatsby-theme-doctoc
 import Code from '@primer/gatsby-theme-doctocat/src/components/code'
 import {HEADER_HEIGHT} from '@primer/gatsby-theme-doctocat/src/components/header'
 import {H2, H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
-import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
-import Table from '@primer/gatsby-theme-doctocat/src/components/table'
 import TableOfContents from '@primer/gatsby-theme-doctocat/src/components/table-of-contents'
 import {LinkExternalIcon} from '@primer/octicons-react'
 import {Box, Heading, Label, Link, Text} from '@primer/react'
 import React, { PropsWithChildren } from 'react'
-import ReactMarkdown from 'react-markdown'
 import {StorybookEmbed} from '../components/storybook-embed'
 import {BaseLayout} from '../components/base-layout'
 import {ComponentPageNav} from '../components/component-page-nav'
 import StatusMenu from '../components/status-menu'
+import ReactPropsTable from './react-props-table'
 
 type ReactComponentPageProps = {
   // Data is the result of the ReactComponentInfo graphql fragment in react-component-layout.tsx
@@ -239,77 +237,4 @@ function sentenceCase(str: string) {
   return str.replace(/([A-Z])/g, ' $1').replace(/^./, function (str) {
     return str.toUpperCase()
   })
-}
-
-// TODO: Make table responsive
-function ReactPropsTable({
-  props,
-}: {
-  props: Array<{
-    name: string
-    type: string
-    defaultValue: string
-    required: boolean
-    deprecated: boolean
-    description: string
-  }>
-}) {
-  if (props.length === 0) {
-    return (
-      <Box sx={{padding: 3, bg: 'canvas.inset', textAlign: 'center', color: 'fg.muted', borderRadius: 2}}>No props</Box>
-    )
-  }
-
-  return (
-    <Box sx={{overflow: 'auto'}}>
-      <Table>
-        <colgroup>
-          <col style={{width: '25%'}} />
-          <col style={{width: '15%'}} />
-          <col style={{width: '60%'}} />
-        </colgroup>
-        <thead>
-          <tr>
-            <th align="left">Name</th>
-            <th align="left">Default</th>
-            <th align="left">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {props.map(prop => (
-            <tr key={prop.name}>
-              <td valign="top">
-                <Box sx={{display: 'flex', gap: 2, alignItems: 'center'}}>
-                  <Text sx={{fontFamily: 'mono', fontSize: 1, whiteSpace: 'nowrap'}}>{prop.name}</Text>
-                  {prop.required ? <Label>Required</Label> : null}
-                  {prop.deprecated ? <Label variant="danger">Deprecated</Label> : null}
-                </Box>
-              </td>
-              <td valign="top">{prop.defaultValue ? <InlineCode>{prop.defaultValue}</InlineCode> : null}</td>
-              <td>
-                <InlineCode>{prop.type}</InlineCode>
-                <Box
-                  sx={{
-                    '&:not(:empty)': {
-                      mt: 2,
-                    },
-                    color: 'fg.muted',
-                    '& > :first-child': {
-                      mt: 0,
-                    },
-                    '& > :last-child': {
-                      mb: 0,
-                    },
-                  }}
-                >
-                  {/* @ts-ignore */}
-                  <ReactMarkdown components={{a: Link, code: InlineCode}}>{prop.description}</ReactMarkdown>
-                </Box>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-    </Box>
-  )
 }

--- a/src/components/react-component-page.tsx
+++ b/src/components/react-component-page.tsx
@@ -1,0 +1,315 @@
+import {AccessibilityLabel, Note, StatusLabel} from '@primer/gatsby-theme-doctocat'
+import Code from '@primer/gatsby-theme-doctocat/src/components/code'
+import {HEADER_HEIGHT} from '@primer/gatsby-theme-doctocat/src/components/header'
+import {H2, H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
+import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
+import Table from '@primer/gatsby-theme-doctocat/src/components/table'
+import TableOfContents from '@primer/gatsby-theme-doctocat/src/components/table-of-contents'
+import {LinkExternalIcon} from '@primer/octicons-react'
+import {Box, Heading, Label, Link, Text} from '@primer/react'
+import React, { PropsWithChildren } from 'react'
+import ReactMarkdown from 'react-markdown'
+import {StorybookEmbed} from '../components/storybook-embed'
+import {BaseLayout} from '../components/base-layout'
+import {ComponentPageNav} from '../components/component-page-nav'
+import StatusMenu from '../components/status-menu'
+
+type ReactComponentPageProps = {
+  // Data is the result of the ReactComponentInfo graphql fragment in react-component-layout.tsx
+  data: any,
+  showExamples?: boolean,
+  showProps?: boolean
+  showImport?: boolean,
+  tocItems?: TocEntry[]
+}
+
+type TocEntry = {
+  url: string,
+  title: string,
+}
+
+export default function ReactComponentPage(props: PropsWithChildren<ReactComponentPageProps>) {
+  const {data, showExamples = true, showProps = true, showImport = true, tocItems = []} = props
+  const {name, status, a11yReviewed, props: componentProps, subcomponents, stories} = data.reactComponent
+  const importStatement = `import {${name}} from '@primer/react${status === 'draft' ? '/drafts' : ''}'`
+
+  const tableOfContents = {
+    items: [...tocItems],
+  }
+
+  if (showImport) {
+    tableOfContents.items.push({url: '#import', title: 'Import'})
+  }
+
+  if (showExamples) {
+    tableOfContents.items.push({url: '#storybook-examples', title: 'Storybook Examples'})
+  }
+
+  if (showProps) {
+    tableOfContents.items.push({url: '#props', title: 'Props'})
+  }
+
+  const title = data.sitePage?.context.frontmatter.title || name
+  const description = data.sitePage?.context.frontmatter.description || ''
+
+  const statusSet: Set<string> = new Set();
+  for (const reactComponent of data.allReactComponent.nodes) {
+    statusSet.add(reactComponent.status)
+  }
+
+  // this component has a dedicated page for its deprecated version
+  if (data.deprecatedMdx?.id) statusSet.add("deprecated")
+  if (data.draftMdx?.id) statusSet.add("draft")
+
+  const statuses = [...statusSet]
+
+  return (
+    <BaseLayout title={title} description={description}>
+      <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
+        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
+        {description ? (
+          <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
+            {description}
+          </Text>
+        ) : null}
+        <Box sx={{mb: 4}}>
+          <ComponentPageNav
+            basePath={data.sitePage.path}
+            includeReact={data.sitePage.context.frontmatter.reactId}
+            includeRails={data.sitePage.context.frontmatter.railsIds}
+            includeFigma={data.sitePage.context.frontmatter.figmaId}
+            includeCSS={data.sitePage.context.frontmatter.cssId}
+            current="react"
+          />
+        </Box>
+        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
+          <Box
+            sx={{
+              width: 220,
+              flex: '0 0 auto',
+              position: 'sticky',
+              top: HEADER_HEIGHT + 24,
+              maxHeight: `calc(100vh - ${HEADER_HEIGHT}px - 24px)`,
+              display: ['none', null, 'block'],
+            }}
+          >
+            <Heading as="h3" sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
+              On this page
+            </Heading>
+            <TableOfContents aria-labelledby="toc-heading" items={tableOfContents.items} />
+          </Box>
+          <Box sx={{minWidth: 0}}>
+            {/* @ts-ignore */}
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: ['column', null, null, null, 'row'],
+                justifyContent: 'space-between',
+                gap: 3,
+                mb: 4,
+              }}
+            >
+              <Box
+                as={'ul'}
+                sx={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 2,
+                  alignItems: 'center',
+                  m: 0,
+                  p: 0,
+                  paddingInline: 0,
+                  listStyle: 'none',
+                  '& > li': {
+                    display: 'flex',
+                  },
+                }}
+              >
+                <li>
+                  <Label size="large">@primer/react@{data.primerReactVersion.version}</Label>
+                </li>
+                <li>
+                  <StatusLabel status={sentenceCase(status)} />
+                </li>
+                <li>
+                  <AccessibilityLabel a11yReviewed={a11yReviewed} short={false} />
+                </li>
+              </Box>
+              {statuses.length > 1 &&
+                <Box
+                  as={'ul'}
+                  sx={{
+                    display: 'flex',
+                    gap: 3,
+                    alignItems: 'center',
+                    m: 0,
+                    p: 0,
+                    paddingInline: 0,
+                    listStyle: 'none',
+                    fontSize: 1,
+                    '& > li': {
+                      display: 'flex',
+                    },
+                  }}
+                >
+                  <StatusMenu currentStatus={status} statuses={statuses} parentPath={`${data.sitePage.path}/react`} />
+                </Box>
+              }
+            </Box>
+            {/* Narrow table of contents */}
+            <Box
+              sx={{
+                display: ['block', null, 'none'],
+                mb: 5,
+                borderColor: 'border.muted',
+                bg: 'canvas.subtle',
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                borderRadius: 2,
+              }}
+            >
+              <Box sx={{px: 3, py: 2}}>
+                <Box
+                  sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
+                >
+                  <Heading as="h3" sx={{fontSize: 1, fontWeight: 'bold'}} id="toc-heading-narrow">
+                    On this page
+                  </Heading>
+                </Box>
+              </Box>
+              <Box sx={{borderTop: '1px solid', borderColor: 'border.muted'}}>
+                <TableOfContents aria-labelledby="toc-heading-narrow" items={tableOfContents.items} />
+              </Box>
+            </Box>
+
+            {status === "deprecated" &&
+              /* @ts-ignore */
+              <Note variant="warning">
+                <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>This component is deprecated</Text>
+                <Text>Please consider using an alternative.</Text>
+              </Note>
+            }
+
+            {showImport && <>
+              <H2>Import</H2>
+              {/* @ts-ignore */}
+              <Code className="language-javascript">{importStatement}</Code>
+            </>}
+
+            {props.children}
+
+            {showExamples && <>
+              <H2>Storybook Examples</H2>
+              {stories.length > 0 ? (
+                <StorybookEmbed framework="react" height={300} stories={stories} />
+              ) : (
+                // If there are no stories, link to the component's page in the Primer React docs
+                <Link
+                  sx={{display: 'inline-flex', gap: 1, alignItems: 'center'}}
+                  href={`https://primer.style/react/${name}#examples`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span>{name} examples</span>
+                  <LinkExternalIcon />
+                </Link>
+              )}
+            </>}
+
+            {showProps && <>
+              <H2>Props</H2>
+              <H3>{name}</H3>
+              <ReactPropsTable props={componentProps} />
+              {subcomponents?.map(subcomponent => (
+                <>
+                  <H3>{subcomponent.name}</H3>
+                  <ReactPropsTable props={subcomponent.props} />
+                </>
+              ))}
+            </>}
+          </Box>
+        </Box>
+      </Box>
+    </BaseLayout>
+  )
+}
+
+/** Convert a string to sentence case. */
+function sentenceCase(str: string) {
+  return str.replace(/([A-Z])/g, ' $1').replace(/^./, function (str) {
+    return str.toUpperCase()
+  })
+}
+
+// TODO: Make table responsive
+function ReactPropsTable({
+  props,
+}: {
+  props: Array<{
+    name: string
+    type: string
+    defaultValue: string
+    required: boolean
+    deprecated: boolean
+    description: string
+  }>
+}) {
+  if (props.length === 0) {
+    return (
+      <Box sx={{padding: 3, bg: 'canvas.inset', textAlign: 'center', color: 'fg.muted', borderRadius: 2}}>No props</Box>
+    )
+  }
+
+  return (
+    <Box sx={{overflow: 'auto'}}>
+      <Table>
+        <colgroup>
+          <col style={{width: '25%'}} />
+          <col style={{width: '15%'}} />
+          <col style={{width: '60%'}} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th align="left">Name</th>
+            <th align="left">Default</th>
+            <th align="left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.map(prop => (
+            <tr key={prop.name}>
+              <td valign="top">
+                <Box sx={{display: 'flex', gap: 2, alignItems: 'center'}}>
+                  <Text sx={{fontFamily: 'mono', fontSize: 1, whiteSpace: 'nowrap'}}>{prop.name}</Text>
+                  {prop.required ? <Label>Required</Label> : null}
+                  {prop.deprecated ? <Label variant="danger">Deprecated</Label> : null}
+                </Box>
+              </td>
+              <td valign="top">{prop.defaultValue ? <InlineCode>{prop.defaultValue}</InlineCode> : null}</td>
+              <td>
+                <InlineCode>{prop.type}</InlineCode>
+                <Box
+                  sx={{
+                    '&:not(:empty)': {
+                      mt: 2,
+                    },
+                    color: 'fg.muted',
+                    '& > :first-child': {
+                      mt: 0,
+                    },
+                    '& > :last-child': {
+                      mb: 0,
+                    },
+                  }}
+                >
+                  {/* @ts-ignore */}
+                  <ReactMarkdown components={{a: Link, code: InlineCode}}>{prop.description}</ReactMarkdown>
+                </Box>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Box>
+  )
+}

--- a/src/components/react-props-table.tsx
+++ b/src/components/react-props-table.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
+import Table from '@primer/gatsby-theme-doctocat/src/components/table'
+import { Box, Text, Label, Link } from '@primer/react'
+
+// TODO: Make table responsive
+export default function ReactPropsTable({
+    props,
+  }: {
+    props: Array<{
+      name: string
+      type: string
+      defaultValue: string
+      required: boolean
+      deprecated: boolean
+      description: string
+    }>
+  }) {
+    if (props.length === 0) {
+      return (
+        <Box sx={{padding: 3, bg: 'canvas.inset', textAlign: 'center', color: 'fg.muted', borderRadius: 2}}>No props</Box>
+      )
+    }
+
+    return (
+      <Box sx={{overflow: 'auto'}}>
+        <Table>
+          <colgroup>
+            <col style={{width: '25%'}} />
+            <col style={{width: '15%'}} />
+            <col style={{width: '60%'}} />
+          </colgroup>
+          <thead>
+            <tr>
+              <th align="left">Name</th>
+              <th align="left">Default</th>
+              <th align="left">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {props.map(prop => (
+              <tr key={prop.name}>
+                <td valign="top">
+                  <Box sx={{display: 'flex', gap: 2, alignItems: 'center'}}>
+                    <Text sx={{fontFamily: 'mono', fontSize: 1, whiteSpace: 'nowrap'}}>{prop.name}</Text>
+                    {prop.required ? <Label>Required</Label> : null}
+                    {prop.deprecated ? <Label variant="danger">Deprecated</Label> : null}
+                  </Box>
+                </td>
+                <td valign="top">{prop.defaultValue ? <InlineCode>{prop.defaultValue}</InlineCode> : null}</td>
+                <td>
+                  <InlineCode>{prop.type}</InlineCode>
+                  <Box
+                    sx={{
+                      '&:not(:empty)': {
+                        mt: 2,
+                      },
+                      color: 'fg.muted',
+                      '& > :first-child': {
+                        mt: 0,
+                      },
+                      '& > :last-child': {
+                        mb: 0,
+                      },
+                    }}
+                  >
+                    {/* @ts-ignore */}
+                    <ReactMarkdown components={{a: Link, code: InlineCode}}>{prop.description}</ReactMarkdown>
+                  </Box>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Box>
+    )
+  }

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -1,25 +1,17 @@
-import {AccessibilityLabel, Note, StatusLabel} from '@primer/gatsby-theme-doctocat'
-import Code from '@primer/gatsby-theme-doctocat/src/components/code'
-import {HEADER_HEIGHT} from '@primer/gatsby-theme-doctocat/src/components/header'
-import {H2, H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
-import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
-import Table from '@primer/gatsby-theme-doctocat/src/components/table'
-import TableOfContents from '@primer/gatsby-theme-doctocat/src/components/table-of-contents'
-import {LinkExternalIcon} from '@primer/octicons-react'
-import {Box, Heading, Label, Link, Text} from '@primer/react'
 import {graphql} from 'gatsby'
 import React from 'react'
-import ReactMarkdown from 'react-markdown'
-import {StorybookEmbed} from '../components/storybook-embed'
-import {BaseLayout} from '../components/base-layout'
-import {ComponentPageNav} from '../components/component-page-nav'
-import StatusMenu from '../components/status-menu'
+import ReactComponentPage from '../components/react-component-page'
 
 export const query = graphql`
-  query ReactComponentPageQuery($componentId: String!, $parentPath: String!, $status: String!) {
+  query ReactComponentLayoutQuery($componentId: String!, $parentPath: String!, $status: String!) {
+    ...ReactComponentInfo
+  }
+
+  fragment ReactComponentInfo on Query {
     primerReactVersion {
       version
     }
+
     sitePage(path: {eq: $parentPath}) {
       path
       context {
@@ -72,271 +64,13 @@ export const query = graphql`
     deprecatedMdx: mdx(frontmatter: {reactId: {eq: $componentId}, reactStatus: {eq: "deprecated"}}) {
       id
     }
+
+    draftMdx: mdx(frontmatter: {reactId: {eq: $componentId}, reactStatus: {eq: "draft"}}) {
+      id
+    }
   }
 `
 
 export default function ReactComponentLayout({data}) {
-  const {name, status, a11yReviewed, props: componentProps, subcomponents, stories} = data.reactComponent
-  const importStatement = `import {${name}} from '@primer/react${status === 'draft' ? '/drafts' : ''}'`
-
-  const tableOfContents = {
-    items: [
-      {url: '#import', title: 'Import'},
-      {url: '#examples', title: 'Examples'},
-      {url: '#props', title: 'Props'},
-    ],
-  }
-
-  const title = data.sitePage?.context.frontmatter.title || name
-  const description = data.sitePage?.context.frontmatter.description || ''
-
-  const statuses: string[] = [];
-  for (const reactComponent of data.allReactComponent.nodes) {
-    statuses.push(reactComponent.status)
-  }
-
-  // this component has a dedicated page for its deprecated version
-  if (data.deprecatedMdx?.id !== undefined) statuses.push("deprecated")
-
-  return (
-    <BaseLayout title={title} description={description}>
-      <Box sx={{maxWidth: 1200, width: '100%', p: [4, 5, 6, 7], mx: 'auto'}}>
-        <Heading as="h1" sx={{fontSize: 7}}>{title}</Heading>
-        {description ? (
-          <Text as="p" sx={{fontSize: 3, m: 0, mb: 3, maxWidth: '60ch'}}>
-            {description}
-          </Text>
-        ) : null}
-        <Box sx={{mb: 4}}>
-          <ComponentPageNav
-            basePath={data.sitePage.path}
-            includeReact={data.sitePage.context.frontmatter.reactId}
-            includeRails={data.sitePage.context.frontmatter.railsIds}
-            includeFigma={data.sitePage.context.frontmatter.figmaId}
-            includeCSS={data.sitePage.context.frontmatter.cssId}
-            current="react"
-          />
-        </Box>
-        <Box sx={{display: 'flex', flexDirection: 'row-reverse', alignItems: 'start', gap: [null, 7, 8, 9]}}>
-          <Box
-            sx={{
-              width: 220,
-              flex: '0 0 auto',
-              position: 'sticky',
-              top: HEADER_HEIGHT + 24,
-              maxHeight: `calc(100vh - ${HEADER_HEIGHT}px - 24px)`,
-              display: ['none', null, 'block'],
-            }}
-          >
-            <Heading as="h3" sx={{fontSize: 1, display: 'inline-block', fontWeight: 'bold', pl: 3}} id="toc-heading">
-              On this page
-            </Heading>
-            <TableOfContents aria-labelledby="toc-heading" items={tableOfContents.items} />
-          </Box>
-          <Box sx={{minWidth: 0}}>
-            {/* @ts-ignore */}
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: ['column', null, null, null, 'row'],
-                justifyContent: 'space-between',
-                gap: 3,
-                mb: 4,
-              }}
-            >
-              <Box
-                as={'ul'}
-                sx={{
-                  display: 'flex',
-                  flexWrap: 'wrap',
-                  gap: 2,
-                  alignItems: 'center',
-                  m: 0,
-                  p: 0,
-                  paddingInline: 0,
-                  listStyle: 'none',
-                  '& > li': {
-                    display: 'flex',
-                  },
-                }}
-              >
-                <li>
-                  <Label size="large">@primer/react@{data.primerReactVersion.version}</Label>
-                </li>
-                <li>
-                  <StatusLabel status={sentenceCase(status)} />
-                </li>
-                <li>
-                  <AccessibilityLabel a11yReviewed={a11yReviewed} short={false} />
-                </li>
-              </Box>
-              {statuses.length > 1 &&
-                <Box
-                  as={'ul'}
-                  sx={{
-                    display: 'flex',
-                    gap: 3,
-                    alignItems: 'center',
-                    m: 0,
-                    p: 0,
-                    paddingInline: 0,
-                    listStyle: 'none',
-                    fontSize: 1,
-                    '& > li': {
-                      display: 'flex',
-                    },
-                  }}
-                >
-                  <StatusMenu currentStatus={status} statuses={statuses} parentPath={`${data.sitePage.path}/react`} />
-                </Box>
-              }
-            </Box>
-            {/* Narrow table of contents */}
-            <Box
-              sx={{
-                display: ['block', null, 'none'],
-                mb: 5,
-                borderColor: 'border.muted',
-                bg: 'canvas.subtle',
-                borderWidth: '1px',
-                borderStyle: 'solid',
-                borderRadius: 2,
-              }}
-            >
-              <Box sx={{px: 3, py: 2}}>
-                <Box
-                  sx={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', display: 'flex'}}
-                >
-                  <Heading as="h3" sx={{fontSize: 1, fontWeight: 'bold'}} id="toc-heading-narrow">
-                    On this page
-                  </Heading>
-                </Box>
-              </Box>
-              <Box sx={{borderTop: '1px solid', borderColor: 'border.muted'}}>
-                <TableOfContents aria-labelledby="toc-heading-narrow" items={tableOfContents.items} />
-              </Box>
-            </Box>
-
-            {status === "deprecated" &&
-              /* @ts-ignore */
-              <Note variant="warning">
-                <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>This component is deprecated</Text>
-                <Text>Please consider using an alternative.</Text>
-              </Note>
-            }
-
-            <H2>Import</H2>
-            {/* @ts-ignore */}
-            <Code className="language-javascript">{importStatement}</Code>
-
-            <H2>Examples</H2>
-            {stories.length > 0 ? (
-              <StorybookEmbed framework="react" height={300} stories={stories} />
-            ) : (
-              // If there are no stories, link to the component's page in the Primer React docs
-              <Link
-                sx={{display: 'inline-flex', gap: 1, alignItems: 'center'}}
-                href={`https://primer.style/react/${name}#examples`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span>{name} examples</span>
-                <LinkExternalIcon />
-              </Link>
-            )}
-
-            <H2>Props</H2>
-            <H3>{name}</H3>
-            <ReactPropsTable props={componentProps} />
-            {subcomponents?.map(subcomponent => (
-              <>
-                <H3>{subcomponent.name}</H3>
-                <ReactPropsTable props={subcomponent.props} />
-              </>
-            ))}
-          </Box>
-        </Box>
-      </Box>
-    </BaseLayout>
-  )
-}
-
-/** Convert a string to sentence case. */
-function sentenceCase(str: string) {
-  return str.replace(/([A-Z])/g, ' $1').replace(/^./, function (str) {
-    return str.toUpperCase()
-  })
-}
-
-// TODO: Make table responsive
-function ReactPropsTable({
-  props,
-}: {
-  props: Array<{
-    name: string
-    type: string
-    defaultValue: string
-    required: boolean
-    deprecated: boolean
-    description: string
-  }>
-}) {
-  if (props.length === 0) {
-    return (
-      <Box sx={{padding: 3, bg: 'canvas.inset', textAlign: 'center', color: 'fg.muted', borderRadius: 2}}>No props</Box>
-    )
-  }
-
-  return (
-    <Box sx={{overflow: 'auto'}}>
-      <Table>
-        <colgroup>
-          <col style={{width: '25%'}} />
-          <col style={{width: '15%'}} />
-          <col style={{width: '60%'}} />
-        </colgroup>
-        <thead>
-          <tr>
-            <th align="left">Name</th>
-            <th align="left">Default</th>
-            <th align="left">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {props.map(prop => (
-            <tr key={prop.name}>
-              <td valign="top">
-                <Box sx={{display: 'flex', gap: 2, alignItems: 'center'}}>
-                  <Text sx={{fontFamily: 'mono', fontSize: 1, whiteSpace: 'nowrap'}}>{prop.name}</Text>
-                  {prop.required ? <Label>Required</Label> : null}
-                  {prop.deprecated ? <Label variant="danger">Deprecated</Label> : null}
-                </Box>
-              </td>
-              <td valign="top">{prop.defaultValue ? <InlineCode>{prop.defaultValue}</InlineCode> : null}</td>
-              <td>
-                <InlineCode>{prop.type}</InlineCode>
-                <Box
-                  sx={{
-                    '&:not(:empty)': {
-                      mt: 2,
-                    },
-                    color: 'fg.muted',
-                    '& > :first-child': {
-                      mt: 0,
-                    },
-                    '& > :last-child': {
-                      mb: 0,
-                    },
-                  }}
-                >
-                  {/* @ts-ignore */}
-                  <ReactMarkdown components={{a: Link, code: InlineCode}}>{prop.description}</ReactMarkdown>
-                </Box>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-    </Box>
-  )
+  return <ReactComponentPage data={data}/>
 }


### PR DESCRIPTION
See https://github.com/primer/design/pull/710 for the migration of deprecated components.

This PR migrates docs for draft React components from the old primer.style/react site to the new docsite. This was not a straightforward migration, but was significantly easier than deprecated components, since all draft components are available in components.json.

However, draft components presented the following challenges:

1. Additional documentation is present in bespoke .md files.
2. Although all draft components are listed in components.json, they are often listed with inconsistent IDs. For example, dialog's ID is `drafts_dialog`, but select panel's is `selectpanel_v2`. Note that the alpha version of select panel has an ID of `select_panel` 🤷 
3. Some components listed under "Drafts" on primer.style/react (the old docsite) are actually deprecated in components.json.

The following draft components have been migrated in this PR:

- `DataTable`: This one was actually already available in the new docsite.
- `Dialog` v2: Available at /components/dialog/react/draft
- `Hidden`: Added a new overview page and the draft component page.
- `InlineAutocomplete`: Deprecated.
- `MarkdownEditor`: Deprecated.
- `MarkdownViewer`: Deprecated
- `PageHeader`: Dedicated page available at /components/page-header/react/draft
- `SelectPanel`: Dedicated page available at /components/selectpanel/react/draft
- `Tooltip`: Dedicated page available at /components/tooltip/react/draft

NOTE: I discovered you can export a special `Layout` component from .mdx files, which greatly simplified several of the already-migrated deprecated components.