### PR TITLE
Remove expectation of breaking changes from Alpha

### DIFF
--- a/content/guides/component-lifecycle.mdx
+++ b/content/guides/component-lifecycle.mdx
@@ -13,7 +13,7 @@ The component exists as a proof-of-concept or is work in progress.
 
 ## Alpha
 
-The component is ready for preliminary usage, with breaking changes expected.
+The component is ready for preliminary usage
 
 - The component does not have external dependencies. This could be external libraries or dependencies on libraries in an application (like GitHub.com)
 - The component is compatible with color modes and can adapt to different themes. The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.

--- a/content/guides/component-lifecycle.mdx
+++ b/content/guides/component-lifecycle.mdx
@@ -13,7 +13,7 @@ The component exists as a proof-of-concept or is work in progress.
 
 ## Alpha
 
-The component is ready for preliminary usage
+The component is ready for preliminary usage.
 
 - The component does not have external dependencies. This could be external libraries or dependencies on libraries in an application (like GitHub.com)
 - The component is compatible with color modes and can adapt to different themes. The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.


### PR DESCRIPTION
```diff > ## Alpha

- The component is ready for preliminary usage, with breaking changes expected.
+ The component is ready for preliminary usage
```

Removed the part about breaking changes expected because this does not match our processes anymore. We only mark a component as alpha when the API is stable. (We use experimental components for unstable APIs)


> [!IMPORTANT]  
> Need to confirm if this is true for PVC as well.