### PR TITLE
update React form component urls

### DIFF
--- a/content/ui-patterns/forms/react.mdx
+++ b/content/ui-patterns/forms/react.mdx
@@ -26,9 +26,9 @@ export default FormsLayout
       one or more values.
     </p>
     <Box display="flex" sx={{gap: 3}}>
-      <a href="../components/autocomplete">Interface guidelines</a>
+      <a href="https://primer.style/components/autocomplete">Interface guidelines</a>
       <span aria-hidden="true">|</span>
-      <a href="https://primer.style/react/Autocomplete">Primer React implementation</a>
+      <a href="https://primer.style/components/autocomplete/react/latest">Primer React implementation</a>
     </Box>
   </div>
 </Box>
@@ -49,9 +49,9 @@ export default FormsLayout
     <Heading sx={{fontSize: 3}}>Checkbox group</Heading>
     <p>A set of checkboxes to let users make one or more selections from a short list of options</p>
     <Box display="flex" sx={{gap: 3}}>
-      <a href="../components/checkbox-group">Interface guidelines</a>
+      <a href="https://primer.style/components/checkbox-group">Interface guidelines</a>
       <span aria-hidden="true">|</span>
-      <a href="https://primer.style/react/CheckboxGroup">Primer React implementation</a>
+      <a href="https://primer.style/components/checkbox-group/react/latest">Primer React implementation</a>
     </Box>
   </div>
 </Box>
@@ -72,9 +72,9 @@ export default FormsLayout
     <Heading sx={{fontSize: 3}}>Form control</Heading>
     <p>A form control renders a labelled input and, optionally, associated validation text and/or hint text.</p>
     <Box display="flex" sx={{gap: 3}}>
-      <a href="../components/form-control">Interface guidelines</a>
+      <a href="https://primer.style/components/form-control">Interface guidelines</a>
       <span aria-hidden="true">|</span>
-      <a href="https://primer.style/react/FormControl">Primer React implementation</a>
+      <a href="https://primer.style/components/form-control/react/latest">Primer React implementation</a>
     </Box>
   </div>
 </Box>
@@ -95,9 +95,9 @@ export default FormsLayout
     <Heading sx={{fontSize: 3}}>Radio group</Heading>
     <p>A set of radio inputs to let users make a single selection from a short list of options</p>
     <Box display="flex" sx={{gap: 3}}>
-      <a href="../components/radio-group">Interface guidelines</a>
+      <a href="https://primer.style/components/radio-group">Interface guidelines</a>
       <span aria-hidden="true">|</span>
-      <a href="https://primer.style/react/RadioGroup">Primer React implementation</a>
+      <a href="https://primer.style/components/radio-group/react/latest">Primer React implementation</a>
     </Box>
   </div>
 </Box>
@@ -117,7 +117,7 @@ export default FormsLayout
   <div>
     <Heading sx={{fontSize: 3}}>Select dropdown</Heading>
     <p>A select input may be used when a user needs to select one option from a long list</p>
-    <a href="https://primer.style/react/Select">Primer React implementation</a>
+    <a href="https://primer.style/components/select/react/latest">Primer React implementation</a>
   </div>
 </Box>
 
@@ -138,7 +138,7 @@ export default FormsLayout
       Textarea
     </Heading>
     <p>A text area is used to put multiple lines of text in an input</p>
-    <a href="https://primer.style/react/Textarea">Primer React implementation</a>
+    <a href="https://primer.style/components/textarea/react/latest">Primer React implementation</a>
   </div>
 </Box>
 
@@ -161,9 +161,9 @@ export default FormsLayout
       <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types">types in the MDN docs</a>.
     </p>
     <Box display="flex" sx={{gap: 3}}>
-      <a href="../components/text-input">Interface guidelines</a>
+      <a href="https://primer.style/components/text-input">Interface guidelines</a>
       <span aria-hidden="true">|</span>
-      <a href="https://primer.style/react/TextInput">Primer React implementation</a>
+      <a href="https://primer.style/components/text-input/react/latest">Primer React implementation</a>
     </Box>
   </div>
 </Box>


### PR DESCRIPTION
I noticed that the component links in the React Forms doc were broken while reviewing https://github.com/github/github/pull/362188.

The url scheme seems to have changed since these docs were last updated. Looks like it now follows the pattern `https://primer.style/components/:component-name/` for interface guidelines and `https://primer.style/components/:component-name/react/latest` for React implementation.

**Questions for reviewers:**
* Are there any url helpers available? Hard-coding the urls seems brittle and could break again if/when the url scheme changes.
* I've seen "dead link" linters in other repos that fail if any urls in the PR return a >4XX response ([example](https://github.com/tcort/markdown-link-check)). Does something like that seem useful for this repo?