### PR TITLE
fix: typos in Tree View doc

### DIFF
--- a/content/components/tree-view.mdx
+++ b/content/components/tree-view.mdx
@@ -248,7 +248,7 @@ If a tree view is truly the best pattern for your use-case and none of the sugge
 
 A tree view solves a very specific problem. It's not a multi-purpose tool like an [action list](/components/action-list) or meant for site navigation like a [nav list](/components/nav-list).
 
-Tree views are used to communicate a hierarchical list of items, and allow a user to navigate through, select, and take action on one or more items. A comparable expereince would be a list of files in a code editor, or an operating system file explorer. While they may visually look like navigation, tree views have specific interaction modes and expectations for assistive technology that differs from other patterns. Trying to use a tree view for something that looks visually apprpriate, but is not functionally inline with its intended use case may cause confusion or an unusable experience, especially if the user cannot see the screen.
+Tree views are used to communicate a hierarchical list of items, and allow a user to navigate through, select, and take action on one or more items. A comparable experience would be a list of files in a code editor, or an operating system file explorer. While they may visually look like navigation, tree views have specific interaction modes and expectations for assistive technology that differs from other patterns. Trying to use a tree view for something that looks visually appropriate, but is not functionally inline with its intended use case may cause confusion or an unusable experience, especially if the user cannot see the screen.
 
 <Text as="p" m={0}>
   Before reaching for a tree view, first make sure that:


### PR DESCRIPTION
This PR fixes some typos in the Tree View doc.

And thank you for making the content public. I really enjoy learning the thoughts behind the design decisions 🙂 