### PR TITLE
include Typography utility class names in documentation for easier reference

### DIFF
--- a/content/foundations/css-utilities/typography.mdx
+++ b/content/foundations/css-utilities/typography.mdx
@@ -32,13 +32,13 @@ Use `.f1` – `.f6` to change an elements font size while keeping inline with ou
 
 <StorybookEmbed framework="css" stories={[{id: 'utilities-typography--font-size'}]} height="280" />
 
-Lighter font-weight utilities are available in a limited range. Lighter font-weights reduce the legibility of text, particularly at small font sizes, so the scale only goes down to `f3` at 20px. The larger sizes`f0` and `f00` allow for lighter and larger type that is in keeping with our marketing styles.
+Lighter font-weight utilities are available in a limited range: `.f00-light` - `.f3-light`. Lighter font-weights reduce the legibility of text, particularly at small font sizes, so the scale only goes down to `f3` at 20px. The larger sizes`f0` and `f00` allow for lighter and larger type that is in keeping with our marketing styles.
 
 <StorybookEmbed framework="css" stories={[{id: 'utilities-typography--font-size-light'}]} height="280" />
 
 ## Line height styles
 
-Change the line height density with these utilities. Responsive variants are also available (e.g. `.lh-sm-condensed`).
+Change the line height density with these utilities: `.lh-default`, `.lh-condensed`, `.lh-condensed-ultra`. Responsive variants are also available (e.g. `.lh-sm-condensed`).
 
 <StorybookEmbed framework="css" stories={[{id: 'utilities-typography--line-height'}]} height="280" />
 
@@ -62,13 +62,13 @@ There are two utilities for adjusting how lines and words of text break when the
 
 ## Text alignment
 
-Use text alignment utilities to left align, center, or right align text.
+Use text alignment utilities `.text-left`, `.text-center`, and `.text-right` to left align, center, or right align text.
 
 <StorybookEmbed framework="css" stories={[{id: 'utilities-typography--text-alignment'}]} height="150" />
 
 ## Responsive text alignment
 
-Use the following formula to make a text alignment utility responsive: `.text-[breakpoint]-[alignment]`
+Use the following formula to make a text alignment utility responsive: `.text-[breakpoint]-[alignment]`.
 
 <StorybookEmbed framework="css" stories={[{id: 'utilities-typography--text-alignment-responsive'}]} height="100" />
 


### PR DESCRIPTION
### Context

Whenever I look up typography utility classes, I end up having to inspect the markup in the embedded Storybook to get the actual class name. It would be much easier if the class names were written out in the documentation instead, so they could be copy/pasted directly from the page, without having to take the extra step of inspecting the page source.

### Summary

This PR adds the class names to the documentation. I tried to maintain consistency with how class names are already referenced elsewhere in the doc (ex. header class names).

### Related 

https://github.com/primer/css/pull/2633