### PR TITLE
Update broken links to content guidelines

### DIFF
--- a/content/foundations/content.mdx
+++ b/content/foundations/content.mdx
@@ -5,7 +5,7 @@ description: These guidelines are specific to and focused on GitHub product inte
 
 import Code from '@primer/gatsby-theme-doctocat/src/components/code'
 
-Your first port of call for general content guidelines should be [GitHub’s content guide](https://github.com/github/brand/blob/main/content.md) (link only accessible to GitHub staff), followed by the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
+Your first port of call for general content guidelines should be [GitHub’s content guide](https://github.com/github/brand/blob/main/docs/how-to-write-at-github.md) (link only accessible to GitHub staff), followed by the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
 
 ## UI content principles
 
@@ -41,7 +41,7 @@ You should consider the context of when a user will read something, keeping in m
 - Humor isn’t welcome in all situations, for example: in errors, when waiting, or when something fails.
 - Error messages should be understandable by humans.
 
-Read more about GitHub’s [voice and tone in the content guide](https://github.com/github/brand/blob/main/content.md#voice-and-tone) (link only accessible to GitHub staff).
+Read more about GitHub’s [voice and tone in the content guide](https://drive.google.com/drive/folders/1Y_cI1_T9FPh1wzA2nA_KKRum29ak23Or) (link only accessible to GitHub staff).
 
 ## Top 10 rules
 


### PR DESCRIPTION
It looks like the links to content guidelines were broken, so I've tried to update them to where I believe they should be pointing.

Also addressed in the new docs: https://github.com/github/primer-docs/pull/354