### PR TITLE
Update tooltip-alternatives.mdx

### DIFF
--- a/content/guides/accessibility/tooltip-alternatives.mdx
+++ b/content/guides/accessibility/tooltip-alternatives.mdx
@@ -71,4 +71,4 @@ If you determine that tooltips are appropriate for your use case, make sure to c
 
 ## Alternatives to tooltips
 
-See [Tooltip interface guidelines](../../components/tooltip.mdx) for example alternatives to using tooltips.
+See the [examples of alternatives to tooltips](../../components/tooltip#alternatives-to-tooltips).


### PR DESCRIPTION
Current link 404s (due to the `.mdx`). Updating this to also link directly to the alternatives section, with a tweak to the link text.