### PR TITLE
docs: expand banner guidance

### DIFF
--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -7,24 +7,37 @@ railsIds:
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Link, Text} from '@primer/react'
-import {Link as GatsbyLink} from 'gatsby'
 export default ComponentLayout
 import {AccessibilityLink} from '~/src/components/accessibility-link'
 
-For general design and usage guidelines of banners, see the [flash component](/components/flash).
-
 ## Accessibility
 
-### Focus management vs. a live region
+### Focus management vs. Live region announcement
 
-There was [extensive research](https://github.com/github/accessibility/blob/main/docs/coaching-recommendations/toast-flash-banner/accessible-banner-prototype.md#engineering-explorations-of-an-accessible-banner) done to determine how best to surface banners in the most accessible way. The answer is, it depends! You can reference the [accessible banner prototype docs](https://github.com/github/accessibility/blob/main/docs/coaching-recommendations/toast-flash-banner/accessible-banner-prototype.md#engineering-explorations-of-an-accessible-banner) for a very detailed explanation of scenarios tested.
+Banner can be used in one of two ways:
+
+* To highlight prominent information on a page.
+* To communicate feedback in response to a user action.
+
+Specifically, the latter scenario of communicating feedback requires the use of focus management or a live region announcement to guarantee that all users are immediately made aware of the feedback. This relates to [WCAG 4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html).
+
+Relevant scenarios where a focus management or a live region technique come into play to draw attention to the Banner include:
+
+* A user submits a form; An error banner is shown with a list of form errors that needs to be corrected.
+* A user submits a form; The submission successfully goes through and the form container is replaced with new content which includes a success banner.
+* A user saves a setting; An error banner is shown communicating that an unexpected error has occured and the setting was not saved.
+
+How should one accessibly surface a feedback Banner? The answer is, it depends! You can reference the [accessible banner prototype docs (GitHub Staff only)](https://github.com/github/accessibility/blob/main/docs/coaching-recommendations/toast-flash-banner/accessible-banner-prototype.md#engineering-explorations-of-an-accessible-banner) for a very detailed explanation of scenarios tested.
 
 When deciding whether to focus a banner or use a live region, consider the following:
 
-* The criticality of the information - critical information (such as an error) should be as discoverable as possible
-* Where is a user's focus when the banner appears; would focus otherwise be lost if the banner is not focused?
-* Is there already a live region on the page that can be utilized? [Dynamic live regions can have some challenges](https://github.com/github/accessibility/blob/main/docs/coaching-recommendations/toast-flash-banner/accessible-banner-prototype.md#challenges-with-dynamically-inserted-live-region), so this method requires ample testing.
+* How critical is the information?
+  * Critical information (such as an error) should be made as discoverable as possible. While moving focus to the Banner can be considered more disruptive than a live region announcement, it's more important that a user is able to discover the Banner so they can take an appropriate action. Prefer placing focus on the Banner over using a live region announcement in critical scenarios.
+  * For communicating non-critical information (such as a success), a live region announcement is sufficient in **most** scenarios. Keep in mind that a live region announcement can sometimes fail to fire and can easily be missed, so it should be reserved for use on non-critical information.
+* Does the Banner contain an action?
+  * If the Banner contains an action, placing focus on the Banner is preferable so that a screen reader user can immediately interact with the action without having to manually locate it.
+* Is there already a live region on the page that can be utilized?
+  * [Dynamic live regions can have some challenges](https://github.com/github/accessibility/blob/main/docs/coaching-recommendations/toast-flash-banner/accessible-banner-prototype.md#challenges-with-dynamically-inserted-live-region), so this method requires ample testing.
 
 Please reach out to the accessibility team if you need help determining the best approach for your use case!
 


### PR DESCRIPTION
Part of: https://github.com/github/accessibility/issues/5649

This PR expands on the accessibility guidance for Banner.