### PR TITLE
Retry "Update tools.mdx (#851)"

### DIFF
--- a/content/guides/accessibility/tools.mdx
+++ b/content/guides/accessibility/tools.mdx
@@ -11,11 +11,12 @@ When testing contrast be wary of tools that use color pickers. The picked color 
 
 ## Figma
 
-### [Accessibility sticker sheet](https://www.figma.com/file/GQEYQhQ5s19Wsp6p2wMcU0/A11y-Design-resources?node-id=1-2&t=SsZrSUTm6mbV06jp-11)
+### Annotation Toolkit (Internal)
 
-This Figma file includes annotations to use on your designs prior to developer hand off. These annotations let you note accessibility information like desired tab order, screen reader labels, headings, and landmarks. Pull directly from the file or turn on the accessibility annotations in your Figma assets list.
+This Figma library includes annotations to use on your designs prior to developer hand off. These annotations let you document semantic structure, make visuals and interactions accessible
+Annotate design system components, outline DOM order, and work better together. It is active by default in all new Figma files, and can also be activated [manually](https://accessibility-playbook.github.com/enabling-a11y-design-toolkit-library-in-figma) if needed.
 
-![""](https://user-images.githubusercontent.com/40274682/102533171-e6993780-4059-11eb-8e7c-5452070e2de0.png)
+![GitHub Annotation Toolkit cover image, featuring an annotated GitHub.com homepage and a design checkpoints tool overlaying some abstract branded GitHub-y key art. A badge in the top right corner says Beta.](https://github.com/user-attachments/assets/4816f0d0-0a00-40d6-bc69-c1d988b82092)
 
 ### [A11y - Focus Order plugin](https://www.figma.com/community/plugin/731310036968334777/A11y---Focus-Orderer)
 

--- a/content/guides/accessibility/tools.mdx
+++ b/content/guides/accessibility/tools.mdx
@@ -11,12 +11,11 @@ When testing contrast be wary of tools that use color pickers. The picked color 
 
 ## Figma
 
-### Annotation Toolkit (Internal)
+### [Accessibility sticker sheet](https://www.figma.com/file/GQEYQhQ5s19Wsp6p2wMcU0/A11y-Design-resources?node-id=1-2&t=SsZrSUTm6mbV06jp-11)
 
-This Figma library includes annotations to use on your designs prior to developer hand off. These annotations let you document semantic structure, make visuals and interactions accessible
-Annotate design system components, outline DOM order, and work better together. It is active by default in all new Figma files, and can also be activated [manually](https://accessibility-playbook.github.com/enabling-a11y-design-toolkit-library-in-figma) if needed.
+This Figma file includes annotations to use on your designs prior to developer hand off. These annotations let you note accessibility information like desired tab order, screen reader labels, headings, and landmarks. Pull directly from the file or turn on the accessibility annotations in your Figma assets list.
 
-<img src="https://github.com/user-attachments/assets/4816f0d0-0a00-40d6-bc69-c1d988b82092"  alt="GitHub Annotation Toolkit cover image, featuring an annotated GitHub.com homepage and a design checkpoints tool overlaying some abstract branded GitHub-y key art. A badge in the top right corner says Beta.">
+![""](https://user-images.githubusercontent.com/40274682/102533171-e6993780-4059-11eb-8e7c-5452070e2de0.png)
 
 ### [A11y - Focus Order plugin](https://www.figma.com/community/plugin/731310036968334777/A11y---Focus-Orderer)
 


### PR DESCRIPTION
Update references from the A11y Design toolkit to the new Annotation Toolkit. Removed the direct link to prevent public access requests to the internal Figma library.