### PR TITLE
docs(PageHeader): add a11y guidance for role and aria-label

### DIFF
--- a/content/components/page-header.mdx
+++ b/content/components/page-header.mdx
@@ -304,7 +304,7 @@ The title bar can include a static page title, actions, and leading and trailing
 Pageheader allows usage of different HTML landmarks to create a more accessible UI.
 The usage of `header` and `nav` regions are allowed within PageHeader, both with different use cases.
 
-If no landmarks are used within the `PageHeader`, consider using the `role` prop to indicate one and provide it with an accessible name (perhaps the same as `PageHeader.Title`) via `aria-label`.
+If the `PageHeader` is not contained within or contains a landmark, consider using the `role` prop to indicate one and provide it with an accessible name (perhaps the same as `PageHeader.Title`) via `aria-label`.
 
 #### PageHeader with `header` landmark
 

--- a/content/components/page-header.mdx
+++ b/content/components/page-header.mdx
@@ -304,7 +304,16 @@ The title bar can include a static page title, actions, and leading and trailing
 Pageheader allows usage of different HTML landmarks to create a more accessible UI.
 The usage of `header` and `nav` regions are allowed within PageHeader, both with different use cases.
 
-If the `PageHeader` is not contained within or contains a landmark, consider using the `role` prop to indicate one and provide it with an accessible name (perhaps the same as `PageHeader.Title`) via `aria-label`.
+If the `PageHeader` is not contained within a landmark, consider using the `role` prop to indicate one and provide it with an accessible name (perhaps the same as `PageHeader.Title`) via `aria-label`:
+
+```jsx
+<PageHeader role="banner" aria-label="Page Title">
+    <PageHeader.TitleArea>
+      <PageHeader.Title>Page Title</PageHeader.Title>
+    </PageHeader.TitleArea>
+  ...
+</PageHeader>
+```
 
 #### PageHeader with `header` landmark
 

--- a/content/components/page-header.mdx
+++ b/content/components/page-header.mdx
@@ -304,6 +304,8 @@ The title bar can include a static page title, actions, and leading and trailing
 Pageheader allows usage of different HTML landmarks to create a more accessible UI.
 The usage of `header` and `nav` regions are allowed within PageHeader, both with different use cases.
 
+If no landmarks are used within the `PageHeader`, consider using the `role` prop to indicate one and provide it with an accessible name (perhaps the same as `PageHeader.Title`) via `aria-label`.
+
 #### PageHeader with `header` landmark
 
 When utilizing landmarks, it's best to ensure that you’re using them correctly. For the header landmark you should follow these guidelines.


### PR DESCRIPTION
Adds accessibility guidance for usage of `PageHeader`'s `role` and `aria-label` props when a landmark hasn't been previously specified. Relates to https://github.com/github/primer/issues/3466

<img width="881" alt="image" src="https://github.com/user-attachments/assets/b8876ff1-c14b-4a3e-aa32-1351722c3593">


See deployment: https://primer-6a854b4d02-26441320.drafts.github.io/components/page-header#landmark-usage
