### PR TITLE
Docs: advise against multiple full-width banners per page

### DIFF
--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -27,6 +27,7 @@ Banner can be used in one of two ways:
 2. To communicate feedback in response to a user action.
 
 ### Best practices
+
 - Use banners sparingly and only when necessary. Banners can disrupt the user experience and should only be used when and where relevant.
 - Keep the message concise and direct. Don't use heading styling or multiple type sizes in banners, rely on the default paragraph size and use the title when appropriate.
 - Do not display more than one banner (full-width or otherwise) on a single page at the same time. This prevents stacking issues, avoids confusing user experiences, and helps reduce [alert fatigue](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/).

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -27,11 +27,9 @@ Banner can be used in one of two ways:
 2. To communicate feedback in response to a user action.
 
 ### Best practices
-Use banners sparingly and only when necessary. Banners can disrupt the user experience and should only be used when and where relevant.
-
-Keep the message concise and direct. Don't use heading styling or multiple type sizes in banners, rely on the default paragraph size and use the title when appropriate.
-
-Don't show more than one banner at a time. For more information, see this article on [alert fatigue](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/).
+- Use banners sparingly and only when necessary. Banners can disrupt the user experience and should only be used when and where relevant.
+- Keep the message concise and direct. Don't use heading styling or multiple type sizes in banners, rely on the default paragraph size and use the title when appropriate.
+- Don't show more than one banner at a time. For more information, see this article on [alert fatigue](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/).
 
 ## Anatomy
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -28,9 +28,8 @@ Banner can be used in one of two ways:
 
 ### Best practices
 - Use banners sparingly and only when necessary. Banners can disrupt the user experience and should only be used when and where relevant.
-- Do not display more than one full-width Banner on a single page at the same time. This prevents stacking issues and avoids confusing user experiences.
 - Keep the message concise and direct. Don't use heading styling or multiple type sizes in banners, rely on the default paragraph size and use the title when appropriate.
-- Don't show more than one banner at a time. For more information, see this article on [alert fatigue](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/).
+- Do not display more than one banner (full-width or otherwise) on a single page at the same time. This prevents stacking issues, avoids confusing user experiences, and helps reduce [alert fatigue](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/).
 
 ## Anatomy
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -297,8 +297,8 @@ Banners that are used to communicate feedback require extra accessibility consid
 
 Consider using either a **live region announcement** or **focus management** technique:
 
-* **Live region announcements**: can be used to announce the new content to screen reader users. This is the preferred method for non-critical information (**though exceptions apply**, such in scenarios where focus loss needs to be handled).
-* **Focus management**: involves shifting a user's focus directly the new Banner. This method is disruptive when used inappropriately, but is extremely helpful in scenarios where we need to guide the user towards an action.
+- **Live region announcements**: can be used to announce the new content to screen reader users. This is the preferred method for non-critical information (**though exceptions apply**, such in scenarios where focus loss needs to be handled).
+- **Focus management**: involves shifting a user's focus directly the new Banner. This method is disruptive when used inappropriately, but is extremely helpful in scenarios where we need to guide the user towards an action.
 
 Here are some questions to consider when deciding which method to use:
 

--- a/content/components/banner.mdx
+++ b/content/components/banner.mdx
@@ -28,6 +28,7 @@ Banner can be used in one of two ways:
 
 ### Best practices
 - Use banners sparingly and only when necessary. Banners can disrupt the user experience and should only be used when and where relevant.
+- Do not display more than one full-width Banner on a single page at the same time. This prevents stacking issues and avoids confusing user experiences.
 - Keep the message concise and direct. Don't use heading styling or multiple type sizes in banners, rely on the default paragraph size and use the title when appropriate.
 - Don't show more than one banner at a time. For more information, see this article on [alert fatigue](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/).
 


### PR DESCRIPTION
## Summary

Closes https://github.com/github/primer/issues/5212

This PR updates the Banner documentation to advise against multiple full-width banners per page. As a polished touched, it also uses unordered list item syntax to organize these best practices.