### PR TITLE
Adds guidance about how to use aria-disabled with inactive controls

### DIFF
--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -466,6 +466,22 @@ See [focus management](/guides/accessibility/focus-management) for more informat
   </Box>
 </Box>
 
+### Inactive menu items vs disabled menu items
+
+Since inactive items can still be focused and activated (for example, to show a modal with more information about an outage), they should not be conveyed as disabled using `aria-disabled`.
+
+This behavior is consistent with the behavior of inactive buttons. See the [button component accessibility guidelines](/components/button#inactive-buttons-and-aria-disabled) and [inactive button guidelines](/components/button#inactive) for more details.
+
+#### Inactive menu items:
+
+- Can be activated
+- Need to be able to get focus so screen reader users can "read" the message about it being inactive
+
+#### Disabled menu items:
+
+- Do not get focus
+- Cannot be activated
+
 ### Keyboard navigation
 
 #### Trigger button

--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -468,7 +468,7 @@ See [focus management](/guides/accessibility/focus-management) for more informat
 
 ### Inactive menu items vs disabled menu items
 
-Since inactive items can still be focused and activated (for example, to show a modal with more information about an outage), they **should not** be conveyed as disabled using `aria-disabled`.
+Inactive menu items are still focusable and may execute actions, so they **should not** be marked as disabled using `aria-disabled`. For example, they might trigger a modal with information about an outage, which is still a valid action.
 
 This behavior is consistent with the behavior of inactive buttons. See the [button component accessibility guidelines](/components/button#inactive-buttons-and-aria-disabled) and [inactive button guidelines](/components/button#inactive) for more details.
 

--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -468,7 +468,7 @@ See [focus management](/guides/accessibility/focus-management) for more informat
 
 ### Inactive menu items vs disabled menu items
 
-Since inactive items can still be focused and activated (for example, to show a modal with more information about an outage), they should not be conveyed as disabled using `aria-disabled`.
+Since inactive items can still be focused and activated (for example, to show a modal with more information about an outage), they **should not** be conveyed as disabled using `aria-disabled`.
 
 This behavior is consistent with the behavior of inactive buttons. See the [button component accessibility guidelines](/components/button#inactive-buttons-and-aria-disabled) and [inactive button guidelines](/components/button#inactive) for more details.
 

--- a/content/components/button.mdx
+++ b/content/components/button.mdx
@@ -436,6 +436,12 @@ There are rare cases where it's ok to disable a button, but it should generally 
 
 For more information on disabled controls, see GitHub's [link and button a11y guidance](https://accessibility-playbook.github.com/link-and-button-guidance#disabling-links-and-buttons) (GitHub staff only).
 
+### Inactive buttons and `aria-disabled`
+
+An [inactive](#inactive) button **should not be conveyed as disabled** with `aria-disabled` if it performs an action when activated. For example, showing a dialog with more info about why the button is inactive.
+
+An [inactive](#inactive) button **may be conveyed as disabled** with `aria-disabled` if it does not perform an action when activated.
+
 ### Descriptive buttons
 
 Labeling buttons properly lets users know what will happen when they activate the control, lessens errors, and increases confidence.


### PR DESCRIPTION
I've added docs that explain why we convey "disabled" and "inactive" controls differently to assistive technologies.

There has been some confusion about why we don't default to using `aria-disabled` with inactive controls such as buttons and action menu items.

---

I'm keeping these changes in a "draft" state until we determine whether we want to keep the implementation as-is, or update it. Related issue: https://github.com/github/primer/issues/3045