### PR TITLE
Update project board link on "how to contribute" page

### DIFF
--- a/content/guides/contribute/how-to-contribute.mdx
+++ b/content/guides/contribute/how-to-contribute.mdx
@@ -47,7 +47,7 @@ Please read the guidelines on [adding new components](/guides/contribute/adding-
 
 Please read the guidelines on how to [handle new patterns](/guides/contribute/handling-new-patterns)<!-- TODO: uncomment this once this page exists [adding new components](/guides/contribute/adding-new-components)--> and [designing Primer patterns](/guides/contribute/design).
 
-From the [Primer project board](https://github.com/orgs/github/projects/2759) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
+From the [Primer project board](https://github.com/orgs/github/projects/4503) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
 
 ## Give us feedback and report bugs
 


### PR DESCRIPTION
The project board link on the "How to contribute" page points to the old Primer Roadmap project board, which isn't actively maintained anymore. I'd rather point potential contributors to the teams backlog which is where "good first issues" and other contribution opportunities live.