### PR TITLE
Change sx migration guide for padding sizes

### DIFF
--- a/content/foundations/primitives/migrating.mdx
+++ b/content/foundations/primitives/migrating.mdx
@@ -21,9 +21,9 @@ Use these values for the internal `padding` (including `p`, `px`, `py`, `pr`, et
 --- | --- | ---
 `0` | 0px | `0`
 `1` | 4px | `--base-size-4`
-`2` | 8px | `--stack-padding-condensed`
-`3` | 16px | `--stack-padding-normal`
-`4` | 24px | `--stack-padding-spacious`
+`2` | 8px | `--base-size-8`
+`3` | 16px | `--base-size-16`
+`4` | 24px | `--base-size-24`
 `5` | 32px | `--base-size-32`
 `6` | 40px | `--base-size-40`
 `7` | 48px | `--base-size-48`


### PR DESCRIPTION
Change the recommended sx prop changes to base-size-* as this is more compliant with the stylelint plugin.