### PR TITLE
CSS grid utility docs: update links to other css utilities

### DIFF
--- a/content/foundations/css-utilities/grid.mdx
+++ b/content/foundations/css-utilities/grid.mdx
@@ -5,7 +5,7 @@ description: The grid is 12 columns and percentage-based. The number of columns 
 
 ## Flexbox grids
 
-You can use [flex utilities](/utilities/flexbox) on the container and columns to create a flexbox grid.
+You can use [flex utilities](/css-utilities/flexbox) on the container and columns to create a flexbox grid.
 
 This can be useful for keeping columns the same height, justifying content and vertically aligning items. The flexbox grid is also great for working with responsive layouts.
 
@@ -69,7 +69,7 @@ You can use column widths and other utilities on elements such as lists to creat
 
 ## Display table grids
 
-Using [display table utilities](/utilities/layout#display) with columns gives you some alternative layout options.
+Using [display table utilities](/css-utilities/layout#display) with columns gives you some alternative layout options.
 
 A useful example is being able to keep the height of the container equal across a row when the length of content may differ.
 


### PR DESCRIPTION
This PR updates the last couple places where the path to CSS utilities hadn't been updated from `/utilities/` to `/css-utilities/` already.

I did a quick search of the directory and couldn't find any other instances of `/utilities/` ([search 1](https://github.com/search?q=repo%3Aprimer%2Fdesign%20%22%2Futilities%22&type=code), [search 2](https://github.com/search?q=repo%3Aprimer%2Fdesign+%22utilities%2F%22&type=code)) that needed to be updated, but please feel free to double check me.
