### PR TITLE
Update icon-button.mdx

### DIFF
--- a/content/components/icon-button.mdx
+++ b/content/components/icon-button.mdx
@@ -43,5 +43,5 @@ Even though the label is visually hidden, a text label needs to be defined so a 
 
 <!-- TODO: link to Tooltip once it's merged -->
 
-- [Button usage](/ui-patterns/button-usage)
+- [Button usage](/components/button#usage)
 - [Button](/components/button)


### PR DESCRIPTION
The link to "ui-patterns/button-usage" is broken. Since, icon buttons and buttons are highly related we could reuse the usage section in the button component page.

We could also remove this link if we don't find the above appropriate.