### PR TITLE
Add note on `Timeline.Break`

### DIFF
--- a/content/components/timeline.mdx
+++ b/content/components/timeline.mdx
@@ -41,9 +41,9 @@ Timeline displays items on a connected vertical timeline. It's primarily used to
 
 ### Timeline breaks
 
-The `Timeline.Break` component allows for content in `Timeline` to be visually seperated and should only be used for decorative purposes only. Since this component is decorative, it is not conveyed to assistive technologies like screen readers.
+The `Timeline.Break` component allows for content in `Timeline` to be visually seperated. This should be used for decorative purposes only. Since this component is decorative, it is not conveyed to assistive technologies like screen readers.
 
-The content within `Timeline` should clearly communicate the status and state of the item, so that if there is a need to seperate content, that indication of the seperation is in `Timeline.Item`.
+The content within `Timeline.Item` should clearly communicate the status and state of that item, so that if there is a need to seperate content, the context of the seperation is communicated in `Timeline.Item`.
 
 ### Known accessibility issues (GitHub staff only)
 


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/3355

Clarifies that `Timeline.Break` should be used for decorative purposes only.