### PR TITLE
Breadcrumb docs: update image screenshots

### DIFF
--- a/content/components/breadcrumbs.mdx
+++ b/content/components/breadcrumbs.mdx
@@ -16,7 +16,7 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 <img
   width="960"
   alt="An image of the breadcrumb component"
-  src="https://user-images.githubusercontent.com/586552/204619264-27de7458-1a77-445f-bc56-83472bf30bfe.png"
+  src="https://private-user-images.githubusercontent.com/7265547/308463005-4bf1f4bd-e067-4e67-bbc4-a2d5119ccf43.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDkxMDY1MzUsIm5iZiI6MTcwOTEwNjIzNSwicGF0aCI6Ii83MjY1NTQ3LzMwODQ2MzAwNS00YmYxZjRiZC1lMDY3LTRlNjctYmJjNC1hMmQ1MTE5Y2NmNDMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMjhUMDc0MzU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZjY1M2YyYjdkMGJhOTg2MGY3NGZjYWVkNzAwYTMxYTNhNmM2MjAzMTdiZjE0ZTNhMWJjZjA2NjZkZTNmOTQzOCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.7vMwmxtuAI2bxgb3UCsrzTYBBSrUWcFfwpIAlZEiZLA"
 />
 
 ## Usage
@@ -37,7 +37,7 @@ Breadcrumbs are made of links (indicating parents), dividers, and the current pa
 <img
   width="960"
   alt="An image showing the anatomy of the breacrumb component"
-  src="https://user-images.githubusercontent.com/586552/204619263-c21f06c1-433d-4817-860b-f9d051836cd3.png"
+  src="https://private-user-images.githubusercontent.com/7265547/308463001-acb756ca-eefe-4822-a00b-3c44830857d9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDkxMDY1MzUsIm5iZiI6MTcwOTEwNjIzNSwicGF0aCI6Ii83MjY1NTQ3LzMwODQ2MzAwMS1hY2I3NTZjYS1lZWZlLTQ4MjItYTAwYi0zYzQ0ODMwODU3ZDkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMjhUMDc0MzU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MjYwMWY5MDMxMGJlNDNiZGMyMGQyMDM3YTE0OWI5YzdiNGI1NTlkMjBmNzViZGI4OGRiOWQyNTBjMzA0MDdhZSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.jLSHwK319mrpvwXWraEPh7qNjnzGrWCcUfO9OjD4bi0"
 />
 
 <Caption>Note: The space between items is set to 0px as the divider has padding built into it.</Caption>
@@ -51,7 +51,7 @@ By default the breadcrumbs component can show up to 10 items within the chain.
 <img
   width="960"
   alt="An image showing various breadcrumbs with different numbers of items in the breadcrumb chain"
-  src="https://user-images.githubusercontent.com/586552/204618645-1abd2204-f197-402d-9b01-de648ddd1812.png"
+  src="https://private-user-images.githubusercontent.com/7265547/308462997-c84faefd-d0bb-4a6e-9bfa-6565d36419e3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDkxMDY1MzUsIm5iZiI6MTcwOTEwNjIzNSwicGF0aCI6Ii83MjY1NTQ3LzMwODQ2Mjk5Ny1jODRmYWVmZC1kMGJiLTRhNmUtOWJmYS02NTY1ZDM2NDE5ZTMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMjhUMDc0MzU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NjBhMmZjM2UyMmExOWM5MzlhOGY3M2FhOThmNGRmYTU0OWY0NzQzZDM0YmRhN2NlMTcxZTNmMzM1ZWVkZjIwYSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.PM1uEXhaUwJ3wobl_mJ5uBmHEdf-8oxdd7yVfFsO-kU"
 />
 
 ## Accessibility

--- a/content/components/breadcrumbs.mdx
+++ b/content/components/breadcrumbs.mdx
@@ -16,7 +16,7 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 <img
   width="960"
   alt="An image of the breadcrumb component"
