### PR TITLE
Add link to full size flowchart in notification-messaging

### DIFF
--- a/content/ui-patterns/notification-messaging.mdx
+++ b/content/ui-patterns/notification-messaging.mdx
@@ -217,7 +217,9 @@ Picking a notification message for an experience can be tricky. Reference this f
   alt=""
   src="https://github.com/user-attachments/assets/b8635f19-629c-42d6-9102-0014257288e5"
 />
+
 [View flowchart in full size](https://github.com/user-attachments/assets/b8635f19-629c-42d6-9102-0014257288e5)
+
 <details style={{padding: "0.5em 0.5em 0"}}>
     <summary>View image description</summary>
       <h3>Success messaging flowchart</h3>

--- a/content/ui-patterns/notification-messaging.mdx
+++ b/content/ui-patterns/notification-messaging.mdx
@@ -217,7 +217,7 @@ Picking a notification message for an experience can be tricky. Reference this f
   alt=""
   src="https://github.com/user-attachments/assets/b8635f19-629c-42d6-9102-0014257288e5"
 />
-
+[View flowchart in full size](https://github.com/user-attachments/assets/b8635f19-629c-42d6-9102-0014257288e5)
 <details style={{padding: "0.5em 0.5em 0"}}>
     <summary>View image description</summary>
       <h3>Success messaging flowchart</h3>


### PR DESCRIPTION
Added link to view the flowchart in full size right before "View image description":

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/5152abd4-7884-4cd5-9990-1b8042cd0778">

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/604f4e91-f1b0-4bb3-90c8-6f8f17f8716c">

I don't think our Primer docs doesn't have a lightbox component to expand images, so linking to the full size image is the best way to view it in detail.


