### PR TITLE
Add link to primerize docs for primer/react

### DIFF
--- a/content/guides/react/index.mdx
+++ b/content/guides/react/index.mdx
@@ -4,6 +4,10 @@ description: Get started using Primer React components in your React application
 source: https://github.com/primer/react
 ---
 
+## Dotcom Codespaces (staff-only)
+
+Are you a GitHub employee (Hubber) looking to make a change to primer/react or another Primer library? Take a look at our documentation for the [`primerize` tool](https://github.com/github/primer-engineering/blob/main/how-we-work/developing-in-dotcom-codespaces.md), which can help get you started in a dotcom codespace.
+
 ## Getting started
 
 1. Install `@primer/react` and its peer dependencies:

--- a/content/guides/react/index.mdx
+++ b/content/guides/react/index.mdx
@@ -6,7 +6,7 @@ source: https://github.com/primer/react
 
 ## Dotcom Codespaces (staff-only)
 
-Are you a GitHub employee (Hubber) looking to make a change to primer/react or another Primer library? Take a look at our documentation for the [`primerize` tool](https://github.com/github/primer-engineering/blob/main/how-we-work/developing-in-dotcom-codespaces.md), which can help get you started in a dotcom codespace.
+Are you a GitHub employee (Hubber) looking to make a change to primer/react or another Primer library? Take a look at our documentation for the [`primerize` tool](https://github.com/github/primer-engineering/blob/main/how-we-work/developing-in-dotcom-codespaces.md) (GitHub staff only), which can help get you started in a dotcom codespace.
 
 ## Getting started
 


### PR DESCRIPTION
Trying to link to these docs in as many places as possible. Also looking to add it to the new docs (internal-only link): https://github.com/github/collaboration-workflows-flex/issues/1369