### PR TITLE
Fix links to responsive sidebar nav patterns from the layout page

### DIFF
--- a/content/foundations/layout.mdx
+++ b/content/foundations/layout.mdx
@@ -295,7 +295,7 @@ List-detail patterns, such as settings pages, can be split into different pages 
 
 In this behavior, only one of pane or content regions is shown. The user can switch between the two by selecting an item from the list to drill-in into its details, or navigate back using a parent link in the page header.
 
-See the [responsive sidebar navigation patterns](/navigation#responsive-sidebar-navigation-patterns) section of our navigation guidelines for more information.
+See the [responsive sidebar navigation patterns](/ui-patterns/navigation#responsive-sidebar-navigation-patterns) section of our navigation guidelines for more information.
 
   </Box>
   <Box justifyContent="center">
@@ -310,7 +310,7 @@ See the [responsive sidebar navigation patterns](/navigation#responsive-sidebar-
 
 Panes can be displayed as bottom sheets when they’re used to display auxiliary information, such as metadata, details or actions. Use narrow viewport-specific button triggers to open the pane as a bottom sheet.
 
-If you're using a pane as a sidebar for navigating or filtering, see the [responsive sidebar navigation patterns](/navigation#responsive-sidebar-navigation-patterns) section of our navigation guidelines for more information.
+If you're using a pane as a sidebar for navigating or filtering, see the [responsive sidebar navigation patterns](/ui-patterns/navigation#responsive-sidebar-navigation-patterns) section of our navigation guidelines for more information.
 
   </Box>
   <Box justifyContent="center">
@@ -325,7 +325,7 @@ If you're using a pane as a sidebar for navigating or filtering, see the [respon
 
 In scenarios where the pane is used to display an overview of the content, it can be stacked vertically on top of the content region. Metadata and auxiliary information can appear stacked below the content region.
 
-Avoid stacking a pane on top of the main content area if the pane has a lot of links. It will push the main content down and force the user to scroll to get to the content. For alternative patterns, see the [responsive sidebar navigation patterns](/navigation#responsive-sidebar-navigation-patterns) section of our navigation guidelines.
+Avoid stacking a pane on top of the main content area if the pane has a lot of links. It will push the main content down and force the user to scroll to get to the content. For alternative patterns, see the [responsive sidebar navigation patterns](/ui-patterns/navigation#responsive-sidebar-navigation-patterns) section of our navigation guidelines.
 
 Additionally, a small pane summary may appear above the content, with a trigger used to display the full details as a bottom sheet.
 


### PR DESCRIPTION
Tiny fix to a couple of broken links. Previously navigated to https://primer.style/navigation#responsive-sidebar-navigation-patterns which should now be https://primer.style/ui-patterns/navigation#responsive-sidebar-navigation-patterns as far as I can tell.