### PR TITLE
Added links to label and feature onboarding docs

### DIFF
--- a/content/components/label.mdx
+++ b/content/components/label.mdx
@@ -72,3 +72,4 @@ Make sure that the label text provides sufficient meaning/context on its own, re
 - [Label group](/components/label-group/)
 - [State label](/components/state-label/)
 - [Token](/components/token/)
+- [Feature onboarding](../ui-patterns/feature-onboarding)

--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -384,3 +384,7 @@ It's important to stick to the correct terminology and label color when referrin
     <Caption>Don't change the label or link color</Caption>
   </Dont>
 </DoDontContainer>
+
+### Label usage and guidelines
+
+For more information on how to properly use labels in the product, [please refer to the design guidelines.](../components/label/)


### PR DESCRIPTION
This PR came up in a Primer Patterns discussion a couple weeks ago. 

The label documentation should include `Feature onboarding` in the list of related links, and vice versa - the Feature Onboarding documentation should include a link that references the Label documentation. 

[Context from Primer patterns notes](https://docs.google.com/document/d/1N9sE86fIy8UkKMv9uNTAX0rVPThaEak1v-wWkTzQoqY/edit#heading=h.dfve5wemmjmn) 📓 