### PR TITLE
bump artifacts version

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get-dotcom-access-token.outputs.access-token }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages
           path: public
@@ -72,6 +72,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
         with:
           preview: true


### PR DESCRIPTION
This PR bumps artifacts action because v3 was deprecated today, resulting in deploy preview failures.

See [build note](https://github.com/primer/design/actions/runs/13060047343/job/36440550479?pr=920).