### PR TITLE
Add note on icons in UnderlinePanels

### DIFF
--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -51,6 +51,8 @@ Underline panels are made of the following ARIA roles:
 
 The active tab is conveyed to assistive technologies using the `aria-selected` attribute. Each tab is associated with it's corresponding panel using the `aria-controls` attribute.
 
+Icons in [UnderlinePanels.Tab](https://primer.style/components/underline-panels/react/draft#underlinepanelstab) are purely decorative and are hidden from screen readers by default. If the icon does convey any informational meaning, the adjacent text inside of the tab should provide all the necessary information without relying on the icon itself.
+
 </div>
 
 <img

--- a/content/components/underline-panels.mdx
+++ b/content/components/underline-panels.mdx
@@ -51,7 +51,7 @@ Underline panels are made of the following ARIA roles:
 
 The active tab is conveyed to assistive technologies using the `aria-selected` attribute. Each tab is associated with it's corresponding panel using the `aria-controls` attribute.
 
-Icons in [UnderlinePanels.Tab](https://primer.style/components/underline-panels/react/draft#underlinepanelstab) are purely decorative and are hidden from screen readers by default. If the icon does convey any informational meaning, the adjacent text inside of the tab should provide all the necessary information without relying on the icon itself.
+Icons in [UnderlinePanels.Tab](https://primer.style/components/underline-panels/react/draft#underlinepanelstab) are purely decorative and are hidden from screen readers by default. If the icon does convey any informational meaning, the adjacent text inside of the tab must provide all the necessary information without relying on the icon itself.
 
 </div>
 


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/3579

Clarifies that icons in `UnderlinePanels.Tab` are purely decorative.