### PR TITLE
Fix status page

### DIFF
--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -224,12 +224,12 @@ async function getComponents(railsActions, railsData, reactData) {
             const current = getStatusIndex(status)
             const existing = getStatusIndex(components[name].status)
 
-            if (current < existing) {
-              components[name] = {a11yReviewed, id, name, status, path: url}
+            if (current > existing) {
+              return;
             }
-          } else {
-            components[name] = {a11yReviewed, id, name, status, path: url}
           }
+
+          components[name] = {a11yReviewed, id, name, status, path: url}
         })
         return Object.values(components)
       })(),

--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -245,7 +245,6 @@ async function getComponents(railsActions, railsData) {
   }
 
   const components = {}
-  
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
     for (const {id, path, status, a11yReviewed} of data) {
       if (!(id in components)) {

--- a/src/components/status.jsx
+++ b/src/components/status.jsx
@@ -190,14 +190,27 @@ async function getComponents(railsActions, railsData) {
   }
 
   // Get component status data
-  const reactComponents = await fetch(`https://primer.github.io/react/components.json`)
+  const reactComponents = await fetch(`https://primer.style/components.json`)
     .then(res => res.json())
     .catch(handleError)
 
   const implementations = {
     react: {
       url: 'https://primer.style/react',
-      data: reactComponents,
+      data: (() => {
+        const rcs = []
+
+        reactComponents.components.forEach((rc) => {
+          const reactImplementation = rc.implementations.react
+
+          if (reactImplementation) {
+            const { id, name, status, a11yReviewed} = reactImplementation
+            rcs.push({id, path: `/${name}`, status, a11yReviewed})
+          }
+        })
+
+        return rcs
+      })(),
     },
     viewComponent: {
       url: '',
@@ -232,7 +245,7 @@ async function getComponents(railsActions, railsData) {
   }
 
   const components = {}
-
+  
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
     for (const {id, path, status, a11yReviewed} of data) {
       if (!(id in components)) {


### PR DESCRIPTION
Swaps out https://primer.github.io/react/components.json with data we get initially [via unpkg & graphql](https://github.com/primer/design/blob/f575f848ed5f8be315f85013dda8eb9dd6c8c04b/gatsby-node.esm.js#L252-L254). This fixes the issue where the status page doesn't load the component table.

It seems that `https://primer.github.io/react/components.json` was removed, and the [JSON provided by unpkg](https://unpkg.com/@primer/react@37.0.1/generated/components.json) is slightly different, so I modified the function slightly to account for that.

This differs from https://github.com/primer/design/pull/879, as we're utilizing the graphql data that we're already pulling, and aligns more with how we handle rails components on the status page.