### PR TITLE
Add VSCode extension link to migration docs

### DIFF
--- a/content/foundations/primitives/migrating.mdx
+++ b/content/foundations/primitives/migrating.mdx
@@ -6,6 +6,8 @@ description:
 
 ## Migrating from `sx` props (Primer React)
 
+:sparkles: A [VSCode extension](https://marketplace.visualstudio.com/items?itemName=ian-sanders.sx-to-css) is available to assist with migrating React code to CSS Modules. The extension automatically handles converting JavaScript syntax to CSS, replacing Primer theme keywords with CSS variables, creating a module file, and more. 
+
 ### Spacing
 
 


### PR DESCRIPTION
Adds a link to [a VSCode extension](https://marketplace.visualstudio.com/items?itemName=ian-sanders.sx-to-css) that helps migrate `sx` props to CSS Modules