### PR TITLE
Update contribute/documentation Style guide links to public docs

### DIFF
--- a/content/guides/contribute/documentation.mdx
+++ b/content/guides/contribute/documentation.mdx
@@ -73,11 +73,11 @@ Follow the [GitHub content guidelines](https://github.com/github/brand/blob/main
   - **Don’t:** “Do not use this class”, “We are happy to see you.”
 - Exclamation points are OK, in moderation.
 
-You may also refer to the content style guide for GitHub docs (accessible to GitHub staff only), in specific:
-- [Keyboard shortcuts](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#keyboard-shortcuts)
-- [Procedural steps](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#procedural-steps)
-- [Titles](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#procedural-steps) (of articles)
-- [User interface elements](https://github.com/github/docs-internal/blob/main/contributing/content-style-guide.md#procedural-steps)
+You may also refer to the content style guide for GitHub Docs, in specific:
+- [Keyboard shortcuts](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#keyboard-shortcuts)
+- [Procedural steps](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#procedural-steps)
+- [Titles](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#titles) (of articles)
+- [User interface elements](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#user-interface-elements)
 
 ## Images and other examples
 


### PR DESCRIPTION
No need to link internal anymore, the same contributing content has been migrated to a new location and available publicly.

(As a bonus fixes two links not pointing to the right location.)