### PR TITLE
Fix flex utilities link in Grid

### DIFF
--- a/content/foundations/css-utilities/grid.mdx
+++ b/content/foundations/css-utilities/grid.mdx
@@ -5,7 +5,7 @@ description: The grid is 12 columns and percentage-based. The number of columns 
 
 ## Flexbox grids
 
-You can use [flex utilities](/css-utilities/flexbox) on the container and columns to create a flexbox grid.
+You can use [flex utilities](/foundations/css-utilities/flexbox) on the container and columns to create a flexbox grid.
 
 This can be useful for keeping columns the same height, justifying content and vertically aligning items. The flexbox grid is also great for working with responsive layouts.
 


### PR DESCRIPTION
### Problem

Flex utilities link in https://primer.style/foundations/css-utilities/grid returns a 404. It points to https://primer.style/css-utilities/flexbox/

<img width="638" alt="Screenshot 2024-08-21 at 16 05 05" src="https://github.com/user-attachments/assets/db95bb15-2bca-4f86-9487-8cb3f1142d5b">

### Solution

Point to the correct link: https://primer.style/foundations/css-utilities/flexbox/