### PR TITLE
Add tags that we can use in Figma

### DIFF
--- a/content/components/action-menu.mdx
+++ b/content/components/action-menu.mdx
@@ -5,6 +5,12 @@ figmaId: action_menu
 railsIds:
 - Primer::Alpha::ActionMenu
 description: Action menu is composed of action list and overlay patterns used for quick actions and selections.
+tags:
+  - dropdown
+  - submenu
+  - popover
+  - context
+  - context menu
 ---
 
 import {Box, Button, Heading, Link} from '@primer/react'

--- a/content/components/avatar-pair.mdx
+++ b/content/components/avatar-pair.mdx
@@ -3,6 +3,8 @@ title: Avatar pair
 description: Avatar pair is composed of two avatars, one larger one and a smaller one, overlaid slightly.
 reactId: avatar_pair
 figmaId: avatar_pair
+tags:
+  - profile picture
 ---
 
 import {Box, Text} from '@primer/react'

--- a/content/components/avatar-stack.mdx
+++ b/content/components/avatar-stack.mdx
@@ -5,6 +5,8 @@ reactId: avatar_stack
 railsIds:
 - Primer::Beta::AvatarStack
 figmaId: avatar_stack
+tags:
+  - profile picture stack
 ---
 
 import {Box, Text} from '@primer/react'

--- a/content/components/avatar.mdx
+++ b/content/components/avatar.mdx
@@ -5,6 +5,8 @@ reactId: avatar
 railsIds:
 - Primer::Beta::Avatar
 figmaId: avatar
+tags:
+  - profile picture
 ---
 
 import {Box, Text} from '@primer/react'

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -3,7 +3,9 @@ title: Banner
 description: Banner is used to highlight important information.
 componentId: banner
 railsIds: 
-- Primer::Alpha::Banner
+  - Primer::Alpha::Banner
+tags:
+  - flash
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/dialog.mdx
+++ b/content/components/dialog.mdx
@@ -8,6 +8,9 @@ railsIds:
   - Primer::Alpha::Dialog
 figmaId: dialog
 rails: https://primer.style/view-components/components/alpha/dialog
+tags:
+  - modal
+  - popup
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/flash.mdx
+++ b/content/components/flash.mdx
@@ -7,6 +7,8 @@ railsIds:
 - Primer::Alpha::Banner
 figmaId: banner
 rails: https://primer.style/view-components/components/beta/flash
+tags:
+  - banner
 ---
 
 import {Heading, Link} from '@primer/react'

--- a/content/components/image.mdx
+++ b/content/components/image.mdx
@@ -3,6 +3,9 @@ title: Image
 description: Use image to render images.
 railsIds:
 - Primer::Alpha::Image
+tags:
+  - image
+  - photo
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/nav-list.mdx
+++ b/content/components/nav-list.mdx
@@ -5,6 +5,10 @@ reactId: nav_list
 railsIds:
 - Primer::Alpha::NavList
 - Primer::Beta::NavList
+tags:
+  - navigation list
+  - menu
+  - sidebar menu
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'

--- a/content/components/progress-bar.mdx
+++ b/content/components/progress-bar.mdx
@@ -5,6 +5,10 @@ reactId: progress_bar
 railsIds:
 - Primer::Beta::ProgressBar
 figmaId: progress_bar
+tags:
+  - loading bar
+  - progress indicator
+  - completion bar
 ---
 
 import {Box} from '@primer/react'

--- a/content/components/tree-view.mdx
+++ b/content/components/tree-view.mdx
@@ -4,6 +4,13 @@ description:
   Tree view is a hierarchical list of items that may have a parent-child relationship where children can be toggled
   into view by expanding or collapsing their parent item.
 reactId: tree_view
+tags:
+  - file tree
+  - outline view
+  - folder tree
+  - expandable list
+  - directory structure
+  - hierachy viewer
 ---
 
 import {Box} from '@primer/react'


### PR DESCRIPTION
In our Figma we want to add alternative tags to some components to make them easier to find. We want to keep the source of truth for those as close as possible to our docs so we are adding them here and will use our plugin to sync them inside Figma.