### PR TITLE
Fix un-processed heading for "Danger items" in action-list.mdx

### DIFF
--- a/content/components/action-list.mdx
+++ b/content/components/action-list.mdx
@@ -182,6 +182,7 @@ Don't mix single select and multi-select of selections in the same list.
 />
 
 <Box sx={{h3: {marginTop: 0}}}>
+
 ### Danger items
 
 An action list item can have a special "danger" style, to be used in cases that require extra attention from the user.


### PR DESCRIPTION
Currently, this appears unprocessed on https://primer.style/components/action-list#options due to the missing line break before it

![screenshot of the documentation, showing the unprocessed '### Danger items'](https://github.com/user-attachments/assets/50d3652b-8a7f-419c-9bff-4c5033fa00ff)