### PR TITLE
Remove `ActionMenu` from forms suggestion

### DIFF
--- a/content/ui-patterns/forms/react.mdx
+++ b/content/ui-patterns/forms/react.mdx
@@ -15,28 +15,6 @@ export default FormsLayout
   sx={{gap: 3}}
 >
   <img
-    width="456"
-    role="presentation"
-    src="https://user-images.githubusercontent.com/293280/123881067-cdbaea00-d8f8-11eb-98e4-e57c64489308.png"
-  />
-  <div>
-    <Heading sx={{fontSize: 3}}>Action menu with selection</Heading>
-    <p>
-      If the parent form control provides sufficient visual context, you may visually hide the label. However, you must
-      specify text for a visually hidden label that is accessible to screen readers.
-    </p>
-    <a href="https://primer.style/react/ActionMenu#with-selection">Primer React implementation</a>
-  </div>
-</Box>
-
-<Box
-  mb={4}
-  display="flex"
-  alignItems="flex-start"
-  flexDirection={['column', 'column', 'column', 'column', 'row']}
-  sx={{gap: 3}}
->
-  <img
     role="presentation"
     width="456"
     src="https://user-images.githubusercontent.com/2313998/170268364-021748a9-f304-4626-8ff2-3a71a5bcbd6b.png"


### PR DESCRIPTION
It was [suggested that we shouldn't recommend using `ActionMenu` with forms](https://github.com/github/primer/issues/3016#issue-2102536619), as they don't provide all of the functionality that would make them accessible in a forms context.

This PR removes the `ActionMenu` [section in our UI patterns for forms](https://primer.style/ui-patterns/forms/react).

Closes https://github.com/github/primer/issues/3016

