### PR TITLE
Update copywriting for product ops

### DIFF
--- a/content/ui-patterns/feature-onboarding.mdx
+++ b/content/ui-patterns/feature-onboarding.mdx
@@ -358,7 +358,7 @@ If the label is not part of a navigational item then it's important to include a
 ### Lifecycles
 
 Depending on the size and impact of your ship you might only release to a fraction of users.
-There are currently 4 main lifecycles: `Private preview`, `Public preview`, `General availability (GA)` and `Deprecation`.
+There are currently 4 main lifecycles: `Private preview`, `Public preview`, `General availability (GA)` and `Closing down`.
 The `Private preview` lifecycle is often referred to as a `Staff ship` within GitHub.
 
 Note: The `Technical preview` label may sometimes be used by the Next team for experiments and research projects.


### PR DESCRIPTION
This updates the label in our documentation from `Deprecation` to `Closing down` to coincide with product ops terms.