### PR TITLE
Use the `docsId` field to group multiple versions of a React component

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -245,7 +245,7 @@ async function sourcePrimerReactData({actions, createNodeId, createContentDigest
 
   for (const component of Object.values(content.components)) {
     const newNode = {
-      ...{...component, componentId: component.id},
+      ...{...component, componentId: component.docsId || component.id},
       id: createNodeId(`react-${component.id}`),
       internal: {
         type: 'ReactComponent',
@@ -450,6 +450,7 @@ async function createComponentPages({actions, graphql}) {
       allReactComponent {
         nodes {
           reactId: componentId
+          docsId
           status
         }
       }


### PR DESCRIPTION
This PR allows a `docsId` field to group multiple versions of a React component together into a single page. The `docsId` concept is motivated by the need to generate a single page for the `Tooltip` component, which has two versions named `tooltip` and `tooltip_v2`.