-  src="https://private-user-images.githubusercontent.com/7265547/308463005-4bf1f4bd-e067-4e67-bbc4-a2d5119ccf43.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDkxMDY1MzUsIm5iZiI6MTcwOTEwNjIzNSwicGF0aCI6Ii83MjY1NTQ3LzMwODQ2MzAwNS00YmYxZjRiZC1lMDY3LTRlNjctYmJjNC1hMmQ1MTE5Y2NmNDMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMjhUMDc0MzU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZjY1M2YyYjdkMGJhOTg2MGY3NGZjYWVkNzAwYTMxYTNhNmM2MjAzMTdiZjE0ZTNhMWJjZjA2NjZkZTNmOTQzOCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.7vMwmxtuAI2bxgb3UCsrzTYBBSrUWcFfwpIAlZEiZLA"
+  src="https://github.com/primer/design/assets/2313998/712e582d-6b51-4b03-a141-747fd31a30e9"
 />
 
 ## Usage
@@ -37,7 +37,7 @@ Breadcrumbs are made of links (indicating parents), dividers, and the current pa
 <img
   width="960"
   alt="An image showing the anatomy of the breacrumb component"
-  src="https://private-user-images.githubusercontent.com/7265547/308463001-acb756ca-eefe-4822-a00b-3c44830857d9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDkxMDY1MzUsIm5iZiI6MTcwOTEwNjIzNSwicGF0aCI6Ii83MjY1NTQ3LzMwODQ2MzAwMS1hY2I3NTZjYS1lZWZlLTQ4MjItYTAwYi0zYzQ0ODMwODU3ZDkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMjhUMDc0MzU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MjYwMWY5MDMxMGJlNDNiZGMyMGQyMDM3YTE0OWI5YzdiNGI1NTlkMjBmNzViZGI4OGRiOWQyNTBjMzA0MDdhZSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.jLSHwK319mrpvwXWraEPh7qNjnzGrWCcUfO9OjD4bi0"
+  src="https://github.com/primer/design/assets/2313998/068d9757-0a9c-46cd-a3b8-2720447d9fad"
 />
 
 <Caption>Note: The space between items is set to 0px as the divider has padding built into it.</Caption>
@@ -51,7 +51,7 @@ By default the breadcrumbs component can show up to 10 items within the chain.
 <img
   width="960"
   alt="An image showing various breadcrumbs with different numbers of items in the breadcrumb chain"
-  src="https://private-user-images.githubusercontent.com/7265547/308462997-c84faefd-d0bb-4a6e-9bfa-6565d36419e3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDkxMDY1MzUsIm5iZiI6MTcwOTEwNjIzNSwicGF0aCI6Ii83MjY1NTQ3LzMwODQ2Mjk5Ny1jODRmYWVmZC1kMGJiLTRhNmUtOWJmYS02NTY1ZDM2NDE5ZTMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIyOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMjhUMDc0MzU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NjBhMmZjM2UyMmExOWM5MzlhOGY3M2FhOThmNGRmYTU0OWY0NzQzZDM0YmRhN2NlMTcxZTNmMzM1ZWVkZjIwYSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.PM1uEXhaUwJ3wobl_mJ5uBmHEdf-8oxdd7yVfFsO-kU"
+  src="https://github.com/primer/design/assets/2313998/0007110c-0e54-4775-aeac-d8de1dfc916a"
 />
 
 ## Accessibility


### PR DESCRIPTION
Updating to include new updated screenshot images of breadcrumbs to match React and PVC styles.

Referencing the following PRs and issue: 
- https://github.com/primer/react/pull/4308
- https://github.com/primer/view_components/pull/2642
- https://github.com/github/primer/issues/3069

For example:
<img width="960" alt="1" src="https://github.com/primer/design/assets/7265547/d1d888ae-5fb3-4568-8c11-fe0d826a5c1a">
<img width="960" alt="2" src="https://github.com/primer/design/assets/7265547/7ccd4406-edaa-4872-938a-807f253f186d">
<img width="960" alt="3" src="https://github.com/primer/design/assets/7265547/383fc5e7-27ee-496b-a078-036619bd0114">
