### PR TITLE
Read import path from component json

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -378,7 +378,6 @@ exports.createPages = async ({actions, graphql}) => {
           name
           status
           a11yReviewed
-          importPath
           stories {
             id
             code
@@ -621,7 +620,6 @@ exports.onPostBuild = async ({graphql}) => {
           name
           status
           a11yReviewed
-          importPath
           stories {
             id
             code

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -378,6 +378,7 @@ exports.createPages = async ({actions, graphql}) => {
           name
           status
           a11yReviewed
+          importPath
           stories {
             id
             code
@@ -620,6 +621,7 @@ exports.onPostBuild = async ({graphql}) => {
           name
           status
           a11yReviewed
+          importPath
           stories {
             id
             code

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -44,6 +44,7 @@ export const query = graphql`
       name
       status
       a11yReviewed
+      importPath
       stories {
         id
         code
@@ -76,8 +77,8 @@ export const query = graphql`
 `
 
 export default function ReactComponentLayout({data}) {
-  const {name, status, a11yReviewed, props: componentProps, subcomponents, stories} = data.reactComponent
-  const importStatement = `import {${name}} from '@primer/react${status === 'draft' ? '/drafts' : ''}'`
+  const {name, status, a11yReviewed, importPath, props: componentProps, subcomponents, stories} = data.reactComponent
+  const importStatement = `import {${name}} from ${importPath}`
 
   const tableOfContents = {
     items: [

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -78,7 +78,11 @@ export const query = graphql`
 
 export default function ReactComponentLayout({data}) {
   const {name, status, a11yReviewed, importPath, props: componentProps, subcomponents, stories} = data.reactComponent
-  const importStatement = `import {${name}} from '${importPath}'`
+  // This is a temporary and very hacky fix to make sure TooltipV2 has the correct component name in the import path.
+  // We will remove this once https://github.com/primer/react/pull/4483 is merged and release.
+  let componentName = name
+  if (name === 'TooltipV2') componentName = 'Tooltip'
+  const importStatement = `import {${componentName}} from '${importPath}'`
 
   const tableOfContents = {
     items: [

--- a/src/layouts/react-component-layout.tsx
+++ b/src/layouts/react-component-layout.tsx
@@ -78,7 +78,7 @@ export const query = graphql`
 
 export default function ReactComponentLayout({data}) {
   const {name, status, a11yReviewed, importPath, props: componentProps, subcomponents, stories} = data.reactComponent
-  const importStatement = `import {${name}} from ${importPath}`
+  const importStatement = `import {${name}} from '${importPath}'`
 
   const tableOfContents = {
     items: [


### PR DESCRIPTION
Having a new next entry point made the current auto generated component import path invalid for next components such as tooltip. Discussed this with @camertron and instead of generating the import path based on the component status, we think adding another `importPath` as a field on the component.docs.json and read the import path directly from field is less prune to invalid path generation. This PR alters how we form the import path.


Associated Primer React PR: https://github.com/primer/react/pull/4461