### PR TITLE
Fix broken layout in banner.mdx

### DIFF
--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -176,8 +176,10 @@ Banners with an `onDismiss` property automatically show a dismiss button. This s
 
 Use the following as a guideline:
 
-* If you're on a page in which you can do other tasks, and the banner is not blocking / does not have to be addressed, then you should be able to have a close button.
-* If accidental closure of the banner would leave the user confused or missing something critical, it should not have a close button.
+<ul>
+  <li>If you're on a page in which you can do other tasks, and the banner is not blocking / does not have to be addressed, then you should be able to have a close button.</li>
+  <li>If accidental closure of the banner would leave the user confused or missing something critical, it should not have a close button.</li>
+</ul>
 
   </div>
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -175,6 +175,7 @@ Use upsell banners to inform the users about a feature that can be enabled by up
 Banners with an `onDismiss` property automatically show a dismiss button. This should be used for banners that inform about something that the user can not solve. For example issues with the organization they are part of or informational banners. When it makes sense, the choice to dismiss the banner should be stored and the banner should not be shown again.
 
 Use the following as a guideline:
+
 * If you're on a page in which you can do other tasks, and the banner is not blocking / does not have to be addressed, then you should be able to have a close button.
 * If accidental closure of the banner would leave the user confused or missing something critical, it should not have a close button.
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -170,11 +170,15 @@ Use upsell banners to inform the users about a feature that can be enabled by up
   sx={{gap: 4}}
 >
 
+  <div>
+
 Banners with an `onDismiss` property automatically show a dismiss button. This should be used for banners that inform about something that the user can not solve. For example issues with the organization they are part of or informational banners. When it makes sense, the choice to dismiss the banner should be stored and the banner should not be shown again.
 
 Use the following as a guideline:
 * If you're on a page in which you can do other tasks, and the banner is not blocking / does not have to be addressed, then you should be able to have a close button.
 * If accidental closure of the banner would leave the user confused or missing something critical, it should not have a close button.
+
+  </div>
 
 <img
   width="456"


### PR DESCRIPTION
Adds wrapping `<div>` to fix the broken layout for the https://primer.style/components/banner#dismissable section in the documentation.

![screenshot of the currently broken documentation section, showing content awkwardly split over four columns when it should only be two columns](https://github.com/primer/design/assets/895831/00ad4faf-2410-4d89-9898-1b68c3746e05)