### PR TITLE
Add note on visually hidden labels

### DIFF
--- a/content/components/textarea.mdx
+++ b/content/components/textarea.mdx
@@ -49,7 +49,7 @@ For more information about the "valid" and "invalid" states, see the [validation
   src="https://user-images.githubusercontent.com/6905903/274239156-064abae9-6d16-4c1a-b673-ec8f96429ed9.png"
 />
 
-**Label (required):** The input's title. It should be as concise as possible and convey the purpose of the input. The label may be visually hidden in rare cases, but a label must be defined for assistive technologies such as a screen reader.
+**Label (required):** The input's title. It should be as concise as possible and convey the purpose of the input. The label may be visually hidden in rare cases, but a label must be defined for assistive technologies such as a screen reader. If the label is visually hidden, ensure there is an element nearby that serves as a visual label for the input. This guarantees that all users, including those not using assistive technologies, have access to a label.
 
 **Required indicator:** Indicates that a value is required. Must be shown for any required field, even if all fields in the form are required.
 


### PR DESCRIPTION
Adds a note on visually hidden labels, that there must be a visual label defined if the label is visually hidden.

Context: https://github.com/github/primer/issues/3441