### PR TITLE
feat: add analytics to gatsby-browser config

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,9 +8,9 @@ exports.wrapPageElement = ({element, props}) => {
     <>
       <Helmet>
         <meta name="ha-url" content="https://collector.githubapp.com/primer/collect" />
+        <script src="https://analytics.githubassets.com/hydro-marketing.min.js" />
       </Helmet>
       {element}
-      <script src="https://analytics.githubassets.com/hydro-marketing.min.js" />
     </>
   )
 }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const React = require('react')
+const {default: Helmet} = require('react-helmet')
+
+exports.wrapPageElement = ({element, props}) => {
+  return (
+    <>
+      <Helmet>
+        <meta name="ha-url" content="https://collector.githubapp.com/primer/collect" />
+      </Helmet>
+      {element}
+      <script src="https://analytics.githubassets.com/hydro-marketing.min.js" />
+    </>
+  )
+}


### PR DESCRIPTION
This is a follow up to: https://github.com/primer/design/pull/765 to see if we can add analytics using `gatsby-browser.js` and the `wrapPageElement` helper there. This helps to prevent having to implement custom layouts and export them in content files.