### PR TITLE
Navigation component guidelines updates

### DIFF
--- a/content/components/segmented-control.mdx
+++ b/content/components/segmented-control.mdx
@@ -37,7 +37,7 @@ The primary purpose of a segmented control is to pick a value from a list of opt
 </Box>
 
 <img
-  src="https://github.com/primer/design/assets/2313998/73881beb-6f5e-4b7f-8571-1197fcaf7b4e"
+  src="https://github.com/primer/design/assets/2313998/24017512-e1e5-47bb-9fbb-dc2ffb7e9c62"
   role="presentation"
   width="456"
 />
@@ -69,24 +69,24 @@ Segmented controls may also be used to change how content in a view is rendered.
 >
   <div>
     <img
-      src="https://github.com/primer/design/assets/2313998/d90da101-1c5f-4ad7-aae7-7de8c4ab2263"
-      role="presentation"
+      src="https://github.com/primer/design/assets/2313998/dbec961f-64b2-4701-8d81-d178dd6ab206"
+      alt="A screenshot of a GitHub discussions list with the segmented segmented control for sorting highlighted. The sort options are 'Oldest', 'Newest', and 'Top'."
       width="456"
     />
     <Caption>As a sort control</Caption>
   </div>
   <div>
     <img
-      src="https://github.com/primer/design/assets/2313998/78374240-ed97-4245-96c1-e64fd578b513"
-      role="presentation"
+      src="https://github.com/primer/design/assets/2313998/6d3ddfc8-f8e9-44ca-ac5f-43cbdaaf8969"
+      alt="A screenshot of the GitHub organization insights page with the segmented control for filtering highlighted. The options are 'All results' and 'Open security advisories'. "
       width="456"
     />
     <Caption>As a filter control</Caption>
   </div>
   <div>
     <img
-      src="https://github.com/primer/design/assets/2313998/93fd200f-adaf-43df-bfc7-303f9004fe5b"
-      role="presentation"
+      src="https://github.com/primer/design/assets/2313998/b56ef0a9-45b6-4cb0-9f7e-10921967ae36"
+      alt="A screenshot of the GitHub billing dashboard with a chart showing costs. The segmented control to switch between the chart type is highlighted. The options are 'Line', 'Area', and 'Bar'"
       width="456"
     />
     <Caption>As a content formatting picker</Caption>
@@ -94,14 +94,6 @@ Segmented controls may also be used to change how content in a view is rendered.
 </Box>
 
 If selecting a segment changes the URL, the segments should be rendered as `<a>` tags.
-
-#### Decision tree
-
-<img
-  src="https://github.com/primer/design/assets/2313998/f4014d7a-e9ed-4196-aae0-7ffb1f4faa26"
-  alt="Decision tree titled 'I think I want to use a segmented control.' It begins with the question 'Is the selected value immediately saved and applied?' If 'Yes,' the tree recommends 'Use a SegmentedControl with button segments.' If 'No,' it asks 'Does the selection switch content visibility like tabs?' If 'Yes,' it recommends 'Use a SegmentedControl with button segments.' If 'No,' it asks 'Is it filtering out content from a full list?' If 'Yes,' it asks 'Is there a segment like All that removes the filter?' If 'No,' it recommends 'Use a SegmentedControl with button segments.' If 'Yes,' the tree ends. If 'No,' it asks 'Does the selection change the formatting of content?' If 'Yes,' it recommends 'Use a SegmentedControl with button segments.' If 'No,' it asks 'Does the URL change when making a selection?' If 'Yes,' it recommends 'Use a UnderlinePanels instead.' If 'No,' the tree ends. If 'No,' to the URL change from the first decision point, it recommends 'Use a UnderlineNav instead.'"
-  width="960"
-/>
 
 ## Content
 

--- a/content/components/segmented-control.mdx
+++ b/content/components/segmented-control.mdx
@@ -527,8 +527,8 @@ Unlike radio groups and toolbars, the left and right arrow keys do not change th
 
 ## Related links
 
-<!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
-- [Saving](/ui-patterns/saving)
 - [Radio group](/components/radio-group)
 - [Underline nav](/components/underline-nav)
 - [Underline panels](/components/underline-panels)
