### PR TITLE
Fix status page

### DIFF
--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -245,7 +245,6 @@ async function getComponents(railsActions, railsData) {
   }
 
   const components = {}
-  
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
     for (const {id, path, status, a11yReviewed} of data) {
       if (!(id in components)) {

--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -190,14 +190,27 @@ async function getComponents(railsActions, railsData) {
   }
 
   // Get component status data
-  const reactComponents = await fetch(`https://primer.github.io/react/components.json`)
+  const reactComponents = await fetch(`https://primer.style/components.json`)
     .then(res => res.json())
     .catch(handleError)
 
   const implementations = {
     react: {
       url: 'https://primer.style/react',
-      data: reactComponents,
+      data: (() => {
+        const rcs = []
+
+        reactComponents.components.forEach((rc) => {
+          const reactImplementation = rc.implementations.react
+
+          if (reactImplementation) {
+            const { id, name, status, a11yReviewed} = reactImplementation
+            rcs.push({id, path: `/${name}`, status, a11yReviewed})
+          }
+        })
+
+        return rcs
+      })(),
     },
     viewComponent: {
       url: '',
@@ -232,7 +245,7 @@ async function getComponents(railsActions, railsData) {
   }
 
   const components = {}
-
+  
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
     for (const {id, path, status, a11yReviewed} of data) {
       if (!(id in components)) {


### PR DESCRIPTION
Swaps out `https://primer.github.io/react/components.json` with `https://primer.style/components.json` to fix the issue where the status page doesn't load the component table. 

It seems that https://primer.github.io/react/components.json was removed, and the JSON provided by https://primer.style/components.json is different between the two, so I modified the function slightly to account for that.