### PR TITLE
docs(Banner): Remove outdated reference

### DIFF
--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -26,8 +26,6 @@ Banner can be used in one of two ways:
 1. To highlight prominent information on a page.
 2. To communicate feedback in response to a user action.
 
-For system wide information, consider using an [announcement](../ui-patterns/messaging#message-types).
-
 ### Best practices
 Use banners sparingly and only when necessary. Banners can disrupt the user experience and should only be used when and where relevant.
 


### PR DESCRIPTION
Removed the sentence referencing the "Announcement" component as the current page's "Usage" section already covers the relevant use cases for Banners.