### PR TITLE
Update circle-octicon.mdx known accessibility issues link

### DIFF
--- a/content/components/circle-octicon.mdx
+++ b/content/components/circle-octicon.mdx
@@ -22,4 +22,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="CirclOcticon"/>
+<AccessibilityLink label="CircleOcticon"/>

--- a/content/components/circle-octicon.mdx
+++ b/content/components/circle-octicon.mdx
@@ -22,4 +22,4 @@ import {AccessibilityLink} from '~/src/components/accessibility-link'
 
 ### Known accessibility issues (GitHub staff only)
 
-<AccessibilityLink label="CircleBadge"/>
+<AccessibilityLink label="CirclOcticon"/>


### PR DESCRIPTION
Currently wrongly points to `CircleBadge` issues.