+- [Navigation](/ui-patterns/navigation)
+- [Saving](/ui-patterns/saving)

--- a/content/components/segmented-control.mdx
+++ b/content/components/segmented-control.mdx
@@ -17,38 +17,97 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ## Anatomy
 
-![A diagram of a segmented control with three buttons. The labeled parts of the segmented control are: the selected third button, the icon in the second button, and the text label in the second button.](https://user-images.githubusercontent.com/2313998/182705417-c0e1dddb-6c6b-4746-9a02-0e3a9eb17017.png)
+![A diagram of a segmented control with three buttons. The labeled parts of the segmented control are: the selected third button, the icon in the second button, and the text label in the second button.](https://github.com/primer/design/assets/2313998/c5bf30c6-d66a-4708-90da-b5bfac3c034b)
 
 ## Usage
 
-A segmented control should only be used to change a value; it's similar to a group of radio inputs.
+### For implicitly saved settings
 
-A segmented control should not be used as a form of navigation: use tabs instead. If your primary use case is to hide or show content, that's a good hint that you should reach for tabs or another navigation pattern instead.
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
 
-<DoDontContainer>
-  <Do>
+<Box flex={1}>
+
+The primary purpose of a segmented control is to pick a value from a list of options and immediately apply that selection. It's similar to a group of radio inputs except radio group selections need to be explicitly saved via form submission.
+
+</Box>
+
+<img
+  src="https://github.com/primer/design/assets/2313998/73881beb-6f5e-4b7f-8571-1197fcaf7b4e"
+  role="presentation"
+  width="456"
+/>
+
+</Box>
+
+For more information about explicit and automatic save patterns, see the [saving pattern guidleines](/ui-patterns/saving).
+
+### To toggle content visibility
+
+<Note>
+
+  The current implementations of our segmented control do not support rendering segments as links (`<a>` tags).
+  Continue to avoid using segmented controls that change the URL until we have a solution for rendering segments as links.
+
+</Note>
+
+Segmented controls may also be used to change how content in a view is rendered. The following use cases are an acceptable use for a segmented control:
+
+- **Sort control**: Activating a segment affects the visibility of items in a list, and there is a segment that shows the full list.
+- **Filter control**: Activating a segment affects the order of a list of items.
+- **Content formatting picker**: Activating a segment changes the formatting of the same content.
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <div>
     <img
-      src="https://user-images.githubusercontent.com/2313998/200646211-c7dd9308-76f8-46b5-a189-4ff332e3921f.png"
+      src="https://github.com/primer/design/assets/2313998/d90da101-1c5f-4ad7-aae7-7de8c4ab2263"
       role="presentation"
       width="456"
     />
-    <Caption>Use tabs for navigation or toggling content visibility.</Caption>
-  </Do>
-  <Dont>
+    <Caption>As a sort control</Caption>
+  </div>
+  <div>
     <img
-      src="https://user-images.githubusercontent.com/2313998/200646212-f17f7da8-276a-4f0e-80eb-d561fe250caf.png"
+      src="https://github.com/primer/design/assets/2313998/78374240-ed97-4245-96c1-e64fd578b513"
       role="presentation"
       width="456"
     />
-    <Caption>Don't use a segmented control for navigation or toggling content visibility.</Caption>
-  </Dont>
-</DoDontContainer>
+    <Caption>As a filter control</Caption>
+  </div>
+  <div>
+    <img
+      src="https://github.com/primer/design/assets/2313998/93fd200f-adaf-43df-bfc7-303f9004fe5b"
+      role="presentation"
+      width="456"
+    />
+    <Caption>As a content formatting picker</Caption>
+  </div>
+</Box>
+
+If selecting a segment changes the URL, the segments should be rendered as `<a>` tags.
+
+#### Decision tree
+
+<img
+  src="https://github.com/primer/design/assets/2313998/f4014d7a-e9ed-4196-aae0-7ffb1f4faa26"
+  alt="Decision tree titled 'I think I want to use a segmented control.' It begins with the question 'Is the selected value immediately saved and applied?' If 'Yes,' the tree recommends 'Use a SegmentedControl with button segments.' If 'No,' it asks 'Does the selection switch content visibility like tabs?' If 'Yes,' it recommends 'Use a SegmentedControl with button segments.' If 'No,' it asks 'Is it filtering out content from a full list?' If 'Yes,' it asks 'Is there a segment like All that removes the filter?' If 'No,' it recommends 'Use a SegmentedControl with button segments.' If 'Yes,' the tree ends. If 'No,' it asks 'Does the selection change the formatting of content?' If 'Yes,' it recommends 'Use a SegmentedControl with button segments.' If 'No,' it asks 'Does the URL change when making a selection?' If 'Yes,' it recommends 'Use a UnderlinePanels instead.' If 'No,' the tree ends. If 'No,' to the URL change from the first decision point, it recommends 'Use a UnderlineNav instead.'"
+  width="960"
+/>
 
 ## Content
 
-### Buttons
+### Segments
 
-A segmented control should have 2–5 choices with text labels, or up to 6 icon-only buttons. Too many choices can be difficult to parse and take up too much horizontal space. If there are more than 5 choices, use another choice selection pattern such as a group of radio inputs or a dropdown menu.
+A segmented control should have 2–5 choices with text labels, or up to 6 icon-only segments. Too many choices can be difficult to parse and take up too much horizontal space. If there are more than 5 choices, use another choice selection pattern such as a group of radio inputs or a dropdown menu.
 
 <DoDontContainer>
   <Do>
@@ -57,7 +116,7 @@ A segmented control should have 2–5 choices with text labels, or up to 6 icon-
       role="presentation"
       width="456"
     />
-    <Caption>Use a segmented control for picking from 5 (6 for icon-only buttons) or fewer options.</Caption>
+    <Caption>Use a segmented control for picking from 5 (6 for icon-only segments) or fewer options.</Caption>
   </Do>
   <Dont>
     <img
@@ -91,7 +150,7 @@ A segmented control should have 2–5 choices with text labels, or up to 6 icon-
   </Dont>
 </DoDontContainer>
 
-### Button icons
+### Segment icons
 
 <Box
   display="flex"
@@ -100,8 +159,7 @@ A segmented control should have 2–5 choices with text labels, or up to 6 icon-
   sx={{gap: 3}}
 >
   <Text as="p" mt="0">
-    An icon can be rendered in a segmented control button as a visual cue to help users understand the choice that
-    button represents.
+    Icons can be rendered in each segment as a visual cue to help users understand their options.
   </Text>
   <img
     src="https://user-images.githubusercontent.com/2313998/182705434-baf679ea-14de-4b62-b83f-f833c1058694.png"
@@ -112,14 +170,14 @@ A segmented control should have 2–5 choices with text labels, or up to 6 icon-
 
 #### Effective visual cues
 
-Be consistent with the way visual cues are used in each button of the segmented control. Use either all icons, all text labels, or all text labels with icons.
+Be consistent with the way visual cues are used in each segment. Use either all icons, all text labels, or all text labels with icons.
 
 Do not change icons to communicate state.
 
 <DoDontContainer>
   <Do>
     <img
-      src="https://user-images.githubusercontent.com/2313998/182705431-fe063f8f-6678-44b7-81a4-9ed3a6968a1e.png"
+      src="https://github.com/primer/design/assets/2313998/4b1bfdea-d222-4a2d-a60f-a6adfb7d33f1"
       role="presentation"
       width="456"
     />
@@ -127,7 +185,7 @@ Do not change icons to communicate state.
   </Do>
   <Dont>
     <img
-      src="https://user-images.githubusercontent.com/2313998/182705433-d5533bac-8f7c-4a9d-8501-a304cdba4619.png"
+      src="https://github.com/primer/design/assets/2313998/777d35a1-37e8-4198-b9a3-d91a72a22de2"
       role="presentation"
       width="456"
     />
@@ -142,7 +200,7 @@ Do not change icons to communicate state.
       role="presentation"
       width="456"
     />
-    <Caption>Keep the visual cues in each button consistent.</Caption>
+    <Caption>Keep the visual cues in each segment consistent.</Caption>
   </Do>
   <Dont>
     <img
@@ -150,11 +208,11 @@ Do not change icons to communicate state.
       role="presentation"
       width="456"
     />
-    <Caption>Don't mix visual cues between buttons.</Caption>
+    <Caption>Don't mix visual cues between segments.</Caption>
   </Dont>
 </DoDontContainer>
 
-#### Icon-only buttons
+#### Icon-only segments
 
 Use icons without a visible text label sparingly, and only with icons that are easily understood by an average GitHub user. When a segment has an icon without a visible text label, the text label should be shown in a tooltip.
 
@@ -177,9 +235,9 @@ Use icons without a visible text label sparingly, and only with icons that are e
   </Dont>
 </DoDontContainer>
 
-### Button label text
+### Segment label text
 
-Segmented control button labels should be nouns or noun phrases that succinctly describe the choice. Button labels may not wrap to multiple lines.
+Segmented control segment labels should be nouns or noun phrases that succinctly describe the choice. Segment labels may not wrap to multiple lines.
 
 <DoDontContainer>
   <Do>
@@ -250,7 +308,6 @@ A segmented control does not require a "Save" button to apply the selection. Whe
 #### Single-column
 
 <Box
-  as="figure"
   display="flex"
   alignItems="flex-start"
   flexDirection={['column-reverse', 'column-reverse', 'column-reverse', 'column-reverse', 'row']}
@@ -258,44 +315,43 @@ A segmented control does not require a "Save" button to apply the selection. Whe
   mb={3}
   sx={{gap: 3}}
 >
-  <Box as="figcaption" mt="0">
-    <Text as="h4" fontSize={2} fontWeight="bold" m={0}>
-      Single-column
-    </Text>
-    <Text as="p" mt="0">
-      A single-column layout is the same way form controls (for example, text inputs) are layed out. The single-column
-      layout is useful for preserving horizontal space.
-    </Text>
-  </Box>
+
+  A single-column layout is the same way form controls (for example, text inputs) are layed out. The single-column layout is useful for preserving horizontal space.
+
   <img
-    src="https://user-images.githubusercontent.com/2313998/182710235-f26b3fa2-fac5-47ff-8334-034d62abb021.png"
+    src="https://github.com/primer/design/assets/2313998/397dad08-8ae4-40fb-9b0b-c41208057161"
     role="presentation"
     width="456"
   />
 </Box>
-
-A single-column layout is the same way form controls (for example, text inputs) are layed out. The single-column layout is useful for preserving horizontal space.
 
 #### Two-column
-
-<Box display="flex" mb={3} flexWrap="wrap" sx={{gap: 3}}>
-  <img
-    src="https://user-images.githubusercontent.com/2313998/182705438-d16f8eeb-8809-4d48-9c3c-528b637d7c2c.png"
-    role="presentation"
-    width="456"
-  />
-  <img
-    src="https://user-images.githubusercontent.com/2313998/182705440-b08a9a2c-0782-4468-9d83-1d8a7f8f77a9.png"
-    role="presentation"
-    width="456"
-  />
-</Box>
 
 A two-column layout can be used to:
 
 - Align the control with adjacent elements
 - Conserve vertical space
 - Group related controls in a way that is easy to scan
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+  <div>
+    <img
+      src="https://github.com/primer/design/assets/2313998/a9a9230c-406f-42dc-9d41-eb160e00c5e7"
+      role="presentation"
+    />
+  </div>
+  <div>
+    <img
+      src="https://github.com/primer/design/assets/2313998/cb9a26c6-ad3b-42ba-b80f-fd921670f8d6"
+      role="presentation"
+    />
+  </div>
+</Box>
 
 ### Fill available width
 
@@ -476,3 +532,11 @@ Unlike radio groups and toolbars, the left and right arrow keys do not change th
 ### Known accessibility issues (GitHub staff only)
 
  <AccessibilityLink label="SegmentedControl"/>
+
+## Related links
+
+<!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
+- [Saving](/ui-patterns/saving)
+- [Radio group](/components/radio-group)
+- [Underline nav](/components/underline-nav)
+- [Underline panels](/components/underline-panels)

--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -38,7 +38,7 @@ If you want to use this pattern without any linked items, use the [underline pan
 - **Counter (optional)**: Displays a count next to the label.
 - **Overflow menu**: A disclosure menu that displays additional items when there are too many to fit in the available space.
 
-#### Label text
+### Label text
 
 The title of the view associated with that tab. Keep labels clear, short, and concise.
 
@@ -63,7 +63,7 @@ Do not rely on leading visuals, tooltips, or supplemental descriptions to commun
   </Dont>
 </DoDontContainer>
 
-#### Leading icons
+### Leading icons
 
 Use an [Octicon](/foundations/icons) to improve the scannability of common items, but only when relevant. When adding leading icons, all items in the navigation should have one.
 
@@ -90,7 +90,7 @@ Label text is required. Leading icons are just a "bonus" affordance and should n
   </Dont>
 </DoDontContainer>
 
-#### Counters
+### Counters
 
 You may include a counter to indicate the number of related resources contained in the desitination page, such as the number of open issues.
 

--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -1,6 +1,6 @@
 ---
 title: Underline nav
-description: The UnderlineNav is used to display navigation.
+description: The UnderlineNav is used to display navigation in a horizontal tabbed format.
 componentId: underline_nav
 reactId: underline_nav
 railsIds:
@@ -8,13 +8,24 @@ railsIds:
 figma: https://www.figma.com/file/GCvY3Qv8czRgZgvl1dG6lp/Primer-Web?node-id=18843-67449&t=XqqSolC6AzRO9nae-11
 ---
 
+import {Box} from '@primer/react'
 import ComponentLayout from '~/src/layouts/component-layout'
 export default ComponentLayout
 import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ## Usage
 
-The underline nav is used to provide navigation links to related views for the user's current context. It is typically used as primary navigation at the top of the page or as secondary or tertiary navigation when nested in views with a [nav list](/components/nav-list).
+The underline nav provides navigation links to let users switch between 2 or more related views without leaving their current context.
+
+If you want to use this pattern without any linked items, use the [underline panels](/components/underline-panels) component.
+
+### Best practices
+
+- Each tab panel should have discrete content with a unique URL, not just different formats to view the same content.
+- One of the tabs should be selected by default when the user loads the page.
+- Avoid overwhelming the user with too many tabs. Instead consider a navigation structure like a [nav list](/components/nav-list) that's meant to handle more links.
+- Each view should have enough information so the user can complete their tasks without switching back and forth between tabs.
+- Views should be able to be navigated in any order. This is not a pattern for navigating stepped flows.
 
 ## Anatomy
 
@@ -37,11 +48,53 @@ The underline nav is composed of a list of items. Each item is a link that can b
 
 The title of the view associated with that tab. Keep labels clear, short, and concise.
 
+Do not rely on leading visuals, tooltips, or supplemental descriptions to communicate what the tab represents.
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://github.com/primer/design/assets/2313998/b96d853e-3a03-47c7-854b-cd69914f6d80"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Use label text that clearly communicates what the tab represents.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://github.com/primer/design/assets/2313998/8d703e04-73f2-4d0c-898d-3a136d193af3"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't rely on supplemental content to communicate what the tab represents.</Caption>
+  </Dont>
+</DoDontContainer>
+
 #### Leading icons
 
 Use an [Octicon](/foundations/icons) to improve the scannability of common items, but only when relevant. When adding leading icons, all items in the navigation should have one.
 
 Make sure that icons used are consistent across views, and that they are not repeated for different navigations across the product.
+
+Label text is required. Leading icons are just a "bonus" affordance and should not be the only way to identify the navigation item.
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://github.com/primer/design/assets/2313998/58b54936-37d4-41d6-a263-7ec49993deb0"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Use leading icons as an enhancement.</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://github.com/primer/design/assets/2313998/ad989a92-f078-454b-9649-7add73785c92"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't exclude label text.</Caption>
+  </Dont>
+</DoDontContainer>
 
 #### Counters
 
@@ -49,20 +102,81 @@ You may include a counter to indicate the number of related resources contained 
 
 When loading multiple counters asynchronously, wait for all the data to be ready before displaying the counters, so you can avoid multiple layout shifts. Use the counter loading state while waiting for the data.
 
+## Hierarchy
+
+Tabs may be used to switch between content at different levels of hierarchy:
+
+- subpages within a larger context
+- content panels within a section of a page
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+    <div>
+        <img
+            src="https://github.com/primer/design/assets/2313998/bd6732fc-3e62-4e2e-afc2-d3312a22e8c2"
+            alt="A page with three top-level tabs. Then, a placeholder heading and description followed by more tabs to separate subpage content. Top-level tabs are highlighted."
+            width="456"
+        />
+        <Caption>Subpage tabs</Caption>
+    </div>
+    <div>
+        <img
+            src="https://github.com/primer/design/assets/2313998/314e0800-3dcc-4bb6-91de-7608db202a0c"
+            alt="A page with three top-level tabs. Then, a placeholder heading and description followed by more tabs to separate subpage content. Inner subpage content tabs are highlighted."
+            width="456"
+        />
+        <Caption>Page content tabs</Caption>
+    </div>
+</Box>
+
+Avoid more than 2 levels of tab hierarchy. If you need more than 2 levels of hierarchy, consider:
+
+- rethinking your information architecture
+- removing a layer of hierarchy and putting more content on the page
+- using a [nav list](/components/nav-list) for a level of hierarchy
+
+### Stacking
+
+Don't stack multiple underline navs or underline panels directly on top of eachother to convey hierarchical levels of navigation. Instead, consider using a [nav list](/components/nav-list) for a higher level of hierarchy.
+
+<DoDontContainer>
+  <Do>
+    <img
+      src="https://github.com/primer/design/assets/2313998/3b9c4160-3f9d-4a28-854f-9d50dcce4aaa"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Limit the levels of tab hierarchy</Caption>
+  </Do>
+  <Dont>
+    <img
+      src="https://github.com/primer/design/assets/2313998/72a9b78d-3227-48ab-a62c-bb44ed4d3be2"
+      role="presentation"
+      width="456"
+    />
+    <Caption>Don't stack tabs or create deep levels of tab hierarchy</Caption>
+  </Dont>
+</DoDontContainer>
+
 ## Layout
 
 ### Placement
 
-The underline nav has two possible main placements depending on its intended usage:
-
-- As primary navigation: place it at the top of the page. Ensure any secondary and tertiary navigation is nested under the underline nav.
-- As secondary or tertiary navigation: place it above the main content of the page.
-
-In either scenarios, avoid stacking multiple uderline navs to display multiple levels of navigation.
+Underline nav should be placed directly above the content it affects.
 
 ### Alignment
 
 Align the the underline nav to the left and, when possible, make the component span the available width.
+
+The left and right edges of the underline nav should not extend beyond the width of the content it affects.
+
+### Clear beginning and end
+
+It should be clear where the tab-switchable content begins and ends. Use spacing, borders, headings, or other visual cues to make it clear where the tab-switchable content ends.
 
 ### Responsive design
 

--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -1,6 +1,6 @@
 ---
 title: Underline nav
-description: The UnderlineNav is used to display navigation in a horizontal tabbed format.
+description: The underline nav is used to display navigation in a horizontal tabbed format.
 componentId: underline_nav
 reactId: underline_nav
 railsIds:
@@ -31,18 +31,12 @@ If you want to use this pattern without any linked items, use the [underline pan
 
 ![Anatomy of the UnderlineNav component](https://user-images.githubusercontent.com/175638/186432408-c2479dd2-31fe-4261-9f9a-e67d49b28e72.png)
 
-- **Item**: A navigation link.
+- **Item**: Tabs to switch between views when activated.
 - **Current item**: The item currently selected is highlighted with an underline.
-- **Label**: Describes the navigation item.
+- **Label text**: Describes the navigation item.
 - **Leading icon (optional)**: An icon that identifies the navigation item.
 - **Counter (optional)**: Displays a count next to the label.
 - **Overflow menu**: A disclosure menu that displays additional items when there are too many to fit in the available space.
-
-## Options
-
-### Item
-
-The underline nav is composed of a list of items. Each item is a link that can be selected to navigate to a different page in the current context.
 
 #### Label text
 
@@ -192,10 +186,10 @@ Set `aria-current` to `"page"` to indicate that the item represents the current 
 
 Items can be activated using a cursor or keyboard
 
-| Key(s)                                                                                                                                                    | Description                   |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| <Box as="kbd" backgroundColor="canvas.subtle" borderRadius={1} borderColor="border.default" borderWidth={1} borderStyle="solid" py={1} px={2}>Enter</Box> | Activates the focused item.   |
-| <Box as="kbd" backgroundColor="canvas.subtle" borderRadius={1} borderColor="border.default" borderWidth={1} borderStyle="solid" py={1} px={2}>Tab</Box>   | Moves focus to the next item. |
+| Key(s)                           | Description                   |
+| -------------------------------- | ----------------------------- |
+| <KeyboardKey>Enter</KeyboardKey> | Activates the focused item.   |
+| <KeyboardKey>Tab</KeyboardKey>   | Moves focus to the next item. |
 
 ### Known accessibility issues (GitHub staff only)
 
@@ -203,5 +197,7 @@ Items can be activated using a cursor or keyboard
 
 ## Related links
 
+<!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
 - [Nav list](/components/nav-list)
-- [Tab nav](/components/tab-nav)
+- [Segmented control](/components/segmented-control)
+- [Underline panels](/components/underline-panels)

--- a/content/components/underline-nav.mdx
+++ b/content/components/underline-nav.mdx
@@ -197,7 +197,7 @@ Items can be activated using a cursor or keyboard
 
 ## Related links
 
-<!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
 - [Nav list](/components/nav-list)
 - [Segmented control](/components/segmented-control)
 - [Underline panels](/components/underline-panels)
+- [Navigation](/ui-patterns/navigation)

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -82,6 +82,6 @@ Underline panels' tabs follow the [automatic activation pattern](https://www.w3.
 
 ## Related links
 
-<!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
 - [Segmented control](/components/segmented-control)
 - [Underline panels](/components/underline-panels)
+- [Navigation](/ui-patterns/navigation)

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -1,23 +1,87 @@
 ---
 title: UnderlinePanels
-description: Use UnderlinePanels to style tabs with an associated panel and an underlined selected state.
+description: The underline panels are used to break related content into tabbed panels.
 railsIds:
 - Primer::Alpha::UnderlinePanels
 ---
 
 import ComponentLayout from '~/src/layouts/component-layout'
-import {Link, Text} from '@primer/react'
-import {Link as GatsbyLink} from 'gatsby'
+import {Box} from '@primer/react'
 export default ComponentLayout
 import {AccessibilityLink} from '~/src/components/accessibility-link'
 
-<Note variant="warning">
-  <Text sx={{display: 'block', fontWeight: 'bold', mb: 2}}>Guidelines for this component are in progress</Text>
-  <Text>Interested in contributing? Review the guidelines for <Link as={GatsbyLink} to="/guides/contribute/documentation#documenting-components">writing component documentation</Link> and open a pull request in our <Link as={GatsbyLink} to="https://github.com/primer/design">documentation repository.</Link></Text>
+<Note>
+
+  The [underline nav](/components/underline-nav) guidelines cover the design guidelines not mentioned here.
+
+  The guidelines on this page only highlight the differences between underline panels and underline nav.
+
 </Note>
 
+## Usage
+
+Underlined panels let users switch between 2 or more related panels of content without changing the URL or leaving their current context.
+
+If you want to use this pattern for tabs that change the URL when activated, use the [underline nav](/components/underline-nav) component instead.
+
+### Best practices
+
+- One of the tabs should be selected by default when the user loads the page.
+- Avoid overwhelming the user with too many tabs. If you have too many tabs, try grouping your content into broader categories or exposing more of the content on the page without requiring the user to click into a tab.
+- Each view should have enough information so the user can complete their tasks without switching back and forth between tabs.
+- Views should be able to be navigated in any order. This is not a pattern for navigating stepped flows.
+
 ## Accessibility
+
+<Box
+  display="flex"
+  alignItems="flex-start"
+  flexDirection={['column', 'column', 'column', 'column', 'row']}
+  sx={{gap: 3}}
+>
+
+<div>
+
+Underline panels are made of the following ARIA roles:
+
+- `tablist`: the container wrapping the tabs
+- `tab`: each individual tab
+- `tabpanel`: the container wrapping the content associated with each tab
+
+The active tab is conveyed to assistive technologies using the `aria-selected` attribute. Each tab is associated with it's corresponding panel using the `aria-controls` attribute.
+
+</div>
+
+<img
+  width="456"
+  role="presentation"
+  src="https://github.com/primer/design/assets/2313998/63c0312a-1e74-4990-b4bf-1795e5f3640d"
+/>
+
+</Box>
+
+### Keyboard navigation
+
+Underline panels' tabs follow the [automatic activation pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/). This means that when a tab receives focus, the tab is activated and the associated panel is displayed.
+
+<!-- TODO: revise this guidance once we change to the manual activation pattern. This was discussed in A11y Office Hours on 02/27/2024: https://github.com/github/accessibility/issues/5623#issuecomment-1967930432 -->
+<!-- Underline panels' tabs follow the [manual activation pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/). This decision was made so users don't unintentionally trigger the side effects of rendering a new tab panel while they're navigating the tab list. For example, activating a new tab could trigger a network request to fetch new content. -->
+
+| Key(s)                                                               | Description                                                                                                                                                                              |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <KeyboardKey>Enter</KeyboardKey> or <KeyboardKey>Space</KeyboardKey> | Activates the focused tab.                                                                                                                                                               |
+| <KeyboardKey>Tab</KeyboardKey>                                       | When focus moves into the tab list, focus goes to the active tab. <br /> When the tab list contains focus, moves focus to the next element in the page tab sequence outside the tablist. |
+| <KeyboardKey>Arrow&nbsp;Left</KeyboardKey>                           | Moves focus to the previous tab. If focus is on the first tab, focus moves to the last tab. <br /> The focused tab is activated.                                                         |
+| <KeyboardKey>Arrow&nbsp;Right</KeyboardKey>                          | Moves focus to the next tab. If focus is on the last tab, focus moves to the first tab. <br /> The focused tab is activated.                                                             |
+| <KeyboardKey>Home</KeyboardKey>                                      | Moves focus to the first tab and activates it.                                                                                                                                           |
+| <KeyboardKey>End</KeyboardKey>                                       | Moves focus to the last tab and activates it.                                                                                                                                            |
 
 ### Known accessibility issues (GitHub staff only)
 
  <AccessibilityLink label="UnderlinePanels"/>
+
+ ## Related links
+
+<!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
+- [Segmented control](/components/segmented-control)
+- [Underline panels](/components/underline-panels)

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -80,7 +80,7 @@ Underline panels' tabs follow the [automatic activation pattern](https://www.w3.
 
  <AccessibilityLink label="UnderlinePanels"/>
 
- ## Related links
+## Related links
 
 <!-- TODO: add this back in once the navigation guidelines PR merges - [Navigation](/ui-patterns/navigation) -->
 - [Segmented control](/components/segmented-control)

--- a/src/@primer/gatsby-theme-doctocat/mdx-components.js
+++ b/src/@primer/gatsby-theme-doctocat/mdx-components.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import CustomVideoPlayer from '../../CustomVideoPlayer'
+import KeyboardKey from '../../KeyboardKey'
 import ImageBox from './components/ImageBox'
 import StorybookEmbed from '../../components/storybook-embed'
 import {ChildPages} from '../../components/child-pages'
@@ -14,4 +15,4 @@ const Table = props => (
   </Box>
 )
 
-export default {table: Table, CustomVideoPlayer, ImageBox, StorybookEmbed, ChildPages}
+export default {table: Table, CustomVideoPlayer, ImageBox, KeyboardKey, StorybookEmbed, ChildPages}

--- a/src/KeyboardKey.tsx
+++ b/src/KeyboardKey.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import {Box} from '@primer/react'
+
+const KeyboardKey = ({children}: {children: React.ReactNode}) => {
+  return (
+    <Box
+      as="kbd"
+      backgroundColor="canvas.subtle"
+      borderRadius={1}
+      borderColor="border.default"
+      borderWidth={1}
+      borderStyle="solid"
+      py={1}
+      px={2}
+    >
+        {children}
+    </Box>
+  )
+}
+
+export default KeyboardKey


### PR DESCRIPTION
This is a follow-up to https://github.com/primer/design/pull/744

I've updated the guidance for UnderlineNav and SegmentedControl, and added guidance for UnderlinePanels.

More updates will be made to SegmentedControl guidance once we implement the component changes needed to support tab-like behavior.