### PR TITLE
Remove broken template code from page-header.mdx

### DIFF
--- a/content/components/page-header.mdx
+++ b/content/components/page-header.mdx
@@ -335,6 +335,4 @@ For navigation, you should follow these guidelines:
 
 ### Known accessibility issues (GitHub staff only)
 
-{' '}
-
 <AccessibilityLink label="PageHeader" />


### PR DESCRIPTION
Remove the stray `{' '}` that is rendered at the end of https://primer.style/components/page-header just after the "Known accessibility issues" heading