### PR TITLE
docs: add a11y guidelines for required fields

### DIFF
--- a/content/components/form-control.mdx
+++ b/content/components/form-control.mdx
@@ -24,6 +24,10 @@ To learn more about anatomy, input methods, forms structure, validation, and mor
 
 ## Accessibility
 
+### Required Fields
+
+When using symbols -e.g., an asterisk (*)- to indicate particular fields are required within a form, consider adding a "Required fields are marked with an asterisk (\*)" message at the top of the form for extra clarity.
+
 ### Known accessibility issues (GitHub staff only)
 
  <AccessibilityLink label="FormControl"/>

--- a/content/components/textarea.mdx
+++ b/content/components/textarea.mdx
@@ -39,8 +39,6 @@ Use a textarea to allow users to input a long string of free-form text.
 
 For more information about the "valid" and "invalid" states, see the [validation section](../ui-patterns/forms/overview#validation) of the form design pattern guidelines.
 
-### Best practices
-
 ## Anatomy
 
 <img
@@ -52,6 +50,7 @@ For more information about the "valid" and "invalid" states, see the [validation
 **Label (required):** The input's title. It should be as concise as possible and convey the purpose of the input. The label may be visually hidden in rare cases, but a label must be defined for assistive technologies such as a screen reader.
 
 **Required indicator:** Indicates that a value is required. Must be shown for any required field, even if all fields in the form are required.
+When using symbols -e.g., an asterisk (*)- to indicate particular fields are required within a form, consider adding a "Required fields are marked with an asterisk (\*)" message at the top of the form for extra clarity.
 
 **Input (required):** Accepts user free-form text input
 


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/3442
Relates to https://github.com/github/primer/issues/3470
Adds `TextArea` and `FormControl` docs for suggestion of adding "Required fields are marked with an asterisk (\*)" disclosure when using asterisk (*) to indicate required fields in forms.