### PR TITLE
fix: allow status table to render with partial information

### DIFF
--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -234,6 +234,9 @@ async function getComponents(railsActions, railsData) {
   const components = {}
 
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
+    if(!data) {
+      continue
+    }
     for (const {id, path, status, a11yReviewed} of data) {
       if (!(id in components)) {
         components[id] = {


### PR DESCRIPTION
Allow status data to render even when partial information is available (i.e. one of the sources fails to load). 
See deployment: https://primer-fe30d4f93e-26441320.drafts.github.io/guides/status
Currently it will fail to render and get stuck loading:
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/41b967c7-b6dc-4cfe-a118-c45125058497">

With fix:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/48bfb218-8fb2-4768-aa50-d5f86b684c1c">
