### PR TITLE
Linking label docs to feature onboarding

### DIFF
--- a/content/components/heading.mdx
+++ b/content/components/heading.mdx
@@ -50,6 +50,36 @@ The heading component provides styles with appropriate text sizes to provide a v
 
 The default heading text has sufficient color contrast against a white background.
 
+### Handling subheadings, eyebrows, and straplines
+
+Eyebrows are "subheading" treatments, where the heading text's visual treatment includes a word or phrase placed above or below the main heading in a smaller font size.
+
+Eyebrows should be incorporated as part of the heading element, and have their visual styling modified via a `span` element applied to the eyebrow word or phrase. Primer [typography utlity styles](http://localhost:8000/foundations/css-utilities/typography/) can be used to accomplish this.
+
+```html
+<h2>
+  <span class="h4 lh-condensed text-uppercase">
+    Eyebrow
+  </span>
+  Heading
+</h2>
+```
+
+Straplines are short pieces of text that are used to augment and provide additional context or information about the heading. They augment the heading content, but are not necessary for understanding. Because of this, the strapline content is not included in the heading element.
+
+A parent landmark element must be used to communicate the programatic association between the heading and its strapline.
+
+```html
+<header>
+  <h2>
+    Heading
+  </h2>
+  <p>
+    Strapline
+  </p>
+</header>
+```
+
 ### Implementation requirements
 
 When using the component, configure it with the heading level provided in annotated designs or with the appropriate level for the structure of the document and content. It should be noted that the visual design may not always match the annotated heading level, and the annotation should always supersede the visual in the implementation if they differ.

--- a/content/components/heading.mdx
+++ b/content/components/heading.mdx
@@ -54,7 +54,7 @@ The default heading text has sufficient color contrast against a white backgroun
 
 Eyebrows are "subheading" treatments, where the heading text's visual treatment includes a word or phrase placed above or below the main heading in a smaller font size.
 
-Eyebrows should be incorporated as part of the heading element, and have their visual styling modified via a `span` element applied to the eyebrow word or phrase. Primer [typography utlity styles](http://localhost:8000/foundations/css-utilities/typography/) can be used to accomplish this.
+Eyebrows should be incorporated as part of the heading element, and have their visual styling modified via a `span` element applied to the eyebrow word or phrase. Primer [typography utility styles](/foundations/css-utilities/typography/) can be used to accomplish this.
 
 ```html
 <h2>

--- a/content/components/label.mdx
+++ b/content/components/label.mdx
@@ -72,3 +72,4 @@ Make sure that the label text provides sufficient meaning/context on its own, re
 - [Label group](/components/label-group/)
 - [State label](/components/state-label/)
 - [Token](/components/token/)
+- [Feature onboarding](../ui-patterns/feature-onboarding)

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -402,3 +402,7 @@ It's important to stick to the correct terminology and label color when referrin
     <Caption>Don't change the label or link color</Caption>
   </Dont>
 </DoDontContainer>
+
+### Label usage and guidelines
+
+For more information on how to properly use labels in the product, [please refer to the design guidelines.](../components/label/)


### PR DESCRIPTION
This PR came up in a Primer Patterns discussion a couple weeks ago. 

The label documentation should include `Feature onboarding` in the list of related links, and vice versa - the Feature Onboarding documentation should include a link that references the Label documentation. 

[Context from Primer patterns notes](https://docs.google.com/document/d/1N9sE86fIy8UkKMv9uNTAX0rVPThaEak1v-wWkTzQoqY/edit#heading=h.dfve5wemmjmn) 📓 